### PR TITLE
feat(api): GET /api/v1/platforms — first F9 read endpoint

### DIFF
--- a/.claude/framework/hooks/known-stdlib.txt
+++ b/.claude/framework/hooks/known-stdlib.txt
@@ -116,6 +116,7 @@ py:concurrent
 py:queue
 py:secrets
 py:uuid
+py:__future__
 
 # Go standard library
 go:fmt

--- a/.claude/process-state.json
+++ b/.claude/process-state.json
@@ -1,9 +1,15 @@
 {
   "build_loop": {
-    "feature": null,
-    "step": 0,
-    "steps_completed": [],
-    "started_at": null
+    "feature": "BL6-F9-platforms-readonly",
+    "step": 5,
+    "steps_completed": [
+      "tests_written",
+      "tests_verified_failing",
+      "implemented",
+      "security_audit",
+      "documentation_updated"
+    ],
+    "started_at": "2026-04-30T17:40:44Z"
   },
   "uat_session": {
     "session_id": 3,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ for handoff clarity. Categories are ordered by impact severity.
 ## [Unreleased]
 
 ### Added
+- **`GET /api/v1/platforms`** (BL6 / Feature 9 partial) — first real
+  domain endpoint on the BL5 substrate. Returns the auth + sync status
+  of every configured platform, with Steam pinned first in the response
+  order. Six fields per platform (name, auth_status, auth_method,
+  auth_expires_at, last_sync_at, last_error); `config` column
+  intentionally excluded from the response surface. `last_error`
+  truncated to 200 chars at the API layer (defense-in-depth on top of
+  upstream redaction). Pool failures translate to HTTP 503 with a
+  structured `api.platforms.read_failed` log event. Locks the wrapped
+  envelope shape `{"<resource>": [...]}` that every future F9 read
+  endpoint will inherit. See
+  [spec](docs/superpowers/specs/2026-04-30-bl6-platforms-readonly-design.md)
+  and [audit](docs/security-audits/bl6-f9-platforms-readonly-security-audit.md).
 - **FastAPI app skeleton** (BL5 / Feature 5) — `create_app()` factory at
   `src/orchestrator/api/main.py`. Lifespan runs migrations + initializes
   the BL4 pool singleton on startup; closes the pool with the BL4 30 s

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -236,4 +236,47 @@ external-IP) for OQ2 testing via `httpx.ASGITransport(app, client=("ip", port))`
 
 ---
 
+## Feature 6: BL6 — `GET /api/v1/platforms` (read-only)
+
+**Phase Built:** 2 (Milestone B, Build Loop 6)
+**Status:** Complete (2026-05-04)
+**Summary:** First real F9 read endpoint on the BL5 substrate. Returns
+the auth + sync status of every configured platform (always exactly
+two rows: `steam`, `epic`). Bearer-required (NOT in
+`AUTH_EXEMPT_PATHS`). Wrapped envelope shape `{"platforms": [...]}` —
+locks the convention every future F9 endpoint inherits. Six fields
+per platform; `config` excluded entirely. `last_error` truncated to
+200 chars at the API layer (defense-in-depth on top of upstream
+redaction). Pool failures translate to HTTP 503 with structured
+`api.platforms.read_failed` log event. Steam-first sort via SQL
+`CASE WHEN name = 'steam' THEN 0 ELSE 1 END, name`.
+**Key Interfaces:**
+  - `src/orchestrator/api/routers/platforms.py` —
+    `PlatformResponse` + `PlatformListResponse` Pydantic models with
+    `extra="forbid"`, `list_platforms` GET handler
+  - Wired in `src/orchestrator/api/main.py` via
+    `app.include_router(platforms_router)`
+  - Wire format: `{"platforms": [{"name", "auth_status",
+    "auth_method", "auth_expires_at", "last_sync_at", "last_error"},
+    ...]}`
+**Locked decisions (D1-D8):**
+  D1 `config` excluded · D2 wrapped envelope · D3 `last_error` 200-char
+  truncation · D4 Steam-first sort · D5 no ETag for v1 · D6 PoolError
+  → 503 · D7 bearer required · D8 `extra="forbid"`. See
+  [spec](superpowers/specs/2026-04-30-bl6-platforms-readonly-design.md).
+**Test Coverage:** 23 tests in `tests/api/test_platforms_router.py`
+(~280 LoC) across 7 classes: happy path, auth, last_error truncation,
+config exclusion, response schema strictness, pool-failure 503,
+ordering. ≥95% branch coverage on `routers/platforms.py`.
+**Related Audit:** [`bl6-f9-platforms-readonly-security-audit.md`](security-audits/bl6-f9-platforms-readonly-security-audit.md) — 0 findings.
+**Known Limitations:**
+  - No ETag / conditional-response support (D5, deferred to a
+    follow-up if Game_shelf surfaces real polling load).
+  - No per-platform endpoint (`GET /api/v1/platforms/{name}`); the
+    list is small enough that clients fetch the whole thing.
+  - No `meta` envelope field yet; will be added uniformly when the
+    first paginated F9 endpoint (`/games`) lands.
+
+---
+
 <!-- Copy the section above for each new feature. Number sequentially. -->

--- a/docs/security-audits/bl6-f9-platforms-readonly-security-audit.md
+++ b/docs/security-audits/bl6-f9-platforms-readonly-security-audit.md
@@ -1,0 +1,86 @@
+# Security Audit — BL6 platforms read-only endpoint
+
+**Feature:** BL6-F9-platforms-readonly (Build Loop 6, Milestone B)
+**Module:** `src/orchestrator/api/routers/platforms.py` (~90 LoC) + `src/orchestrator/api/main.py` (+2 lines wiring)
+**Audit date:** 2026-05-04
+**Auditor:** self-review (Senior Security Engineer persona) + automated SAST (semgrep OWASP top-10 + project custom rules) + gitleaks
+**Phase:** 2 (Construction), Build Loop step 2.4
+
+<!-- Last Updated: 2026-05-04 -->
+
+## Scope
+
+Post-implementation security review of the first real F9 read endpoint:
+
+- `src/orchestrator/api/routers/platforms.py` — `PlatformResponse` + `PlatformListResponse` Pydantic models with `extra="forbid"`, `list_platforms` GET handler reading via `Depends(get_pool_dep)`, structured 503 path on `PoolError`.
+- `src/orchestrator/api/main.py` — added `from orchestrator.api.routers.platforms import router as platforms_router` and `app.include_router(platforms_router)`.
+- `tests/api/test_platforms_router.py` — 23 tests across 7 classes (~280 LoC).
+
+The audit inherits the BL5 + UAT-3 substrate: middleware-based bearer auth, CORS-outermost stack, correlation-ID propagation, ID3 log redaction. Auth, body-cap, and CORS handling are not in scope here — they were audited in BL5 and re-validated in UAT-3.
+
+## Methodology
+
+1. **Automated SAST:** `semgrep --config p/owasp-top-ten --error src/orchestrator/api/routers/platforms.py src/orchestrator/api/main.py` — 0 findings.
+2. **gitleaks** on the full repo (105 commits) — 0 findings.
+3. **ruff check + ruff format** on changed files — clean.
+4. **mypy --strict** on changed files — clean.
+5. **Manual review** against the spec's locked decisions D1-D8 + the project threat model TMs that apply at the API surface (TM-001 auth, TM-012 redaction, TM-013 fingerprinting).
+
+## Findings
+
+**SEV-1:** 0
+**SEV-2:** 0
+**SEV-3:** 0
+**SEV-4:** 0
+
+No findings. Rationale below for each TM walk and design decision.
+
+## Threat-model walk
+
+### TM-001 — Unauthorized API access
+**Verdict: MITIGATED.** Path is NOT in `AUTH_EXEMPT_PATHS`; BL5's `BearerAuthMiddleware` enforces. Tests `TestPlatformsAuth` cover missing header (401), wrong token (401), valid token (200). Auth-state matrix from UAT-3's auth-lifespan audit applies unchanged.
+
+### TM-012 — Credential redaction in logs
+**Verdict: MITIGATED.** The endpoint logs only `api.platforms.read_failed` with `reason=str(e)` — `e` is a `PoolError` whose message comes from the BL4 pool's structured exception layer (no raw SQL/params/credentials per ADR-0011). Correlation_id propagated from the outer middleware. No raw row contents (including `last_error` text) reach any log call.
+
+### TM-013 — Fingerprinting via differential responses
+**Verdict: MITIGATED for the BL5 substrate; not amplified by this endpoint.** The endpoint produces only two response shapes: 200 with the canonical envelope, and 503 with `{"detail": "database unavailable"}`. No path-dependent timing differences (single SQL query, deterministic ORDER BY, same response shape regardless of input).
+
+### Decisions D1-D8 walk
+
+- **D1 (`config` excluded):** Verified — SELECT statement omits `config`; `PlatformResponse` has no `config` field; `extra="forbid"` blocks accidental construction. Test `TestPlatformsConfigExclusion::test_config_not_in_response_when_set` writes a sensitive-looking JSON into the DB row's `config` and asserts neither the field name nor the value reaches the wire. **Defense-in-depth:** even if a future migration added `config` to the SELECT by mistake, `extra="forbid"` would raise during model construction in development → caught in CI.
+- **D2 (wrapped envelope):** Verified — `PlatformListResponse` shape; `TestPlatformsHappyPath::test_response_envelope_shape` asserts exactly one top-level key `"platforms"`.
+- **D3 (`last_error` truncation):** Verified — `_LAST_ERROR_TRUNCATE = 200`; truncation is `[:200]` on the raw string. Tests at boundaries 100, 200, 201, 5000 + null. Defense-in-depth on top of upstream redaction (which doesn't yet exist; F1/F2 will write structured errors). Note: 200-char truncation is by codepoint, not bytes — for UTF-8 multi-byte content a partial-codepoint cut isn't possible (Python str slicing is codepoint-aware), so no malformed-UTF-8-on-wire risk.
+- **D4 (Steam-first sort):** Verified via SQL `ORDER BY CASE WHEN name = 'steam' THEN 0 ELSE 1 END, name`. Tests assert at index 0 (steam) and index 1 (epic).
+- **D5 (no ETag):** Not implemented; documented in spec as YAGNI for v1.
+- **D6 (PoolError → 503):** Verified — `except PoolError` with structured 503 body and `api.platforms.read_failed` log event. Tests pin both the wire response and the log emission.
+- **D7 (bearer required):** Verified — path NOT added to `AUTH_EXEMPT_PATHS` in `dependencies.py`.
+- **D8 (`extra="forbid"`):** Verified on both `PlatformResponse` and `PlatformListResponse`. `TestPlatformsResponseSchema` covers extra-field rejection + 3 Literal-narrowing rejection cases (invalid name, auth_status, auth_method).
+
+## Non-findings (explicitly cleared)
+
+- **No SQL injection vector.** The single SQL is a parameter-free literal string with no user-input interpolation. The CASE clause is hardcoded.
+- **No timing oracle on auth.** Auth handling is delegated to the middleware (audited in BL5/UAT-3); this router executes only after auth has passed.
+- **No row-count fingerprinting.** The endpoint always returns exactly 2 platforms (schema CHECK constraint + seed); response size is constant at ~400 bytes regardless of any state.
+- **No DoS via response size.** Two rows max; `last_error` capped at 200 chars; total response well under any reasonable response-size limit.
+- **No log-volume amplification.** Successful reads emit only the standard `api.request.received` + `api.request.completed` from `CorrelationIdMiddleware`; the router itself emits only on the 503 error path.
+- **No ETag/304 oracle.** No conditional response handling (D5 deferred ETag).
+- **No CORS interaction risk.** The router doesn't override CORS; the BL5+UAT-3 stack handles it (CORS outermost since UAT-3 S2-F).
+
+## Test coverage
+
+23 tests in `tests/api/test_platforms_router.py`, all passing. Branch coverage on `routers/platforms.py` ≥ 95% (target met per spec §4).
+
+## Verification artifacts
+
+- `pytest tests/api/ -q`: 99 tests passing (76 prior + 23 new).
+- `pytest -q`: 387 tests passing project-wide (was 364; +23).
+- `ruff check`: clean.
+- `ruff format --check`: clean.
+- `mypy --strict src/orchestrator/api/routers/platforms.py src/orchestrator/api/main.py`: clean.
+- `semgrep --config p/owasp-top-ten --error`: 0 findings.
+- `gitleaks detect --source .` (full history, 105 commits): no leaks found.
+
+## Conclusion
+
+**APPROVED for merge.** Zero findings across automated and manual review. The endpoint inherits BL5+UAT-3's hardened substrate, adds no new attack surface beyond the read of two seeded rows, and respects every locked decision D1-D8. The conventions established here (envelope shape, response strictness, error semantics) are sound for propagation to the next F9 endpoints (`/games`, `/jobs`, `/manifests`, etc.).

--- a/docs/superpowers/plans/2026-04-30-bl6-platforms-readonly.md
+++ b/docs/superpowers/plans/2026-04-30-bl6-platforms-readonly.md
@@ -1,0 +1,950 @@
+# BL6 Platforms Read-Only Endpoint Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `GET /api/v1/platforms` — the first real domain read endpoint on the BL5 FastAPI substrate — with full test-first coverage, structured error handling, and the locked API conventions every future F9 endpoint will inherit.
+
+**Architecture:** New router module at `src/orchestrator/api/routers/platforms.py` mounted on the BL5 app via `include_router`. Pydantic models with `extra="forbid"` for response envelope and per-row shape. Reads via `Depends(get_pool_dep)` → BL4 pool's `read_all`. Pool failures caught at the router boundary and translated to 503 with structured log. `last_error` truncated to 200 chars defensively. `config` column excluded from the response surface entirely.
+
+**Tech Stack:** Python 3.12, FastAPI 0.136.1, Pydantic v2, aiosqlite, structlog, httpx (test client), pytest-asyncio.
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `src/orchestrator/api/routers/platforms.py` | **Create** (~80 LoC) | Router module: response models + handler + structured error path |
+| `src/orchestrator/api/main.py` | **Modify** (+1 import, +1 `include_router` line) | Wire the new router into the app factory |
+| `tests/api/test_platforms_router.py` | **Create** (~280 LoC, ~22 tests) | Full test suite per spec §4 |
+| `docs/superpowers/specs/2026-04-30-bl6-platforms-readonly-design.md` | **Already created** (spec) | Locked decisions D1-D8 |
+| `CHANGELOG.md` | **Modify** (entry under `[Unreleased]` → `### Added`) | BL6 entry |
+| `FEATURES.md` | **Modify** (new F9-platforms-readonly entry) | Feature ledger update |
+
+---
+
+## Task 0: Bundle spec + plan into a single docs commit
+
+**Files:**
+- Already on disk: `docs/superpowers/specs/2026-04-30-bl6-platforms-readonly-design.md`
+- Already on disk after this plan is written: `docs/superpowers/plans/2026-04-30-bl6-platforms-readonly.md`
+
+**Branch state:** Already on `feat/bl6-platforms-readonly`. `--start-feature "BL6-F9-platforms-readonly"` already recorded.
+
+- [ ] **Step 1: Confirm both files exist and are unmodified since approval**
+
+Run:
+```bash
+git status --short docs/superpowers/specs/2026-04-30-bl6-platforms-readonly-design.md docs/superpowers/plans/2026-04-30-bl6-platforms-readonly.md
+```
+Expected: both shown as `??` (untracked, not yet staged).
+
+- [ ] **Step 2: Stage both files**
+
+Run:
+```bash
+git add docs/superpowers/specs/2026-04-30-bl6-platforms-readonly-design.md docs/superpowers/plans/2026-04-30-bl6-platforms-readonly.md
+```
+
+- [ ] **Step 3: Write the commit message to a tmp file (avoids path-string regex on the command line per project memory)**
+
+Write `/tmp/bl6-commit0.txt` with content:
+```
+docs(bl6): platforms read-only spec + implementation plan
+
+Spec locks 8 decisions for the first F9 read endpoint:
+- D1 config field excluded from response (least-blast-radius)
+- D2 wrapped envelope `{"platforms": [...]}` (locks F9 convention)
+- D3 last_error truncated to 200 chars (defense-in-depth on top of
+  upstream redaction)
+- D4 Steam-first sort order via CASE expression (operator preference)
+- D5 no ETag for v1 (YAGNI; 400-byte response)
+- D6 PoolError → 503 with structured body (consistent with /health)
+- D7 bearer required (NOT in AUTH_EXEMPT_PATHS)
+- D8 Pydantic extra="forbid" on response model
+
+Plan decomposes into 6 tasks following the project Build Loop:
+tests-first → impl → security audit → docs → combined commit →
+feature record.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+- [ ] **Step 4: Commit the spec + plan bundle**
+
+Run:
+```bash
+git commit -F /tmp/bl6-commit0.txt
+```
+Expected: 2 files committed, 1 commit on `feat/bl6-platforms-readonly`.
+
+- [ ] **Step 5: Verify**
+
+Run:
+```bash
+git log --oneline -1
+git status --short
+```
+Expected: top commit subject is `docs(bl6): platforms read-only spec + implementation plan`. Working tree clean.
+
+---
+
+## Task 1: Write the failing test suite (red phase)
+
+**Files:**
+- Create: `tests/api/test_platforms_router.py`
+
+This task writes the entire test suite at once. Tests reference the not-yet-existing router; running them fails with `ImportError`. That collective failure is the red-phase signal.
+
+- [ ] **Step 1: Read the existing test conventions**
+
+Run:
+```bash
+sed -n '1,90p' tests/api/conftest.py
+```
+Expected: see `unit_app`, `client`, `loopback_client`, `external_client`, `populated_pool` fixtures.
+
+- [ ] **Step 2: Read the platforms schema for grounding**
+
+Run:
+```bash
+grep -A 14 "CREATE TABLE platforms" src/orchestrator/db/migrations/0001_initial.sql
+```
+Expected: see name PRIMARY KEY, auth_status, auth_method, auth_expires_at, last_sync_at, last_error, config columns.
+
+- [ ] **Step 3: Write the full test file**
+
+Create `tests/api/test_platforms_router.py`:
+
+```python
+"""Tests for GET /api/v1/platforms (BL6 / Feature 9 partial).
+
+Covers spec §4 — happy path, auth, last_error truncation, config exclusion,
+response schema strictness, pool-failure 503 path, ordering + stability.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+VALID_TOKEN = "a" * 32  # matches conftest dummy ORCH_TOKEN
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformsHappyPath:
+    async def test_returns_seeded_platforms(self, client):
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert "platforms" in body
+        assert len(body["platforms"]) == 2
+
+    async def test_response_envelope_shape(self, client):
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        body = r.json()
+        # Wrapped envelope per D2.
+        assert isinstance(body, dict)
+        assert list(body.keys()) == ["platforms"]
+        assert isinstance(body["platforms"], list)
+
+    async def test_response_field_set_per_platform(self, client):
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        body = r.json()
+        for item in body["platforms"]:
+            assert set(item.keys()) == {
+                "name",
+                "auth_status",
+                "auth_method",
+                "auth_expires_at",
+                "last_sync_at",
+                "last_error",
+            }
+
+    async def test_steam_first_in_order(self, client):
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        body = r.json()
+        assert body["platforms"][0]["name"] == "steam"
+        assert body["platforms"][1]["name"] == "epic"
+
+
+# ---------------------------------------------------------------------------
+# Auth (D7)
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformsAuth:
+    async def test_no_auth_header_returns_401(self, client):
+        r = await client.get("/api/v1/platforms")
+        assert r.status_code == 401
+
+    async def test_invalid_token_returns_401(self, client):
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": "Bearer wrong"},
+        )
+        assert r.status_code == 401
+
+    async def test_valid_token_returns_200(self, client):
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# last_error truncation (D3)
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformsLastErrorTruncation:
+    async def _set_last_error(self, populated_pool, name: str, value: str | None) -> None:
+        async with populated_pool.write_transaction() as tx:
+            await tx.execute(
+                "UPDATE platforms SET last_error = ? WHERE name = ?",
+                (value, name),
+            )
+
+    async def test_null_passes_through(self, client, populated_pool):
+        await self._set_last_error(populated_pool, "steam", None)
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        steam = next(p for p in r.json()["platforms"] if p["name"] == "steam")
+        assert steam["last_error"] is None
+
+    async def test_under_200_chars_unchanged(self, client, populated_pool):
+        s = "x" * 100
+        await self._set_last_error(populated_pool, "steam", s)
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        steam = next(p for p in r.json()["platforms"] if p["name"] == "steam")
+        assert steam["last_error"] == s
+
+    async def test_exactly_200_chars_unchanged(self, client, populated_pool):
+        s = "x" * 200
+        await self._set_last_error(populated_pool, "steam", s)
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        steam = next(p for p in r.json()["platforms"] if p["name"] == "steam")
+        assert steam["last_error"] == s
+        assert len(steam["last_error"]) == 200
+
+    async def test_201_chars_truncated_to_200(self, client, populated_pool):
+        s = "x" * 201
+        await self._set_last_error(populated_pool, "steam", s)
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        steam = next(p for p in r.json()["platforms"] if p["name"] == "steam")
+        assert len(steam["last_error"]) == 200
+        assert steam["last_error"] == "x" * 200
+
+    async def test_5000_chars_truncated_to_200(self, client, populated_pool):
+        s = "x" * 5000
+        await self._set_last_error(populated_pool, "steam", s)
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        steam = next(p for p in r.json()["platforms"] if p["name"] == "steam")
+        assert len(steam["last_error"]) == 200
+
+
+# ---------------------------------------------------------------------------
+# config exclusion (D1)
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformsConfigExclusion:
+    async def test_config_not_in_response_when_set(self, client, populated_pool):
+        sensitive_config = '{"refresh_token": "should-never-appear"}'
+        async with populated_pool.write_transaction() as tx:
+            await tx.execute(
+                "UPDATE platforms SET config = ? WHERE name = 'steam'",
+                (sensitive_config,),
+            )
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        body = r.json()
+        # Config field absent from any item.
+        for item in body["platforms"]:
+            assert "config" not in item
+        # Sensitive value never reaches the wire.
+        assert "should-never-appear" not in r.text
+        assert "refresh_token" not in r.text
+
+    async def test_config_not_in_response_when_null(self, client):
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        for item in r.json()["platforms"]:
+            assert "config" not in item
+
+
+# ---------------------------------------------------------------------------
+# Response schema strictness (D8)
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformsResponseSchema:
+    def test_extra_fields_rejected_by_pydantic(self):
+        from orchestrator.api.routers.platforms import PlatformResponse
+
+        with pytest.raises(ValidationError):
+            PlatformResponse(
+                name="steam",
+                auth_status="never",
+                auth_method="steam_cm",
+                auth_expires_at=None,
+                last_sync_at=None,
+                last_error=None,
+                some_unknown_field="should be rejected",  # type: ignore[call-arg]
+            )
+
+    def test_invalid_name_rejected_by_literal(self):
+        from orchestrator.api.routers.platforms import PlatformResponse
+
+        with pytest.raises(ValidationError):
+            PlatformResponse(
+                name="origin",  # type: ignore[arg-type]
+                auth_status="never",
+                auth_method="steam_cm",
+                auth_expires_at=None,
+                last_sync_at=None,
+                last_error=None,
+            )
+
+    def test_invalid_auth_status_rejected_by_literal(self):
+        from orchestrator.api.routers.platforms import PlatformResponse
+
+        with pytest.raises(ValidationError):
+            PlatformResponse(
+                name="steam",
+                auth_status="bogus",  # type: ignore[arg-type]
+                auth_method="steam_cm",
+                auth_expires_at=None,
+                last_sync_at=None,
+                last_error=None,
+            )
+
+    def test_invalid_auth_method_rejected_by_literal(self):
+        from orchestrator.api.routers.platforms import PlatformResponse
+
+        with pytest.raises(ValidationError):
+            PlatformResponse(
+                name="steam",
+                auth_status="never",
+                auth_method="oauth2",  # type: ignore[arg-type]
+                auth_expires_at=None,
+                last_sync_at=None,
+                last_error=None,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Pool failure path (D6)
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformsPoolFailure:
+    async def test_pool_error_returns_503_with_detail(self, unit_app, client):
+        from orchestrator.api.dependencies import get_pool_dep
+        from orchestrator.db.pool import PoolError
+
+        class _FakeBrokenPool:
+            async def read_all(self, *_a, **_kw):
+                raise PoolError("simulated db unavailable")
+
+        unit_app.dependency_overrides[get_pool_dep] = lambda: _FakeBrokenPool()
+
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r.status_code == 503
+        assert r.json() == {"detail": "database unavailable"}
+
+    async def test_pool_error_logs_structured_event(self, unit_app, client, capsys):
+        from orchestrator.api.dependencies import get_pool_dep
+        from orchestrator.core.logging import configure_logging
+        from orchestrator.db.pool import PoolError
+
+        configure_logging()
+
+        class _FakeBrokenPool:
+            async def read_all(self, *_a, **_kw):
+                raise PoolError("simulated db unavailable")
+
+        unit_app.dependency_overrides[get_pool_dep] = lambda: _FakeBrokenPool()
+
+        await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        out = capsys.readouterr().out
+        events = [json.loads(line) for line in out.splitlines() if line.strip()]
+        names = [e.get("event") for e in events]
+        assert "api.platforms.read_failed" in names
+        # Correlation_id propagated through CorrelationIdMiddleware.
+        failed = next(e for e in events if e.get("event") == "api.platforms.read_failed")
+        assert "correlation_id" in failed
+
+
+# ---------------------------------------------------------------------------
+# Ordering + stability (D4)
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformsOrdering:
+    async def test_steam_at_index_0(self, client):
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        body = r.json()
+        assert body["platforms"][0]["name"] == "steam"
+
+    async def test_epic_at_index_1(self, client):
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        body = r.json()
+        assert body["platforms"][1]["name"] == "epic"
+
+    async def test_steam_first_regardless_of_row_order(self, client, populated_pool):
+        # Mutate platform rows out of seed order; assert response order
+        # remains stable. The CHECK constraint forbids new platform names,
+        # but we can clobber/restore to make rowid order non-trivial.
+        async with populated_pool.write_transaction() as tx:
+            await tx.execute("DELETE FROM platforms WHERE name IN ('steam', 'epic')")
+            # Re-insert with Epic first to shake any rowid-dependent ordering.
+            await tx.execute(
+                "INSERT INTO platforms (name, auth_status, auth_method) "
+                "VALUES ('epic', 'never', 'epic_oauth')"
+            )
+            await tx.execute(
+                "INSERT INTO platforms (name, auth_status, auth_method) "
+                "VALUES ('steam', 'never', 'steam_cm')"
+            )
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        body = r.json()
+        assert body["platforms"][0]["name"] == "steam"
+```
+
+- [ ] **Step 4: Run the test file — verify red phase**
+
+Run:
+```bash
+source .venv/bin/activate && pytest tests/api/test_platforms_router.py -q --no-header 2>&1 | tail -10
+```
+Expected: collection or import errors because `orchestrator.api.routers.platforms` does not yet exist. Every test fails with `ModuleNotFoundError: No module named 'orchestrator.api.routers.platforms'` or similar.
+
+- [ ] **Step 5: Mark tests_written and tests_verified_failing**
+
+Run:
+```bash
+scripts/process-checklist.sh --complete-step build_loop:tests_written
+scripts/process-checklist.sh --complete-step build_loop:tests_verified_failing
+```
+Expected: both report `[OK] Step ... completed for build_loop`.
+
+---
+
+## Task 2: Implement the router (green phase)
+
+**Files:**
+- Create: `src/orchestrator/api/routers/platforms.py`
+- Modify: `src/orchestrator/api/main.py` (1 import + 1 `include_router` call)
+
+- [ ] **Step 1: Write the router module**
+
+Create `src/orchestrator/api/routers/platforms.py`:
+
+```python
+"""GET /api/v1/platforms — list platform auth/sync status (BL6 / Feature 9)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+import structlog
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict
+
+from orchestrator.api.dependencies import get_pool_dep
+from orchestrator.db.pool import PoolError
+
+if TYPE_CHECKING:
+    from orchestrator.db.pool import Pool
+
+
+_LAST_ERROR_TRUNCATE = 200
+_log = structlog.get_logger(__name__)
+
+
+class PlatformResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: Literal["steam", "epic"]
+    auth_status: Literal["ok", "expired", "error", "never"]
+    auth_method: Literal["steam_cm", "epic_oauth"]
+    auth_expires_at: str | None
+    last_sync_at: str | None
+    last_error: str | None
+
+
+class PlatformListResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    platforms: list[PlatformResponse]
+
+
+router = APIRouter(prefix="/api/v1", tags=["platforms"])
+
+
+@router.get(
+    "/platforms",
+    response_model=PlatformListResponse,
+    responses={
+        200: {"description": "List of all configured platforms"},
+        401: {"description": "Missing or invalid bearer token"},
+        503: {"description": "Database pool unhealthy"},
+    },
+    summary="List all platforms",
+    description=(
+        "Returns the auth and sync status of every configured platform. "
+        "Always returns exactly two rows (steam, epic). Steam is pinned "
+        "first in the response order. The `config` field is intentionally "
+        "not exposed via this endpoint."
+    ),
+)
+async def list_platforms(
+    pool: Pool = Depends(get_pool_dep),  # noqa: B008  FastAPI idiomatic Depends in default
+) -> JSONResponse:
+    try:
+        rows = await pool.read_all(
+            "SELECT name, auth_status, auth_method, auth_expires_at, "
+            "last_sync_at, last_error FROM platforms "
+            "ORDER BY CASE WHEN name = 'steam' THEN 0 ELSE 1 END, name"
+        )
+    except PoolError as e:
+        _log.error("api.platforms.read_failed", reason=str(e))
+        return JSONResponse(
+            content={"detail": "database unavailable"},
+            status_code=503,
+        )
+
+    items = [
+        PlatformResponse(
+            name=row["name"],
+            auth_status=row["auth_status"],
+            auth_method=row["auth_method"],
+            auth_expires_at=row["auth_expires_at"],
+            last_sync_at=row["last_sync_at"],
+            last_error=(
+                row["last_error"][:_LAST_ERROR_TRUNCATE]
+                if row["last_error"]
+                else None
+            ),
+        )
+        for row in rows
+    ]
+    body = PlatformListResponse(platforms=items)
+    return JSONResponse(content=body.model_dump())
+```
+
+- [ ] **Step 2: Wire the router into main.py**
+
+Open `src/orchestrator/api/main.py`. Find the existing import line:
+```python
+from orchestrator.api.routers.health import router as health_router
+```
+Add an import below it:
+```python
+from orchestrator.api.routers.platforms import router as platforms_router
+```
+
+Then find the existing wiring line near the bottom of `create_app()`:
+```python
+    # Routers
+    app.include_router(health_router)
+```
+Add an `include_router` line for platforms below it:
+```python
+    app.include_router(platforms_router)
+```
+
+- [ ] **Step 3: Run the test file — verify green phase**
+
+Run:
+```bash
+source .venv/bin/activate && pytest tests/api/test_platforms_router.py -q --no-header 2>&1 | tail -10
+```
+Expected: all tests pass.
+
+- [ ] **Step 4: Run the full project test suite — confirm no regressions**
+
+Run:
+```bash
+source .venv/bin/activate && pytest -q --no-header 2>&1 | tail -3
+```
+Expected: 387 tests passing (was 364 + ~23 new = ~387). 0 failures.
+
+- [ ] **Step 5: Mark implemented**
+
+Run:
+```bash
+scripts/process-checklist.sh --complete-step build_loop:implemented
+```
+Expected: `[OK] Step 'implemented' completed for build_loop`.
+
+---
+
+## Task 3: Security audit pass
+
+**Files:** No file changes if all checks pass; if a check fails, fix in source/tests and re-run.
+
+- [ ] **Step 1: ruff check**
+
+Run:
+```bash
+source .venv/bin/activate && ruff check src/orchestrator/api/routers/platforms.py src/orchestrator/api/main.py tests/api/test_platforms_router.py
+```
+Expected: `All checks passed!`
+
+- [ ] **Step 2: ruff format check**
+
+Run:
+```bash
+source .venv/bin/activate && ruff format --check src/orchestrator/api/routers/platforms.py src/orchestrator/api/main.py tests/api/test_platforms_router.py
+```
+Expected: `3 files already formatted`. If reformat suggested: run `ruff format <file>` then re-run `--check`.
+
+- [ ] **Step 3: mypy --strict**
+
+Run:
+```bash
+source .venv/bin/activate && mypy --strict src/orchestrator/api/routers/platforms.py src/orchestrator/api/main.py
+```
+Expected: `Success: no issues found in 2 source files`.
+
+- [ ] **Step 4: semgrep OWASP Top 10**
+
+Run:
+```bash
+source .venv/bin/activate && semgrep --config p/owasp-top-ten --error src/orchestrator/api/routers/platforms.py src/orchestrator/api/main.py
+```
+Expected: `0 findings`.
+
+- [ ] **Step 5: gitleaks (whole repo, since the platform/path strings interact with the gitleaks `curl-auth-header` rule per UAT-3 closure memory)**
+
+Run:
+```bash
+gitleaks detect --no-banner --redact --source .
+```
+Expected: `no leaks found`.
+
+- [ ] **Step 6: Mark security_audit**
+
+Run:
+```bash
+scripts/process-checklist.sh --complete-step build_loop:security_audit
+```
+Expected: `[OK] Step 'security_audit' completed for build_loop`.
+
+---
+
+## Task 4: Documentation updates
+
+**Files:**
+- Modify: `CHANGELOG.md` (entry under `[Unreleased]` → `### Added`)
+- Modify: `FEATURES.md` (new feature ledger entry)
+
+- [ ] **Step 1: Update CHANGELOG.md**
+
+Open `CHANGELOG.md`. Find the `[Unreleased]` → `### Added` section (the BL5 entries should be at the top of `[Unreleased]`). Add this entry as the FIRST item under `### Added` (newest entries on top):
+
+```markdown
+- **`GET /api/v1/platforms`** (BL6 / Feature 9 partial) — first real
+  domain endpoint on the BL5 substrate. Returns the auth + sync status
+  of every configured platform, with Steam pinned first in the response
+  order. Six fields per platform (name, auth_status, auth_method,
+  auth_expires_at, last_sync_at, last_error); `config` column
+  intentionally excluded from the response surface. `last_error`
+  truncated to 200 chars at the API layer (defense-in-depth on top of
+  upstream redaction). Pool failures translate to HTTP 503 with a
+  structured `api.platforms.read_failed` log event. Locks the wrapped
+  envelope shape `{"<resource>": [...]}` that every future F9 read
+  endpoint will inherit. See
+  [spec](docs/superpowers/specs/2026-04-30-bl6-platforms-readonly-design.md).
+```
+
+- [ ] **Step 2: Update FEATURES.md**
+
+Open `FEATURES.md`. Find the existing F9 entries (BL5 added some). Add a new entry following the same format:
+
+```markdown
+### F9 — `GET /api/v1/platforms` (read-only)
+
+**Status:** Shipped (BL6, 2026-04-30)
+**Branch:** `feat/bl6-platforms-readonly`
+**Spec:** `docs/superpowers/specs/2026-04-30-bl6-platforms-readonly-design.md`
+
+Lists the auth + sync status of all configured platforms (steam, epic).
+Bearer-required, returns wrapped envelope `{"platforms": [...]}`.
+`config` field excluded from response surface; `last_error` truncated
+to 200 chars. Steam-first sort order. Locks the F9 read-endpoint
+conventions (envelope shape, error semantics, response strictness)
+that subsequent endpoints inherit.
+```
+
+If `FEATURES.md` doesn't have F9 entries yet (verify first with `grep -c "^### F9" FEATURES.md`), add the section under the most appropriate parent heading following the file's existing structure.
+
+- [ ] **Step 3: Verify docs render reasonably**
+
+Run:
+```bash
+head -60 CHANGELOG.md
+echo "---"
+grep -A 8 "F9 — \`GET /api/v1/platforms\`" FEATURES.md
+```
+Expected: CHANGELOG entry visible at top of `[Unreleased]` → `### Added`; FEATURES entry block visible.
+
+- [ ] **Step 4: Mark documentation_updated**
+
+Run:
+```bash
+scripts/process-checklist.sh --complete-step build_loop:documentation_updated
+```
+Expected: `[OK] Step 'documentation_updated' completed for build_loop`.
+
+---
+
+## Task 5: Combined feat + docs commit (Build Loop forces this ordering)
+
+**Files staged:** all source + tests + CHANGELOG + FEATURES (per BL5 closure pattern — gate forces docs-marked-before-source-commit).
+
+- [ ] **Step 1: Survey staged + unstaged state**
+
+Run:
+```bash
+git status --short
+git diff --stat
+```
+Expected: `?? tests/api/test_platforms_router.py`, modified files: `src/orchestrator/api/routers/platforms.py` (new), `src/orchestrator/api/main.py`, `CHANGELOG.md`, `FEATURES.md`, `.claude/process-state.json` (auto-bumped by checklist marks), `.claude/build-progress.json` (auto-bumped).
+
+- [ ] **Step 2: Stage files**
+
+Run:
+```bash
+git add src/orchestrator/api/routers/platforms.py src/orchestrator/api/main.py tests/api/test_platforms_router.py CHANGELOG.md FEATURES.md .claude/process-state.json .claude/build-progress.json
+git status --short
+```
+Expected: all listed files now staged (`A` for new, `M` for modified). Working tree should have no remaining changes.
+
+- [ ] **Step 3: Write commit message to a tmp file**
+
+Write `/tmp/bl6-commit1.txt` with:
+```
+feat(api): GET /api/v1/platforms — first F9 read endpoint
+
+First real domain endpoint on the BL5 FastAPI substrate. Lists the
+auth + sync status of every configured platform.
+
+Behavior:
+- Wrapped envelope: {"platforms": [{...}, {...}]} — locks F9 convention
+- Six fields per platform (config excluded — D1)
+- last_error truncated to 200 chars at API layer (D3)
+- Steam-first sort via CASE expression (D4)
+- Pool errors → 503 with structured api.platforms.read_failed log (D6)
+- Bearer required (NOT in AUTH_EXEMPT_PATHS — D7)
+- Pydantic extra="forbid" on response model (D8)
+
+Implementation: src/orchestrator/api/routers/platforms.py (~80 LoC)
++ 2-line wire-up in main.py.
+
+Tests: tests/api/test_platforms_router.py — 22 tests across 7 classes
+(happy path, auth, last_error truncation, config exclusion, response
+schema strictness, pool failure 503 path, ordering + stability).
+
+Docs: CHANGELOG entry under [Unreleased] → Added; FEATURES F9 ledger
+entry; spec already on disk at
+docs/superpowers/specs/2026-04-30-bl6-platforms-readonly-design.md.
+
+Verification: full project suite green (387 tests); ruff / mypy
+--strict / semgrep OWASP Top 10 / gitleaks all clean.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+- [ ] **Step 4: Commit**
+
+Run:
+```bash
+git commit -F /tmp/bl6-commit1.txt
+```
+
+If pre-commit gate blocks: read the message, fix the underlying issue, re-stage, commit again. NEVER use `--no-verify`.
+
+If config-guard blocks `.claude/*` staging via Bash (per UAT-3 memory `.claude/process-state.json` and `.claude/build-progress.json` are NOT in the blocked-list, but verify): hand off to user terminal with `! git add .claude/process-state.json .claude/build-progress.json && git commit -F /tmp/bl6-commit1.txt`.
+
+- [ ] **Step 5: Verify commit landed**
+
+Run:
+```bash
+git log --oneline -2
+git status --short
+```
+Expected: top commit subject `feat(api): GET /api/v1/platforms — first F9 read endpoint`. Working tree clean (or only `M .claude/process-state.json` if the next checklist mark already fired — that's expected).
+
+---
+
+## Task 6: Record the feature; mark feature_recorded; check test gate
+
+**Files:** `.claude/build-progress.json` and `.claude/process-state.json` updated by the scripts.
+
+- [ ] **Step 1: Mark feature_recorded**
+
+Run:
+```bash
+scripts/process-checklist.sh --complete-step build_loop:feature_recorded
+```
+Expected: `[OK] Step 'feature_recorded' completed for build_loop (6/6)` + `[OK] All steps complete for build_loop!`.
+
+- [ ] **Step 2: Record feature in test-gate counter**
+
+Run:
+```bash
+scripts/test-gate.sh --record-feature "BL6-F9-platforms-readonly"
+```
+Expected: `[OK] Feature recorded`. Counter increments to 1/2.
+
+- [ ] **Step 3: Verify state**
+
+Run:
+```bash
+scripts/test-gate.sh --check-batch
+```
+Expected: `[OK] Clear to continue (1 features until next testing session)` (UAT-4 will fire after the NEXT feature, since interval is 2).
+
+- [ ] **Step 4: Push branch + open PR**
+
+Run:
+```bash
+git push -u origin feat/bl6-platforms-readonly
+```
+
+Then write `/tmp/bl6-pr-body.txt`:
+```markdown
+## Summary
+
+BL6 — `GET /api/v1/platforms` — first real F9 read endpoint on the BL5 FastAPI substrate. Locks the API conventions (wrapped envelope, response strictness, error semantics) every future F9 endpoint will inherit.
+
+## What's in this PR
+
+- **`docs(bl6)`** — design spec + implementation plan
+- **`feat(api)`** — router + main.py wiring + 22-test suite + CHANGELOG/FEATURES updates
+
+## Locked decisions (D1-D8)
+
+| ID | Decision |
+|---|---|
+| D1 | `config` field excluded from response (least blast-radius) |
+| D2 | Wrapped envelope `{"platforms": [...]}` — locks F9 convention |
+| D3 | `last_error` truncated to 200 chars at API layer |
+| D4 | Steam-first sort via CASE expression |
+| D5 | No ETag for v1 (YAGNI) |
+| D6 | Pool errors → 503 with structured body |
+| D7 | Bearer required (NOT in AUTH_EXEMPT_PATHS) |
+| D8 | Pydantic `extra="forbid"` on response model |
+
+## Verification
+
+- 387 project tests passing (+22 new in `test_platforms_router.py`)
+- ruff / ruff format / mypy --strict / semgrep p/owasp-top-ten / gitleaks all clean
+- 6/6 Build Loop checklist; feature recorded; test-gate counter at 1/2
+
+## Test plan
+
+- [ ] CI status checks pass (8 required)
+- [ ] Manual smoke: `uvicorn orchestrator.api.main:app` boots; `curl -H "Authorization: Bearer $T" http://127.0.0.1:8765/api/v1/platforms` returns `{"platforms": [{"name": "steam", ...}, {"name": "epic", ...}]}`
+- [ ] Review locked decisions in spec; flag any conventions you want to revisit before they propagate to `/games`, `/jobs`, `/manifests`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+Then:
+```bash
+gh pr create --title "feat(api): GET /api/v1/platforms — first F9 read endpoint" --body-file /tmp/bl6-pr-body.txt --base main --head feat/bl6-platforms-readonly
+```
+
+- [ ] **Step 5: Stop. Report PR URL to the user; do not call `gh pr merge`.**
+
+Per project memory `feedback_pr_merge_ownership.md`: user merges PRs themselves on GitHub.
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec section | Plan task |
+|---|---|
+| §1 Goal | Tasks 2-6 (full implementation + commit) |
+| §2 D1 (config excluded) | Task 1 `TestPlatformsConfigExclusion`; Task 2 router doesn't SELECT or expose config |
+| §2 D2 (wrapped envelope) | Task 1 `TestPlatformsHappyPath::test_response_envelope_shape`; Task 2 `PlatformListResponse` |
+| §2 D3 (last_error truncation) | Task 1 `TestPlatformsLastErrorTruncation` (5 tests); Task 2 `_LAST_ERROR_TRUNCATE = 200` |
+| §2 D4 (Steam-first ordering) | Task 1 `TestPlatformsOrdering` (3 tests); Task 2 SQL CASE clause |
+| §2 D5 (no ETag) | implicit — no ETag code in Task 2; deferred to follow-ups |
+| §2 D6 (pool error 503) | Task 1 `TestPlatformsPoolFailure` (2 tests); Task 2 `except PoolError` |
+| §2 D7 (bearer required) | Task 1 `TestPlatformsAuth` (3 tests); Task 2 path NOT added to `AUTH_EXEMPT_PATHS` |
+| §2 D8 (extra="forbid") | Task 1 `TestPlatformsResponseSchema` (4 tests); Task 2 `model_config = ConfigDict(extra="forbid")` on both models |
+| §3.1 file layout | Task 2 file paths exact |
+| §3.2 router structure | Task 2 Step 1 — full file content |
+| §3.3 wire format | Task 1 happy-path tests assert on this |
+| §3.4 main.py wiring | Task 2 Step 2 — exact import + `include_router` lines |
+| §4.1 test classes | Task 1 — all 7 classes present |
+| §4.2 test fixtures | Task 1 uses `client`, `unit_app`, `populated_pool` |
+| §4.3 out of scope | Plan respects: no ETag tests; no concurrent-read tests; no CORS tests |
+| §5 risk register | Tasks 1-2 cover migration drift (extra=forbid test), credential leak (truncation test), config exclusion test |
+| §6 documentation deltas | Task 4 covers CHANGELOG + FEATURES; Task 0 covers spec/plan commit; ADR omitted per spec |
+| §7 cross-references | All paths used in plan match spec §7 |
+| §8 open follow-ups | Plan does not implement diagnostics endpoint, ETag, per-platform endpoint, or `meta` envelope — correctly deferred |
+
+**Placeholder scan:** No "TBD", "TODO", "implement later", or unspecified-detail steps. All file paths, code blocks, and commands are concrete.
+
+**Type consistency:** `PlatformResponse` and `PlatformListResponse` referenced consistently across Task 1 (tests) and Task 2 (impl). `_LAST_ERROR_TRUNCATE = 200` used in Task 2 only; tests check the OUTCOME (length 200) not the constant name. `get_pool_dep` imported from `orchestrator.api.dependencies` in both source and tests. `PoolError` from `orchestrator.db.pool` consistent. `_log` private name only used in source; tests assert on event-name string.

--- a/docs/superpowers/specs/2026-04-30-bl6-platforms-readonly-design.md
+++ b/docs/superpowers/specs/2026-04-30-bl6-platforms-readonly-design.md
@@ -1,0 +1,260 @@
+# BL6-F9 — `GET /api/v1/platforms` (read-only) — Design Spec
+
+**Date:** 2026-04-30
+**Phase:** 2 (Construction), Milestone B, Build Loop 6
+**Feature:** F9 partial — first read-only `/api/v1/*` endpoint
+**Branch:** `feat/bl6-platforms-readonly`
+**Depends on:** BL3 (Settings), BL4 (DB pool), BL5 (FastAPI skeleton + UAT-3 remediation)
+**Unblocks:** F1/F2 (Steam/Epic auth) — operator can verify auth state via this read endpoint after running `POST /api/v1/platforms/{name}/auth`
+
+---
+
+## 1. Goal
+
+Expose the BL5 FastAPI skeleton's first real domain endpoint: a read-only listing of every configured platform's auth + sync status. Game_shelf UI consumes this to render the platform-status panel; operator CLI can poll it for diagnostics.
+
+This endpoint also locks the API conventions every future F9 read endpoint (games, jobs, manifests, stats, block_list) will inherit:
+
+- Wrapped envelope shape: `{"<resource>": [...], (optionally) "meta": {...}}`
+- Pydantic response model with `extra="forbid"`
+- `Depends(get_pool_dep)` for DB access (Bible §10.5)
+- `JSONResponse(content=body.model_dump())` return idiom (per BL5 health)
+- 503 with `{"detail": "database unavailable"}` on `PoolError` (consistent with `/health`)
+- Bearer-required (NOT in `AUTH_EXEMPT_PATHS`)
+
+---
+
+## 2. Locked decisions
+
+| # | Decision | Choice | Rationale |
+|---|---|---|---|
+| **D1** | `config` field exposure | **Excluded entirely** | Least-blast-radius. Config will hold credentials when F1/F2 land; no operator workflow currently needs config readback through the read endpoint. Add a separate `GET /api/v1/platforms/{name}/diagnostics` later if a real need emerges. |
+| **D2** | Response envelope | **Wrapped: `{"platforms": [...]}`** | Locks the convention for every future F9 endpoint. Same shape generalizes to `{"games": [...], "meta": {...}}` for paginated lists later. Resource-name key beats generic `"data"` for grep-during-debug. |
+| **D3** | `last_error` field | **Truncate to 200 chars at API layer** | Defense-in-depth on top of upstream redaction. Caps any leak that slips through F1/F2/F3 sync-error scrubbing. 200 chars is enough for operator triage, not enough for a typical credential blob. Full string preserved in structured logs only. |
+| **D4** | Sort order | **Steam first, then alphabetical** | `ORDER BY CASE WHEN name = 'steam' THEN 0 ELSE 1 END, name`. Operator preference; pin Steam at the top of the Game_shelf platform panel. CASE expression keeps order stable if a future migration adds a third platform. |
+| **D5** | ETag / caching | **None for v1 (YAGNI)** | Two rows × ~200 bytes each ≈ 400-byte response; no realistic poll rate is bandwidth-constrained. Add ETag in a follow-up only if Game_shelf surfaces a real need. |
+| **D6** | Pool-error semantics | **503 with structured body** | Consistent with `/api/v1/health` pattern. Catches `PoolError`/`PoolNotInitializedError`/`QueryError`. Default Starlette 500 would be a less informative wire signal. |
+| **D7** | Auth | **Bearer required (NOT exempt)** | Platform auth/sync status is operator-only data. Path is added to no exempt list; BL5's `BearerAuthMiddleware` enforces. |
+| **D8** | Response model strictness | **`extra="forbid"`** | Future migration adding a column without updating the model is caught immediately by the test suite (mismatch raises during model validation). |
+
+---
+
+## 3. Architecture
+
+### 3.1 File layout
+
+```
+src/orchestrator/api/routers/platforms.py    NEW — ~80 LoC
+src/orchestrator/api/main.py                 +1 line (app.include_router)
+tests/api/test_platforms_router.py           NEW — ~250 LoC, ~15 tests
+docs/ADR documentation/...                   no new ADR; this spec + CHANGELOG suffice
+```
+
+No schema migration required — table already exists from `0001_initial.sql`.
+
+### 3.2 Module: `src/orchestrator/api/routers/platforms.py`
+
+```python
+"""GET /api/v1/platforms — list platform auth/sync status (BL6 / Feature 9)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+import structlog
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict
+
+from orchestrator.api.dependencies import get_pool_dep
+from orchestrator.db.pool import PoolError
+
+if TYPE_CHECKING:
+    from orchestrator.db.pool import Pool
+
+
+_LAST_ERROR_TRUNCATE = 200
+_log = structlog.get_logger(__name__)
+
+
+class PlatformResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: Literal["steam", "epic"]
+    auth_status: Literal["ok", "expired", "error", "never"]
+    auth_method: Literal["steam_cm", "epic_oauth"]
+    auth_expires_at: str | None
+    last_sync_at: str | None
+    last_error: str | None
+
+
+class PlatformListResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    platforms: list[PlatformResponse]
+
+
+router = APIRouter(prefix="/api/v1", tags=["platforms"])
+
+
+@router.get(
+    "/platforms",
+    response_model=PlatformListResponse,
+    responses={
+        200: {"description": "List of all configured platforms"},
+        401: {"description": "Missing or invalid bearer token"},
+        503: {"description": "Database pool unhealthy", "model": dict},
+    },
+    summary="List all platforms",
+    description=(
+        "Returns the auth and sync status of every configured platform. "
+        "Always returns exactly two rows (steam, epic). Steam is pinned "
+        "first in the response order. The `config` field is intentionally "
+        "not exposed via this endpoint."
+    ),
+)
+async def list_platforms(
+    pool: Pool = Depends(get_pool_dep),  # noqa: B008  FastAPI idiomatic
+) -> JSONResponse:
+    try:
+        rows = await pool.read_all(
+            "SELECT name, auth_status, auth_method, auth_expires_at, "
+            "last_sync_at, last_error FROM platforms "
+            "ORDER BY CASE WHEN name = 'steam' THEN 0 ELSE 1 END, name"
+        )
+    except PoolError as e:
+        _log.error("api.platforms.read_failed", reason=str(e))
+        return JSONResponse(
+            content={"detail": "database unavailable"},
+            status_code=503,
+        )
+
+    items = [
+        PlatformResponse(
+            name=row["name"],
+            auth_status=row["auth_status"],
+            auth_method=row["auth_method"],
+            auth_expires_at=row["auth_expires_at"],
+            last_sync_at=row["last_sync_at"],
+            last_error=(
+                row["last_error"][:_LAST_ERROR_TRUNCATE]
+                if row["last_error"] else None
+            ),
+        )
+        for row in rows
+    ]
+    body = PlatformListResponse(platforms=items)
+    return JSONResponse(content=body.model_dump())
+```
+
+### 3.3 Wire format
+
+```json
+{
+  "platforms": [
+    {
+      "name": "steam",
+      "auth_status": "never",
+      "auth_method": "steam_cm",
+      "auth_expires_at": null,
+      "last_sync_at": null,
+      "last_error": null
+    },
+    {
+      "name": "epic",
+      "auth_status": "never",
+      "auth_method": "epic_oauth",
+      "auth_expires_at": null,
+      "last_sync_at": null,
+      "last_error": null
+    }
+  ]
+}
+```
+
+Six fields per platform. `config` excluded. `last_error` truncated to 200 chars.
+
+### 3.4 Wiring in `main.py`
+
+```python
+from orchestrator.api.routers.platforms import router as platforms_router
+# ...
+app.include_router(health_router)
+app.include_router(platforms_router)  # BL6
+```
+
+---
+
+## 4. Test plan
+
+Target: ≥95% branch coverage on `routers/platforms.py`. ~15 tests in `tests/api/test_platforms_router.py`.
+
+### 4.1 Test classes
+
+| Class | Tests | Coverage |
+|---|---|---|
+| `TestPlatformsHappyPath` | seeded steam+epic returned; correct order (steam first); 6-field response; envelope shape; 200 status | Happy path |
+| `TestPlatformsAuth` | unauth → 401; wrong token → 401; valid token → 200 | Auth integration |
+| `TestPlatformsLastErrorTruncation` | 199-char unchanged; 200-char unchanged; 201-char truncated; 5000-char truncated; null → null | D3 |
+| `TestPlatformsConfigExclusion` | `config` field never in response even when DB row has non-null config; sensitive content in DB doesn't leak | D1 |
+| `TestPlatformsResponseSchema` | `extra="forbid"` rejects unknown fields; Pydantic Literal narrowing on auth_status/auth_method | D8 |
+| `TestPlatformsPoolFailure` | `PoolError` → 503 + `{"detail": "database unavailable"}`; structured `api.platforms.read_failed` log with correlation_id propagated | D6 |
+| `TestPlatformsOrdering` | steam at index 0, epic at index 1; verify CASE clause via direct query inspection | D4 |
+| `TestPlatformsSortStability` | hand-write rows in alpha order then non-alpha order → steam still first | D4 stability |
+
+### 4.2 Test fixtures
+
+Reuse `tests/api/conftest.py` fixtures:
+- `unit_app` — fast-path app with `dependency_overrides[get_pool_dep] = populated_pool`
+- `client` — `httpx.AsyncClient` against `unit_app`
+- `populated_pool` — fresh DB with seeded `steam`/`epic` rows
+
+For tests that need to mutate platform rows (e.g., `last_error` truncation), use `populated_pool.write_transaction()` to UPDATE before the GET.
+
+### 4.3 Out of scope for BL6
+
+- ETag / Last-Modified handling (D5, deferred)
+- Concurrent-read stress (covered by BL4 pool tests)
+- CORS allowed-origin mechanics (covered by BL5 + UAT-3 tests)
+- The `POST /api/v1/platforms/{name}/auth` handler (F1/F2 — separate BL)
+
+---
+
+## 5. Risk register
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Future migration adds a column to `platforms` and the response model isn't updated | Medium | `extra="forbid"` on `PlatformResponse` causes Pydantic to raise during construction; CI tests catch it |
+| Future F1/F2 writes credentials into `last_error` (e.g., raw exception with refresh token in URL) | Medium | D3 200-char truncation caps blast; ID3's `_redact_sensitive_values` redacts at log-write time. Defense-in-depth, not single-layer. |
+| `config` field accidentally added back to the response model | Low | `TestPlatformsConfigExclusion` test asserts `config` not in response keys; `extra="forbid"` blocks accidental construction |
+| Pool returns a row with a name not in the Literal type | Low | Schema CHECK constrains to ('steam', 'epic'); migration to add a third platform requires explicit Literal expansion |
+| Pool error during test causes test flakiness | Low | All tests use `populated_pool` fixture which is per-test-deterministic; no shared mutable pool state |
+| Steam-first ordering is unstable if the rows are written in different order at migration time | Low | Explicit `ORDER BY CASE WHEN name = 'steam' THEN 0 ELSE 1 END, name` is deterministic regardless of insert order |
+
+---
+
+## 6. Documentation deltas
+
+- **CHANGELOG.md:** add to `[Unreleased]` → `### Added` (under BL6 heading)
+- **README.md:** if a "What endpoints are available?" section exists, add `/api/v1/platforms` to the list
+- **FEATURES.md:** add F9-platforms-readonly entry per existing convention
+- **ADR:** none — this spec + the CHANGELOG entry constitute the design record. ADR is reserved for cross-cutting architectural decisions (BL5 was; this isn't).
+
+---
+
+## 7. Cross-references
+
+- **Data model contract:** `docs/phase-1/data-model.md` (platforms table schema + invariants)
+- **DB pool API:** ADR-0011 (`read_all` returns list of `aiosqlite.Row` objects with `.keys()` access)
+- **API substrate:** ADR-0012 + UAT-3 addendum (middleware stack, AUTH_EXEMPT_PATHS, response idiom)
+- **Threat model:** TM-001 (auth — handled by middleware), TM-012 (log redaction — `_log.error` uses ID3's redactor)
+- **Bible:** §8.4 (health endpoint pattern this mirrors), §10.5 (no direct singleton imports)
+
+---
+
+## 8. Open follow-ups (deferred, not blocking)
+
+- Diagnostics endpoint (`GET /api/v1/platforms/{name}/diagnostics`) — full `last_error`, recent sync attempts, structured error category. Lands when Game_shelf surfaces a real need.
+- ETag support — when Game_shelf shows real polling load.
+- Per-platform read endpoint (`GET /api/v1/platforms/{name}`) — currently no need; Game_shelf reads the whole list.
+- `meta` envelope field — wire when first paginated endpoint (`/games`) lands; backfill `/platforms` to include `{"meta": {"count": 2}}` for client uniformity at that time.

--- a/src/orchestrator/api/main.py
+++ b/src/orchestrator/api/main.py
@@ -23,6 +23,7 @@ from orchestrator.api.middleware import (
     CorrelationIdMiddleware,
 )
 from orchestrator.api.routers.health import router as health_router
+from orchestrator.api.routers.platforms import router as platforms_router
 from orchestrator.core.settings import get_settings
 from orchestrator.db import migrate
 from orchestrator.db.pool import (
@@ -198,6 +199,7 @@ def create_app() -> FastAPI:
 
     # Routers
     app.include_router(health_router)
+    app.include_router(platforms_router)
 
     return app
 

--- a/src/orchestrator/api/routers/platforms.py
+++ b/src/orchestrator/api/routers/platforms.py
@@ -1,0 +1,87 @@
+"""GET /api/v1/platforms — list platform auth/sync status (BL6 / Feature 9)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+import structlog
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict
+
+from orchestrator.api.dependencies import get_pool_dep
+from orchestrator.db.pool import PoolError
+
+if TYPE_CHECKING:
+    from orchestrator.db.pool import Pool
+
+
+_LAST_ERROR_TRUNCATE = 200
+_log = structlog.get_logger(__name__)
+
+
+class PlatformResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: Literal["steam", "epic"]
+    auth_status: Literal["ok", "expired", "error", "never"]
+    auth_method: Literal["steam_cm", "epic_oauth"]
+    auth_expires_at: str | None
+    last_sync_at: str | None
+    last_error: str | None
+
+
+class PlatformListResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    platforms: list[PlatformResponse]
+
+
+router = APIRouter(prefix="/api/v1", tags=["platforms"])
+
+
+@router.get(
+    "/platforms",
+    response_model=PlatformListResponse,
+    responses={
+        200: {"description": "List of all configured platforms"},
+        401: {"description": "Missing or invalid bearer token"},
+        503: {"description": "Database pool unhealthy"},
+    },
+    summary="List all platforms",
+    description=(
+        "Returns the auth and sync status of every configured platform. "
+        "Always returns exactly two rows (steam, epic). Steam is pinned "
+        "first in the response order. The `config` field is intentionally "
+        "not exposed via this endpoint."
+    ),
+)
+async def list_platforms(
+    pool: Pool = Depends(get_pool_dep),  # noqa: B008  FastAPI idiomatic Depends in default
+) -> JSONResponse:
+    try:
+        rows = await pool.read_all(
+            "SELECT name, auth_status, auth_method, auth_expires_at, "
+            "last_sync_at, last_error FROM platforms "
+            "ORDER BY CASE WHEN name = 'steam' THEN 0 ELSE 1 END, name"
+        )
+    except PoolError as e:
+        _log.error("api.platforms.read_failed", reason=str(e))
+        return JSONResponse(
+            content={"detail": "database unavailable"},
+            status_code=503,
+        )
+
+    items = [
+        PlatformResponse(
+            name=row["name"],
+            auth_status=row["auth_status"],
+            auth_method=row["auth_method"],
+            auth_expires_at=row["auth_expires_at"],
+            last_sync_at=row["last_sync_at"],
+            last_error=(row["last_error"][:_LAST_ERROR_TRUNCATE] if row["last_error"] else None),
+        )
+        for row in rows
+    ]
+    body = PlatformListResponse(platforms=items)
+    return JSONResponse(content=body.model_dump())

--- a/tests/api/test_platforms_router.py
+++ b/tests/api/test_platforms_router.py
@@ -1,0 +1,336 @@
+"""Tests for GET /api/v1/platforms (BL6 / Feature 9 partial).
+
+Covers spec §4 — happy path, auth, last_error truncation, config exclusion,
+response schema strictness, pool-failure 503 path, ordering + stability.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+VALID_TOKEN = "a" * 32  # matches conftest dummy ORCH_TOKEN
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformsHappyPath:
+    async def test_returns_seeded_platforms(self, client):
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert "platforms" in body
+        assert len(body["platforms"]) == 2
+
+    async def test_response_envelope_shape(self, client):
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        body = r.json()
+        # Wrapped envelope per D2.
+        assert isinstance(body, dict)
+        assert list(body.keys()) == ["platforms"]
+        assert isinstance(body["platforms"], list)
+
+    async def test_response_field_set_per_platform(self, client):
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        body = r.json()
+        for item in body["platforms"]:
+            assert set(item.keys()) == {
+                "name",
+                "auth_status",
+                "auth_method",
+                "auth_expires_at",
+                "last_sync_at",
+                "last_error",
+            }
+
+    async def test_steam_first_in_order(self, client):
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        body = r.json()
+        assert body["platforms"][0]["name"] == "steam"
+        assert body["platforms"][1]["name"] == "epic"
+
+
+# ---------------------------------------------------------------------------
+# Auth (D7)
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformsAuth:
+    async def test_no_auth_header_returns_401(self, client):
+        r = await client.get("/api/v1/platforms")
+        assert r.status_code == 401
+
+    async def test_invalid_token_returns_401(self, client):
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": "Bearer wrong"},
+        )
+        assert r.status_code == 401
+
+    async def test_valid_token_returns_200(self, client):
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# last_error truncation (D3)
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformsLastErrorTruncation:
+    async def _set_last_error(self, populated_pool, name: str, value: str | None) -> None:
+        async with populated_pool.write_transaction() as tx:
+            await tx.execute(
+                "UPDATE platforms SET last_error = ? WHERE name = ?",
+                (value, name),
+            )
+
+    async def test_null_passes_through(self, client, populated_pool):
+        await self._set_last_error(populated_pool, "steam", None)
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        steam = next(p for p in r.json()["platforms"] if p["name"] == "steam")
+        assert steam["last_error"] is None
+
+    async def test_under_200_chars_unchanged(self, client, populated_pool):
+        s = "x" * 100
+        await self._set_last_error(populated_pool, "steam", s)
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        steam = next(p for p in r.json()["platforms"] if p["name"] == "steam")
+        assert steam["last_error"] == s
+
+    async def test_exactly_200_chars_unchanged(self, client, populated_pool):
+        s = "x" * 200
+        await self._set_last_error(populated_pool, "steam", s)
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        steam = next(p for p in r.json()["platforms"] if p["name"] == "steam")
+        assert steam["last_error"] == s
+        assert len(steam["last_error"]) == 200
+
+    async def test_201_chars_truncated_to_200(self, client, populated_pool):
+        s = "x" * 201
+        await self._set_last_error(populated_pool, "steam", s)
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        steam = next(p for p in r.json()["platforms"] if p["name"] == "steam")
+        assert len(steam["last_error"]) == 200
+        assert steam["last_error"] == "x" * 200
+
+    async def test_5000_chars_truncated_to_200(self, client, populated_pool):
+        s = "x" * 5000
+        await self._set_last_error(populated_pool, "steam", s)
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        steam = next(p for p in r.json()["platforms"] if p["name"] == "steam")
+        assert len(steam["last_error"]) == 200
+
+
+# ---------------------------------------------------------------------------
+# config exclusion (D1)
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformsConfigExclusion:
+    async def test_config_not_in_response_when_set(self, client, populated_pool):
+        sensitive_config = '{"refresh_token": "should-never-appear"}'
+        async with populated_pool.write_transaction() as tx:
+            await tx.execute(
+                "UPDATE platforms SET config = ? WHERE name = 'steam'",
+                (sensitive_config,),
+            )
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        body = r.json()
+        # Config field absent from any item.
+        for item in body["platforms"]:
+            assert "config" not in item
+        # Sensitive value never reaches the wire.
+        assert "should-never-appear" not in r.text
+        assert "refresh_token" not in r.text
+
+    async def test_config_not_in_response_when_null(self, client):
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        for item in r.json()["platforms"]:
+            assert "config" not in item
+
+
+# ---------------------------------------------------------------------------
+# Response schema strictness (D8)
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformsResponseSchema:
+    def test_extra_fields_rejected_by_pydantic(self):
+        from orchestrator.api.routers.platforms import PlatformResponse
+
+        with pytest.raises(ValidationError):
+            PlatformResponse(
+                name="steam",
+                auth_status="never",
+                auth_method="steam_cm",
+                auth_expires_at=None,
+                last_sync_at=None,
+                last_error=None,
+                some_unknown_field="should be rejected",  # type: ignore[call-arg]
+            )
+
+    def test_invalid_name_rejected_by_literal(self):
+        from orchestrator.api.routers.platforms import PlatformResponse
+
+        with pytest.raises(ValidationError):
+            PlatformResponse(
+                name="origin",  # type: ignore[arg-type]
+                auth_status="never",
+                auth_method="steam_cm",
+                auth_expires_at=None,
+                last_sync_at=None,
+                last_error=None,
+            )
+
+    def test_invalid_auth_status_rejected_by_literal(self):
+        from orchestrator.api.routers.platforms import PlatformResponse
+
+        with pytest.raises(ValidationError):
+            PlatformResponse(
+                name="steam",
+                auth_status="bogus",  # type: ignore[arg-type]
+                auth_method="steam_cm",
+                auth_expires_at=None,
+                last_sync_at=None,
+                last_error=None,
+            )
+
+    def test_invalid_auth_method_rejected_by_literal(self):
+        from orchestrator.api.routers.platforms import PlatformResponse
+
+        with pytest.raises(ValidationError):
+            PlatformResponse(
+                name="steam",
+                auth_status="never",
+                auth_method="oauth2",  # type: ignore[arg-type]
+                auth_expires_at=None,
+                last_sync_at=None,
+                last_error=None,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Pool failure path (D6)
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformsPoolFailure:
+    async def test_pool_error_returns_503_with_detail(self, unit_app, client):
+        from orchestrator.api.dependencies import get_pool_dep
+        from orchestrator.db.pool import PoolError
+
+        class _FakeBrokenPool:
+            async def read_all(self, *_a, **_kw):
+                raise PoolError("simulated db unavailable")
+
+        unit_app.dependency_overrides[get_pool_dep] = lambda: _FakeBrokenPool()
+
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r.status_code == 503
+        assert r.json() == {"detail": "database unavailable"}
+
+    async def test_pool_error_logs_structured_event(self, unit_app, client, capsys):
+        from orchestrator.api.dependencies import get_pool_dep
+        from orchestrator.core.logging import configure_logging
+        from orchestrator.db.pool import PoolError
+
+        configure_logging()
+
+        class _FakeBrokenPool:
+            async def read_all(self, *_a, **_kw):
+                raise PoolError("simulated db unavailable")
+
+        unit_app.dependency_overrides[get_pool_dep] = lambda: _FakeBrokenPool()
+
+        await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        out = capsys.readouterr().out
+        events = [json.loads(line) for line in out.splitlines() if line.strip()]
+        names = [e.get("event") for e in events]
+        assert "api.platforms.read_failed" in names
+        # Correlation_id propagated through CorrelationIdMiddleware.
+        failed = next(e for e in events if e.get("event") == "api.platforms.read_failed")
+        assert "correlation_id" in failed
+
+
+# ---------------------------------------------------------------------------
+# Ordering + stability (D4)
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformsOrdering:
+    async def test_steam_at_index_0(self, client):
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        body = r.json()
+        assert body["platforms"][0]["name"] == "steam"
+
+    async def test_epic_at_index_1(self, client):
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        body = r.json()
+        assert body["platforms"][1]["name"] == "epic"
+
+    async def test_steam_index_distinct_from_epic_index(self, client):
+        # Cheap non-rowid-dependent stability check: assert the two
+        # platforms end up at distinct indexes 0 and 1 with steam first.
+        # The deeper "shake the insert order" test is omitted because
+        # FK ON DELETE RESTRICT (games → platforms) makes a true reset
+        # impractical from inside the populated_pool fixture.
+        r = await client.get(
+            "/api/v1/platforms",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        names = [p["name"] for p in r.json()["platforms"]]
+        assert names == ["steam", "epic"]


### PR DESCRIPTION
## Summary

BL6 — `GET /api/v1/platforms` — first real F9 read endpoint on the BL5 FastAPI substrate. Locks the API conventions (wrapped envelope, response strictness, error semantics) every future F9 endpoint will inherit.

## What's in this PR

| Commit | Purpose |
|---|---|
| `docs(spec)` | Design with 8 locked decisions D1-D8 |
| `docs(plan)` | 6-task implementation plan |
| `feat(api)` | Router + tests + CHANGELOG/FEATURES + security audit |
| `chore(framework)` | Add `py:__future__` to context7 stdlib whitelist (one-line orthogonal hook fix surfaced during BL6) |

## Locked decisions (D1-D8)

| ID | Decision |
|---|---|
| D1 | `config` field excluded from response (least blast-radius) |
| D2 | Wrapped envelope `{"platforms": [...]}` — locks F9 convention |
| D3 | `last_error` truncated to 200 chars at API layer |
| D4 | Steam-first sort via CASE expression |
| D5 | No ETag for v1 (YAGNI) |
| D6 | Pool errors → 503 with structured body |
| D7 | Bearer required (NOT in AUTH_EXEMPT_PATHS) |
| D8 | Pydantic `extra="forbid"` on response model |

## Verification

- 387 project tests passing (+23 new in `test_platforms_router.py`)
- ruff / ruff format / mypy --strict / semgrep p/owasp-top-ten / gitleaks all clean
- 6/6 Build Loop checklist; feature recorded; test-gate counter at 1/2
- Security audit: 0 findings (`docs/security-audits/bl6-f9-platforms-readonly-security-audit.md`)

## Test plan

- [ ] CI status checks pass (8 required)
- [ ] Manual smoke: `uvicorn orchestrator.api.main:app` boots; with `ORCH_TOKEN` set, `curl -H "Authorization: Bearer $ORCH_TOKEN" http://127.0.0.1:8765/api/v1/platforms` returns `{"platforms": [{"name": "steam", ...}, {"name": "epic", ...}]}`
- [ ] Review locked decisions in spec; flag any conventions you want to revisit before they propagate to `/games`, `/jobs`, `/manifests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
