### PR TITLE
fix(db-pool): burndown 3 issues — disk metrics + query timing + coverage (#40, #41, #42)

### DIFF
--- a/src/orchestrator/core/settings.py
+++ b/src/orchestrator/core/settings.py
@@ -84,6 +84,14 @@ class Settings(BaseSettings):
     db_cache_size_kib: int = Field(default=16384, ge=1024, le=1048576)
     db_mmap_size_bytes: int = Field(default=268_435_456, ge=0, le=17_179_869_184)
     db_journal_size_limit_bytes: int = Field(default=67_108_864, ge=1_048_576, le=1_073_741_824)
+    # Issue #40: low-free-space threshold for the DB-volume health check. When
+    # `free_pct` drops below this, health_check surfaces `low_space=True` and
+    # the pool emits a rate-limited `pool.disk_low` WARNING.
+    pool_disk_low_pct: float = Field(default=10.0, gt=0.0, le=100.0)
+    # Issue #41: emit `pool.query_completed` at DEBUG after each successful
+    # read/write helper call (with template-only SQL + param shape, never raw
+    # values). Opt-in to avoid log volume at INFO/WARN deployments.
+    pool_query_log_completed: bool = Field(default=False)
 
     @field_validator("cors_origins")
     @classmethod

--- a/src/orchestrator/db/pool.py
+++ b/src/orchestrator/db/pool.py
@@ -15,19 +15,18 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import re
+import shutil
 import time
 from collections.abc import AsyncIterator, Generator, Iterable, Mapping, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import fields, is_dataclass
-from typing import TYPE_CHECKING, Any, Literal, TypeVar
+from pathlib import Path
+from typing import Any, Literal, TypeVar
 
 import aiosqlite
 import structlog
 
 from orchestrator.core.settings import get_settings
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 T = TypeVar("T")
 
@@ -589,6 +588,16 @@ class Pool:
         self._total_writes = 0
         self._total_reads = 0
 
+        # Issue #40: disk-low rate-limiter — emit the warning at most once
+        # per 60s to avoid log flooding when the volume sits below threshold.
+        self._last_disk_low_warn_monotonic: float = 0.0
+
+        # Issue #41: query-completed logging is opt-in via Settings.
+        # Cached at construction so we don't re-read on every query.
+        settings = get_settings()
+        self._log_query_completed: bool = settings.pool_query_log_completed
+        self._disk_low_pct: float = settings.pool_disk_low_pct
+
         # Background fire-and-forget tasks (replacement, safe-close).
         # Held to prevent GC; cleaned up via add_done_callback.
         self._bg_tasks: set[asyncio.Task[Any]] = set()
@@ -906,9 +915,32 @@ class Pool:
 
     # --- Single-statement helpers -------------------------------------
 
+    def _emit_query_completed(
+        self,
+        *,
+        role: str,
+        sql: str,
+        params: Any,
+        t0: float,
+    ) -> None:
+        """Issue #41: emit `pool.query_completed` at DEBUG with timing and
+        scrubbed metadata. No-op unless `Settings.pool_query_log_completed`
+        is True (opt-in to avoid log volume at INFO/WARN deployments)."""
+        if not self._log_query_completed:
+            return
+        duration_ms = (time.perf_counter() - t0) * 1000
+        _log.debug(
+            "pool.query_completed",
+            role=role,
+            sql=_template_only(sql),
+            params=_shape(params),
+            duration_ms=duration_ms,
+        )
+
     async def read_one(
         self, sql: str, params: Sequence[Any] | Mapping[str, Any] = ()
     ) -> dict[str, Any] | None:
+        t0 = time.perf_counter()
         async with self._checkout_reader() as conn:
             try:
                 cur = await conn.execute(sql, params)
@@ -917,6 +949,7 @@ class Pool:
                 finally:
                     await cur.close()
                 self._total_reads += 1
+                self._emit_query_completed(role="reader", sql=sql, params=params, t0=t0)
                 return _row_to_dict(row)
             except aiosqlite.Error as e:
                 raise _wrap_aiosqlite_error(e, sql=sql, params=params, role="reader") from e
@@ -924,6 +957,7 @@ class Pool:
     async def read_all(
         self, sql: str, params: Sequence[Any] | Mapping[str, Any] = ()
     ) -> list[dict[str, Any]]:
+        t0 = time.perf_counter()
         async with self._checkout_reader() as conn:
             try:
                 cur = await conn.execute(sql, params)
@@ -932,6 +966,7 @@ class Pool:
                 finally:
                     await cur.close()
                 self._total_reads += 1
+                self._emit_query_completed(role="reader", sql=sql, params=params, t0=t0)
                 return [r for r in (_row_to_dict(row) for row in rows) if r is not None]
             except aiosqlite.Error as e:
                 raise _wrap_aiosqlite_error(e, sql=sql, params=params, role="reader") from e
@@ -940,6 +975,7 @@ class Pool:
         self, cls: type[T], sql: str, params: Sequence[Any] | Mapping[str, Any] = ()
     ) -> T | None:
         _check_is_dataclass(cls)
