### PR TITLE
chore(state): record BL10 feature in build_loop + test-gate counter

### DIFF
--- a/.claude/build-progress.json
+++ b/.claude/build-progress.json
@@ -9,10 +9,11 @@
     "BL6-F9-platforms-readonly",
     "BL7-F9-games-readonly",
     "BL8-F9-jobs-readonly",
-    "BL9-F9-manifests-readonly"
+    "BL9-F9-manifests-readonly",
+    "BL10-F1-steam-auth-substrate"
   ],
-  "features_since_last_test": 0,
-  "features_since_last_health_check": 3,
+  "features_since_last_test": 1,
+  "features_since_last_health_check": 4,
   "test_interval": 2,
   "last_test_session": "2026-05-20",
   "testing_required": false,

--- a/.claude/process-state.json
+++ b/.claude/process-state.json
@@ -1,15 +1,9 @@
 {
   "build_loop": {
-    "feature": "BL10-F1-steam-auth-substrate",
-    "step": 5,
-    "steps_completed": [
-      "tests_written",
-      "tests_verified_failing",
-      "implemented",
-      "security_audit",
-      "documentation_updated"
-    ],
-    "started_at": "2026-05-24T23:20:21Z"
+    "feature": null,
+    "step": 0,
+    "steps_completed": [],
+    "started_at": null
   },
   "uat_session": {
     "session_id": 5,


### PR DESCRIPTION
## Summary

Post-merge state bump for BL10 (`BL10-F1-steam-auth-substrate`). Two `.claude/*` files auto-updated by `scripts/process-checklist.sh --complete-step build_loop:feature_recorded` and `scripts/test-gate.sh --record-feature` after the feat commit landed in PR #92 (`31839ab` merged).

Tracking on main keeps:
- Build Loop closure visible (6/6 reset to fresh state, ready for next feature)
- Test-gate counter accurate (currently 1/2; **one more feature triggers UAT-6**)

No code changes. Same pattern as PR #60 (post-BL6), PR #69 (post-BL7), PR #74 (post-BL9).

## Test plan

- [ ] CI status checks pass (8 required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)