### PR TITLE
chore(state): record BL6 feature in build_loop + test-gate counter

### DIFF
--- a/.claude/build-progress.json
+++ b/.claude/build-progress.json
@@ -5,10 +5,11 @@
     "ID4-settings",
     "BL4-DB-pool",
     "UAT-2-remediation",
-    "BL5-F9-fastapi-skeleton"
+    "BL5-F9-fastapi-skeleton",
+    "BL6-F9-platforms-readonly"
   ],
-  "features_since_last_test": 0,
-  "features_since_last_health_check": 3,
+  "features_since_last_test": 1,
+  "features_since_last_health_check": 4,
   "test_interval": 2,
   "last_test_session": "2026-04-30",
   "testing_required": false,

--- a/.claude/process-state.json
+++ b/.claude/process-state.json
@@ -1,15 +1,9 @@
 {
   "build_loop": {
-    "feature": "BL6-F9-platforms-readonly",
-    "step": 5,
-    "steps_completed": [
-      "tests_written",
-      "tests_verified_failing",
-      "implemented",
-      "security_audit",
-      "documentation_updated"
-    ],
-    "started_at": "2026-04-30T17:40:44Z"
+    "feature": null,
+    "step": 0,
+    "steps_completed": [],
+    "started_at": null
   },
   "uat_session": {
     "session_id": 3,


### PR DESCRIPTION
## Summary

Post-merge state bump for BL6 (`BL6-F9-platforms-readonly`). Two `.claude/*` files were auto-updated by `scripts/process-checklist.sh --complete-step build_loop:feature_recorded` and `scripts/test-gate.sh --record-feature` after the feat commit (`e4373fe`) landed in #59.

Tracking these on main keeps:
- Build Loop closure visible (6/6 reset to fresh state, ready for next feature)
- UAT-4 trigger timing accurate (counter at 1/2; one more feature triggers UAT-4)

No code changes. No test changes. No CI risk beyond the standard pipeline.

## Test plan

- [ ] CI status checks pass (8 required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
