### PR TITLE
fix(migrations): burndown 3 SEV-3 audit findings (#19, #20, #21)

### DIFF
--- a/src/orchestrator/db/migrate.py
+++ b/src/orchestrator/db/migrate.py
@@ -72,8 +72,18 @@ _NETWORK_FSTYPES = frozenset(
     }
 )
 
+# Issue #20: widened to also match CREATE [TEMP|TEMPORARY] TABLE,
+# CREATE VIRTUAL TABLE … USING …, with optional schema-qualified name (main.foo).
+# `_DROP_TABLE_RE` is subtracted so a migration that drops a table no longer
+# leaves a stale expectation in the post-apply sanity check.
 _CREATE_TABLE_RE = re.compile(
-    r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([a-zA-Z_][a-zA-Z0-9_]*)",
+    r"CREATE\s+(?:TEMP(?:ORARY)?\s+|VIRTUAL\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"
+    r"(?:[a-zA-Z_][a-zA-Z0-9_]*\.)?([a-zA-Z_][a-zA-Z0-9_]*)",
+    re.IGNORECASE,
+)
+_DROP_TABLE_RE = re.compile(
+    r"DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?(?:[a-zA-Z_][a-zA-Z0-9_]*\.)?"
+    r"([a-zA-Z_][a-zA-Z0-9_]*)",
     re.IGNORECASE,
 )
 