+        t0 = time.perf_counter()
         async with self._checkout_reader() as conn:
             try:
                 cur = await conn.execute(sql, params)
@@ -948,6 +984,7 @@ class Pool:
                 finally:
                     await cur.close()
                 self._total_reads += 1
+                self._emit_query_completed(role="reader", sql=sql, params=params, t0=t0)
                 return _row_to_dataclass(cls, row)
             except aiosqlite.Error as e:
                 raise _wrap_aiosqlite_error(e, sql=sql, params=params, role="reader") from e
@@ -956,6 +993,7 @@ class Pool:
         self, cls: type[T], sql: str, params: Sequence[Any] | Mapping[str, Any] = ()
     ) -> list[T]:
         _check_is_dataclass(cls)
+        t0 = time.perf_counter()
         async with self._checkout_reader() as conn:
             try:
                 cur = await conn.execute(sql, params)
@@ -964,6 +1002,7 @@ class Pool:
                 finally:
                     await cur.close()
                 self._total_reads += 1
+                self._emit_query_completed(role="reader", sql=sql, params=params, t0=t0)
                 return [
                     obj for obj in (_row_to_dataclass(cls, row) for row in rows) if obj is not None
                 ]
@@ -971,6 +1010,7 @@ class Pool:
                 raise _wrap_aiosqlite_error(e, sql=sql, params=params, role="reader") from e
 
     async def execute_write(self, sql: str, params: Sequence[Any] | Mapping[str, Any] = ()) -> int:
+        t0 = time.perf_counter()
         async with self._checkout_writer() as conn:
             try:
                 cur = await conn.execute(sql, params)
@@ -980,6 +1020,7 @@ class Pool:
                     await cur.close()
                 await conn.commit()
                 self._total_writes += 1
+                self._emit_query_completed(role="writer", sql=sql, params=params, t0=t0)
                 return rowcount
             except aiosqlite.Error as e:
                 # Best-effort rollback; ignore if there's no active txn.
@@ -992,6 +1033,7 @@ class Pool:
         sql: str,
         params_seq: Iterable[Sequence[Any] | Mapping[str, Any]],
     ) -> int:
+        t0 = time.perf_counter()
         async with self._checkout_writer() as conn:
             try:
                 cur = await conn.executemany(sql, params_seq)
@@ -1001,6 +1043,7 @@ class Pool:
                     await cur.close()
                 await conn.commit()
                 self._total_writes += 1
+                self._emit_query_completed(role="writer", sql=sql, params="<many>", t0=t0)
                 return rowcount
             except aiosqlite.Error as e:
                 with contextlib.suppress(Exception):
@@ -1113,6 +1156,59 @@ class Pool:
                 "replacements": self._replacement_count["reader"],
             },
             "uptime_sec": int(time.monotonic() - self._created_monotonic),
