### PR TITLE
chore(state): record BL9 feature in build_loop + test-gate counter

### DIFF
--- a/.claude/build-progress.json
+++ b/.claude/build-progress.json
@@ -8,13 +8,14 @@
     "BL5-F9-fastapi-skeleton",
     "BL6-F9-platforms-readonly",
     "BL7-F9-games-readonly",
-    "BL8-F9-jobs-readonly"
+    "BL8-F9-jobs-readonly",
+    "BL9-F9-manifests-readonly"
   ],
-  "features_since_last_test": 1,
-  "features_since_last_health_check": 2,
+  "features_since_last_test": 2,
+  "features_since_last_health_check": 3,
   "test_interval": 2,
   "last_test_session": "2026-05-20",
-  "testing_required": false,
+  "testing_required": true,
   "tester_count": 1,
   "bug_tracker": "github_issues",
   "sessions_completed": 4

--- a/.claude/process-state.json
+++ b/.claude/process-state.json
@@ -1,15 +1,9 @@
 {
   "build_loop": {
-    "feature": "BL9-F9-manifests-readonly",
-    "step": 5,
-    "steps_completed": [
-      "tests_written",
-      "tests_verified_failing",
-      "implemented",
-      "security_audit",
-      "documentation_updated"
-    ],
-    "started_at": "2026-05-20T22:00:23Z"
+    "feature": null,
+    "step": 0,
+    "steps_completed": [],
+    "started_at": null
   },
   "uat_session": {
     "session_id": 4,


### PR DESCRIPTION
## Summary

Post-merge state bump for BL9 (`BL9-F9-manifests-readonly`). Two `.claude/*` files auto-updated by `scripts/process-checklist.sh --complete-step build_loop:feature_recorded` and `scripts/test-gate.sh --record-feature` after the feat commit landed in PR #73 (`d9918ff` → merged).

Tracking on main keeps:
- Build Loop closure visible (6/6 reset to fresh state, ready for next feature)
- Test-gate counter accurate (currently **2/2; UAT-5 required before BL10**)

No code changes. Same pattern as PR #60 (post-BL6), PR #69 (post-BL7), and the BL8 state-bump commit.

## Test plan

- [ ] CI status checks pass (8 required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