@@ -303,6 +313,12 @@ def _load_checksum_manifest(source: Path | Traversable) -> dict[int, tuple[str, 
             raise MigrationError(f"CHECKSUMS line {lineno}: non-integer id {id_str!r}") from e
         if not _SHA_RE.match(sha.lower()):
             raise MigrationError(f"CHECKSUMS line {lineno}: invalid sha256 {sha!r}")
+        # Issue #21: validate filename at parse time. Defense-in-depth: a
+        # future refactor that uses the manifest filename for a path join
+        # would otherwise be traversal-vulnerable. _MIGRATION_NAME_RE locks
+        # the form to NNNN_snake_case.sql with no path separators.
+        if not _MIGRATION_NAME_RE.match(fn):
+            raise MigrationError(f"CHECKSUMS line {lineno}: invalid migration filename {fn!r}")
         if mid in result:
             raise MigrationError(f"CHECKSUMS line {lineno}: duplicate id {mid}")
         result[mid] = (sha.lower(), fn)
@@ -371,11 +387,86 @@ def _assert_no_gaps(applied: set[int], available: set[int]) -> None:
 
 
 def _split_sql(script: str) -> list[str]:
-    """Strip comments and split on `;`. Migration SQL must not contain
-    semicolons inside string literals (DDL rarely does)."""
-    stripped = re.sub(r"--[^\n]*", "", script)
-    stripped = re.sub(r"/\*.*?\*/", "", stripped, flags=re.DOTALL)
-    return [s.strip() for s in stripped.split(";") if s.strip()]
+    """Strip comments and split on `;`, honoring string literals.
+
+    Issue #19: prior implementation used global regex strips for `--` line
+    comments and `/* */` block comments, then split on `;`. Migrations that
+    contain a semicolon or comment delimiter INSIDE a string literal would
+    be mis-split mid-statement. This tokenizer walks the script character
+    by character, tracking whether we're inside `'...'`/`"..."` literals
+    (with `''` / `""` doubled-quote escaping per SQL standard) before
+    deciding whether a `;`/`--`/`/*` is structural or literal content.
+    """
+    statements: list[str] = []
+    buf: list[str] = []
+    i = 0
+    n = len(script)
+    in_single = False  # inside '…'
+    in_double = False  # inside "…"
+    while i < n:
+        ch = script[i]
+        nxt = script[i + 1] if i + 1 < n else ""
+
+        if in_single:
+            buf.append(ch)
+            if ch == "'" and nxt == "'":
+                # doubled '' escape; consume the pair as literal content
+                buf.append(nxt)
+                i += 2
+                continue
+            if ch == "'":
+                in_single = False
+            i += 1
+            continue
+        if in_double:
+            buf.append(ch)
+            if ch == '"' and nxt == '"':
+                buf.append(nxt)
+                i += 2
+                continue
+            if ch == '"':
+                in_double = False
+            i += 1
+            continue
+
+        # Not in a string literal — comments and statement separators apply.
+        if ch == "-" and nxt == "-":
+            # line comment: consume until newline
+            while i < n and script[i] != "\n":
+                i += 1
+            continue
+        if ch == "/" and nxt == "*":
+            # block comment: consume until */
+            i += 2
+            while i < n - 1 and not (script[i] == "*" and script[i + 1] == "/"):
+                i += 1
+            i += 2  # past the */ (or end-of-input if unterminated)
+            continue
+        if ch == "'":
+            in_single = True
+            buf.append(ch)
+            i += 1
+            continue
+        if ch == '"':
+            in_double = True
+            buf.append(ch)
+            i += 1
+            continue
+        if ch == ";":
+            stmt = "".join(buf).strip()
+            if stmt:
+                statements.append(stmt)
+            buf = []
+            i += 1
+            continue
+
+        buf.append(ch)
+        i += 1
+
+    tail = "".join(buf).strip()
+    if tail:
+        statements.append(tail)
+    return statements
 
 
 # ---------------------------------------------------------------------------
@@ -392,6 +483,10 @@ def _expected_tables_for(migrations: list[_Migration]) -> set[str]:
         for stmt in _split_sql(mig.sql):
             for name in _CREATE_TABLE_RE.findall(stmt):
                 tables.add(name)
+            # Issue #20: subtract drops so the expected set tracks the
+            # cumulative end-state, not just everything ever created.
+            for name in _DROP_TABLE_RE.findall(stmt):
+                tables.discard(name)
     return tables
 
 

--- a/tests/db/test_migrate.py
+++ b/tests/db/test_migrate.py
@@ -806,3 +806,134 @@ async def test_verify_schema_current_detects_unknown(
         with pytest.raises(SchemaUnknownMigrationError) as exc_info:
             await migrate.verify_schema_current(conn)
         assert exc_info.value.unknown == [1]
+
+
+# ---------------------------------------------------------------------------
+# Issue #19: _split_sql honors string literals
+# ---------------------------------------------------------------------------
+
+
+class TestSplitSqlStringLiteralAware:
+    def test_semicolon_inside_single_quote_literal_not_split(self) -> None:
+        sql = "INSERT INTO t (col) VALUES (';-- oops'); SELECT 1;"
+        result = migrate._split_sql(sql)
+        assert result == ["INSERT INTO t (col) VALUES (';-- oops')", "SELECT 1"]
+
+    def test_semicolon_inside_double_quote_identifier_not_split(self) -> None:
+        sql = 'CREATE TABLE "t;weird" (x INTEGER); SELECT 1;'
+        result = migrate._split_sql(sql)
+        assert result == ['CREATE TABLE "t;weird" (x INTEGER)', "SELECT 1"]
+
+    def test_doubled_single_quote_escape_preserved(self) -> None:
+        # SQL escape: '' inside '...' is a literal single quote.
+        sql = "INSERT INTO t VALUES ('it''s fine'); SELECT 2;"
+        result = migrate._split_sql(sql)
+        assert result == ["INSERT INTO t VALUES ('it''s fine')", "SELECT 2"]
+
+    def test_line_comment_inside_literal_not_stripped(self) -> None:
+        sql = "INSERT INTO t VALUES ('-- not a comment'); SELECT 3;"
+        result = migrate._split_sql(sql)
+        assert result == ["INSERT INTO t VALUES ('-- not a comment')", "SELECT 3"]
+
+    def test_block_comment_inside_literal_not_stripped(self) -> None:
+        sql = "INSERT INTO t VALUES ('text /* not comment */ more'); SELECT 4;"
+        result = migrate._split_sql(sql)
+        assert result == [
+            "INSERT INTO t VALUES ('text /* not comment */ more')",
+            "SELECT 4",
+        ]
+
+    def test_real_line_comment_stripped(self) -> None:
+        sql = "SELECT 1; -- this is a comment\nSELECT 2;"
+        result = migrate._split_sql(sql)
+        assert result == ["SELECT 1", "SELECT 2"]
+
+    def test_real_block_comment_stripped(self) -> None:
+        sql = "SELECT 1; /* block\nmultiline */ SELECT 2;"
+        result = migrate._split_sql(sql)
+        assert result == ["SELECT 1", "SELECT 2"]
+
+    def test_trailing_semicolon_handled(self) -> None:
+        assert migrate._split_sql("SELECT 1;") == ["SELECT 1"]
+        assert migrate._split_sql("SELECT 1") == ["SELECT 1"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #20: _expected_tables_for handles VIRTUAL/TEMP/DROP + schema-qualified
+# ---------------------------------------------------------------------------
+
+
+class TestExpectedTablesParsing:
+    def _mig(self, mid: int, sql: str):
+        return migrate._Migration(mid=mid, name="t", sql=sql, sha="", filename=f"{mid:04d}_t.sql")
+
+    def test_create_virtual_table_detected(self) -> None:
+        mig = self._mig(1, "CREATE VIRTUAL TABLE fts USING fts5(body);")
+        assert "fts" in migrate._expected_tables_for([mig])
+
+    def test_create_temp_table_detected(self) -> None:
+        mig = self._mig(1, "CREATE TEMP TABLE staging (x INT);")
+        assert "staging" in migrate._expected_tables_for([mig])
+
+    def test_create_temporary_table_detected(self) -> None:
+        mig = self._mig(1, "CREATE TEMPORARY TABLE staging (x INT);")
+        assert "staging" in migrate._expected_tables_for([mig])
+
+    def test_schema_qualified_name_picks_table_only(self) -> None:
+        mig = self._mig(1, "CREATE TABLE main.foo (x INT);")
+        tables = migrate._expected_tables_for([mig])
+        assert "foo" in tables
+        assert "main" not in tables
+        assert "main.foo" not in tables
+
+    def test_drop_table_subtracts(self) -> None:
+        mig = self._mig(
+            1,
+            "CREATE TABLE foo (x INT); CREATE TABLE bar (y INT); DROP TABLE foo;",
+        )
+        tables = migrate._expected_tables_for([mig])
+        assert "bar" in tables
+        assert "foo" not in tables
+        assert "schema_migrations" in tables
+
+    def test_drop_table_if_exists_subtracts(self) -> None:
+        mig = self._mig(1, "CREATE TABLE foo (x INT); DROP TABLE IF EXISTS foo;")
+        assert "foo" not in migrate._expected_tables_for([mig])
+
+    def test_create_then_drop_in_separate_migrations(self) -> None:
+        m1 = self._mig(1, "CREATE TABLE foo (x INT);")
+        m2 = self._mig(2, "DROP TABLE foo;")
+        assert "foo" not in migrate._expected_tables_for([m1, m2])
+
+
+# ---------------------------------------------------------------------------
+# Issue #21: CHECKSUMS filename validated at parse time
+# ---------------------------------------------------------------------------
+
+
+class TestChecksumFilenameValidation:
+    def test_path_traversal_filename_rejected(self, migs_dir, db_path) -> None:
+        _write_migration(migs_dir, 1, "initial", _VALID_FIRST_MIG)
+        sha = _sha256(_VALID_FIRST_MIG)
+        (migs_dir / "CHECKSUMS").write_text(f"1 {sha} ../../etc/passwd\n", encoding="utf-8")
+        with pytest.raises(migrate.MigrationError, match=r"invalid migration filename"):
+            migrate.run_migrations(db_path, migrations_dir=migs_dir)
+
+    def test_reserved_filename_rejected(self, migs_dir, db_path) -> None:
+        _write_migration(migs_dir, 1, "initial", _VALID_FIRST_MIG)
+        sha = _sha256(_VALID_FIRST_MIG)
+        (migs_dir / "CHECKSUMS").write_text(f"1 {sha} CHECKSUMS\n", encoding="utf-8")
+        with pytest.raises(migrate.MigrationError, match=r"invalid migration filename"):
+            migrate.run_migrations(db_path, migrations_dir=migs_dir)
+
+    def test_init_py_filename_rejected(self, migs_dir, db_path) -> None:
+        _write_migration(migs_dir, 1, "initial", _VALID_FIRST_MIG)
+        sha = _sha256(_VALID_FIRST_MIG)
+        (migs_dir / "CHECKSUMS").write_text(f"1 {sha} __init__.py\n", encoding="utf-8")
+        with pytest.raises(migrate.MigrationError, match=r"invalid migration filename"):
+            migrate.run_migrations(db_path, migrations_dir=migs_dir)
+
+    def test_valid_filename_accepted(self, migs_dir, db_path) -> None:
+        _write_migration(migs_dir, 1, "initial", _VALID_FIRST_MIG)
+        _write_checksums(migs_dir, [(1, _sha256(_VALID_FIRST_MIG), "0001_initial.sql")])
+        migrate.run_migrations(db_path, migrations_dir=migs_dir)


### PR DESCRIPTION
## Summary

Burndown of 3 SEV-3 audit findings clustered in `src/orchestrator/db/migrate.py`. Closes #19, #20, #21.

## Fixes

| Issue | Fix |
|---|---|
| **#19** statement splitter mis-handles `;`/comments in string literals | `_split_sql` now character-by-character tokenizes, honoring `'…'` / `"…"` literals with SQL-standard doubled-quote escaping |
| **#20** `_CREATE_TABLE_RE` misses TEMP/VIRTUAL; stale on DROP | regex widened to match `CREATE [TEMP|TEMPORARY|VIRTUAL] TABLE`, added `_DROP_TABLE_RE` to subtract dropped tables from the expected-tables set, also handles schema-qualified names (`main.foo`) |
| **#21** CHECKSUMS parser accepts path separators / reserved filenames | filename validated at parse time against `_MIGRATION_NAME_RE` — rejects `../../etc/passwd`, `CHECKSUMS`, `__init__.py`, etc. |

## Verification

- 594 tests pass (+19 new, baseline was 575)
- ruff check + ruff format / mypy --strict / gitleaks all clean
- 3 new test classes (`TestSplitSqlStringLiteralAware`, `TestExpectedTablesParsing`, `TestChecksumFilenameValidation`)

## Test plan

- [ ] CI status checks pass (8 required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