+            # Issue #40: disk metrics for the DB volume so operators can see
+            # the root cause of disk-i/o-error storms before the volume fills.
+            "disk": self._check_disk(),
+        }
+
+    def _check_disk(self) -> dict[str, Any]:
+        """Return disk-space metrics for the DB volume.
+
+        Issue #40: `shutil.disk_usage` is stdlib, doesn't fault on missing
+        paths (we walk up parents to find an existing dir), and is cheap
+        enough to call per health probe. On any unexpected error we return
+        a minimal `{path, error}` shape so the rest of health_check still
+        works — operators see an explicit failure mode rather than a 500.
+        """
+        target = Path(self._database_path).parent
+        # Walk parents until one exists (database dir might not be created yet
+        # on first boot; shutil.disk_usage raises FileNotFoundError otherwise).
+        probe_path = target
+        while not probe_path.exists() and probe_path != probe_path.parent:
+            probe_path = probe_path.parent
+
+        try:
+            usage = shutil.disk_usage(str(probe_path))
+        except OSError as e:  # /proc weirdness, permission denied, etc.
+            return {
+                "path": str(target),
+                "error": f"{type(e).__name__}: {e}",
+                "low_space": False,
+            }
+
+        free_pct = (usage.free / usage.total * 100.0) if usage.total > 0 else 0.0
+        low_space = free_pct < self._disk_low_pct
+
+        # Rate-limit the warning to one per 60s. The metric itself is always
+        # returned; only the structured log event is suppressed in-between.
+        if low_space:
+            now = time.monotonic()
+            if now - self._last_disk_low_warn_monotonic >= 60.0:
+                _log.warning(
+                    "pool.disk_low",
+                    path=str(probe_path),
+                    free_bytes=usage.free,
+                    free_pct=round(free_pct, 2),
+                    threshold_pct=self._disk_low_pct,
+                )
+                self._last_disk_low_warn_monotonic = now
+
+        return {
+            "path": str(probe_path),
+            "total_bytes": usage.total,
+            "free_bytes": usage.free,
+            "free_pct": round(free_pct, 2),
+            "low_space": low_space,
         }
 
     async def schema_status(self) -> dict[str, Any]:

--- a/tests/db/test_pool.py
+++ b/tests/db/test_pool.py
@@ -686,3 +686,249 @@ class TestModuleSingleton:
         await close_pool()
         with pytest.raises(PoolNotInitializedError):
             get_pool()
+
+
+# ----------------------------------------------------------------------
+# Issue #40: disk-space metrics in health_check
+# ----------------------------------------------------------------------
+
+
+class TestHealthCheckDiskMetrics:
+    async def test_disk_block_present_and_shape(self, db_path: Path) -> None:
+        async with Pool.create(database_path=db_path, readers_count=2) as pool:
+            health = await pool.health_check()
+        assert "disk" in health
+        disk = health["disk"]
+        assert set(disk.keys()) == {
+            "path",
+            "total_bytes",
+            "free_bytes",
+            "free_pct",
+            "low_space",
+        }
+        assert disk["total_bytes"] > 0
+        assert disk["free_bytes"] >= 0
+        assert 0.0 <= disk["free_pct"] <= 100.0
+
+    async def test_low_space_false_on_real_disk(self, db_path: Path) -> None:
+        async with Pool.create(database_path=db_path, readers_count=2) as pool:
+            health = await pool.health_check()
+        # No realistic test runner is on a <10% disk; if this fails the runner
+        # actually has low disk and that's the only correct answer.
+        if shutil_disk_usage_free_pct() >= 10.0:
+            assert health["disk"]["low_space"] is False
+
+    async def test_low_space_triggered_by_low_threshold(self, db_path: Path, monkeypatch) -> None:
+        """Force the threshold above the current free_pct to trigger the path."""
+        from orchestrator.core.settings import get_settings
+
+        monkeypatch.setenv("ORCH_DISK_LOW_PCT_OVERRIDE_TEST", "1")  # unused; just ensures clean env
+        get_settings.cache_clear()
+
+        async with Pool.create(database_path=db_path, readers_count=2) as pool:
+            # Override the cached threshold to force low_space=True
+            pool._disk_low_pct = 99.99
+            pool._last_disk_low_warn_monotonic = 0.0  # reset rate-limit
+            health = await pool.health_check()
+        assert health["disk"]["low_space"] is True
+
+    async def test_disk_check_handles_oserror_gracefully(self, db_path: Path, monkeypatch) -> None:
+        """If shutil.disk_usage raises, health_check returns a sentinel."""
+
+        from orchestrator.db import pool as pool_mod
+
+        def _raise_oserror(_path: str):
+            raise PermissionError("simulated /proc unreadable")
+
+        async with Pool.create(database_path=db_path, readers_count=2) as pool:
+            monkeypatch.setattr(pool_mod.shutil, "disk_usage", _raise_oserror)
+            health = await pool.health_check()
+        disk = health["disk"]
+        assert disk["low_space"] is False  # don't false-alarm when probe failed
+        assert "error" in disk
+        assert "PermissionError" in disk["error"]
+
+    async def test_disk_check_walks_up_to_existing_parent(
+        self, db_path: Path, tmp_path: Path
+    ) -> None:
+        """db_path may not exist on first boot; probe walks up parents."""
+        async with Pool.create(database_path=db_path, readers_count=2) as pool:
+            # Force the database_path to a deep nonexistent path
+            nonexistent_dir = tmp_path / "does" / "not" / "exist"
+            pool._database_path = nonexistent_dir / "orch.db"
+            disk = pool._check_disk()
+        assert "error" not in disk
+        assert disk["total_bytes"] > 0
+
+
+def shutil_disk_usage_free_pct() -> float:
+    import shutil
+
+    u = shutil.disk_usage(".")
+    return u.free / u.total * 100.0 if u.total > 0 else 0.0
+
+
+# ----------------------------------------------------------------------
+# Issue #41: pool.query_completed logging is opt-in
+# ----------------------------------------------------------------------
+
+
+class TestPoolQueryCompletedLogging:
+    async def test_default_off_emits_no_event(self, db_path: Path, monkeypatch, capsys) -> None:
+        from orchestrator.core.logging import configure_logging
+
+        monkeypatch.delenv("ORCH_POOL_QUERY_LOG_COMPLETED", raising=False)
+        from orchestrator.core.settings import get_settings
+
+        get_settings.cache_clear()
+        configure_logging()
+        async with Pool.create(database_path=db_path, readers_count=2) as pool:
+            await pool.read_one("SELECT 1 AS x")
+        out = capsys.readouterr().out
+        # The event must NOT appear when the flag is off
+        assert "pool.query_completed" not in out
+
+    async def test_opt_in_emits_query_completed_event(self, db_path: Path, monkeypatch) -> None:
+        """When the Settings flag is on, every successful read/write helper
+        calls `_emit_query_completed`. Verify by spying on `_log.debug`
+        directly — capsys interaction with structlog level config is
+        brittle in suite ordering."""
+        from orchestrator.core.settings import get_settings
+        from orchestrator.db import pool as pool_mod
+
+        monkeypatch.setenv("ORCH_POOL_QUERY_LOG_COMPLETED", "1")
+        get_settings.cache_clear()
+        assert get_settings().pool_query_log_completed is True
+
+        events: list[tuple[str, dict]] = []
+
+        def _spy(event: str, **kwargs: Any) -> None:
+            events.append((event, kwargs))
+
+        monkeypatch.setattr(pool_mod._log, "debug", _spy)
+
+        async with Pool.create(database_path=db_path, readers_count=2) as pool:
+            assert pool._log_query_completed is True
+            await pool.read_one("SELECT 1 AS x")
+            await pool.execute_write("CREATE TABLE foo (x INT)")
+
+        completed = [(e, kw) for e, kw in events if e == "pool.query_completed"]
+        assert len(completed) >= 2
+        roles = {kw["role"] for _, kw in completed}
+        assert {"reader", "writer"}.issubset(roles)
+        for _, kw in completed:
+            assert "duration_ms" in kw
+            assert "sql" in kw
+            assert "params" in kw
+
+        get_settings.cache_clear()
+
+
+# ----------------------------------------------------------------------
+# Issue #42: branch-coverage push on pool.py
+# ----------------------------------------------------------------------
+
+
+class TestBranchCoverageGaps:
+    """Targeted tests for branches the existing suite didn't exercise."""
+
+    async def test_wrap_aiosqlite_error_catchall(self) -> None:
+        """Branch: _wrap_aiosqlite_error's PoolError catch-all (unrecognized
+        aiosqlite.Error subclass) must return a wrapped PoolError, not bubble."""
+        import aiosqlite
+
+        from orchestrator.db.pool import PoolError, _wrap_aiosqlite_error
+
+        class _CustomAioErr(aiosqlite.Error):
+            pass
+
+        wrapped = _wrap_aiosqlite_error(
+            _CustomAioErr("custom failure"),
+            sql="SELECT 1",
+            params=(),
+            role="reader",
+        )
+        assert isinstance(wrapped, PoolError)
+
+    async def test_writer_unreachable_error_carries_message(self) -> None:
+        from orchestrator.db.pool import WriterUnreachableError
+
+        e = WriterUnreachableError("writer probe timeout")
+        assert "writer probe timeout" in str(e)
+        assert e.reason == "writer probe timeout"
+
+    async def test_reader_unreachable_error_carries_index_and_reason(self) -> None:
+        from orchestrator.db.pool import ReaderUnreachableError
+
+        e = ReaderUnreachableError(2, "reader probe timeout")
+        assert "reader[2]" in str(e)
+        assert e.reader_index == 2
+        assert e.reason == "reader probe timeout"
+
+    async def test_pragma_value_matches_numeric_tolerance(self) -> None:
+        """Branch: _pragma_value_matches accepts numeric equivalence."""
+        from orchestrator.db.pool import _pragma_value_matches
+
+        # int vs str-repr of int should match (real callers compare 1 vs "1")
+        assert _pragma_value_matches("foreign_keys", 1, 1) is True
+        assert _pragma_value_matches("foreign_keys", 1, "1") is True
+
+    async def test_classify_integrity_error_message_fallback(self) -> None:
+        """Branch: when aiosqlite has no sqlite_errorcode, fall back to msg match."""
+        import aiosqlite
+
+        from orchestrator.db.pool import _classify_integrity_error
+
+        # Force a stub error without sqlite_errorcode
+        e = aiosqlite.IntegrityError("UNIQUE constraint failed: foo.id")
+        # _classify returns (kind, table, column) — message match fallback path
+        kind, _table, _column = _classify_integrity_error(e)
+        assert kind in ("unique", "fk", "check", "notnull", "other")
+
+    async def test_close_pool_when_already_closed(self, db_path: Path) -> None:
+        """Branch: close_pool called twice — second call is a no-op."""
+        import os
+
+        from orchestrator.core.settings import get_settings
+        from orchestrator.db.pool import init_pool
+
+        os.environ["ORCH_DATABASE_PATH"] = str(db_path)
+        get_settings.cache_clear()
+        # Apply migrations first (init_pool verifies schema)
+        from orchestrator.db.migrate import run_migrations
+
+        run_migrations(db_path)
+        await init_pool()
+        await close_pool()
+        # Second call should not raise
+        await close_pool()
+
+    async def test_check_is_dataclass_rejects_non_dataclass(self) -> None:
+        from orchestrator.db.pool import _check_is_dataclass
+
+        with pytest.raises(TypeError, match=r"not a dataclass|dataclass"):
+            _check_is_dataclass(dict)
+
+    async def test_row_to_dict_handles_none(self) -> None:
+        from orchestrator.db.pool import _row_to_dict
+
+        assert _row_to_dict(None) is None
+
+    async def test_row_to_dataclass_handles_none(self) -> None:
+        from orchestrator.db.pool import _row_to_dataclass
+
+        @dataclass
+        class _Foo:
+            x: int
+
+        assert _row_to_dataclass(_Foo, None) is None
+
+    async def test_is_disk_io_error_recognizes_message(self) -> None:
+        # Real path: aiosqlite raises OperationalError with this message
+        import aiosqlite
+
+        from orchestrator.db.pool import _is_disk_io_error
+
+        assert _is_disk_io_error(aiosqlite.OperationalError("disk I/O error")) is True
+        # Unrelated error
+        assert _is_disk_io_error(ValueError("nope")) is False


### PR DESCRIPTION
## Summary

Burndown of 3 db-pool issues filed at BL4 close. Closes #40, #41, #42.

## Fixes

| Issue | Sev | Fix |
|---|---|---|
| **#40** disk-space metrics missing from health_check | SEV-3 | `_check_disk()` adds `{path, total_bytes, free_bytes, free_pct, low_space}` to the health response; `pool.disk_low` WARNING fires when free_pct drops below `Settings.pool_disk_low_pct` (default 10%), rate-limited to once per 60s |
| **#41** no `pool.query_completed` event for slow-query analysis | SEV-4 | `_emit_query_completed()` called from 6 top-level helpers; emits role/template-SQL/param-shape/duration_ms at DEBUG. Opt-in via `Settings.pool_query_log_completed` (default False) |
| **#42** branch coverage on pool.py | SEV-4 | 10 targeted tests covering the previously-uncovered branches: error catch-all, error class construction, pragma numeric tolerance, integrity classification fallback, close-after-close, dataclass rejection, None-row handling, disk-i/o-error recognition |

## Settings additions

```python
pool_disk_low_pct: float = 10.0   # gt 0, le 100
pool_query_log_completed: bool = False
```

Both are env-driven via the standard `ORCH_*` prefix.

## Verification

- 592 tests pass (+17 new)
- ruff check + ruff format / mypy --strict / gitleaks all clean

## Test plan

- [ ] CI status checks pass (8 required)
- [ ] Manual smoke: `health` endpoint response (after BL5+ wiring) includes a `disk` block
- [ ] `ORCH_POOL_QUERY_LOG_COMPLETED=1 ORCH_LOG_LEVEL=DEBUG` → see `pool.query_completed` events in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
