### PR TITLE
fix(api): Phase-3 hardening sweep (#51, #52, #84, #87)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ The bearer token (`orchestrator_token`) is the only required field. Every other 
 
 Full descriptions, validators, and design rationale: [`FEATURES.md` — Feature 3](FEATURES.md). Sensitive values (the bearer token specifically) are redacted across all serialization paths (`repr`, `model_dump`, `model_dump(mode="json")`, JSON schema) and pickling is explicitly blocked — see ADR-0010 §D4 for the three-layer redaction defense.
 
+### CORS for browser clients
+
+`ORCH_CORS_ORIGINS` defaults to `[]` (no origins allowed). This is correct for production deployments where the API is consumed only by server-side clients (Game_shelf backend proxy, CLI, scripts) — the bearer auth + loopback enforcement provide the security boundary.
+
+**If a browser client must call the API directly** (e.g., a Game_shelf frontend issuing fetch requests from a non-same-origin page), the deployment MUST set `ORCH_CORS_ORIGINS` to a JSON list of the consuming origins:
+
+```bash
+# Single origin
+ORCH_CORS_ORIGINS='["https://game-shelf.lan"]'
+
+# Multiple origins
+ORCH_CORS_ORIGINS='["https://game-shelf.lan","http://localhost:3000"]'
+```
+
+Without an entry in this list, browser preflight (`OPTIONS`) requests will return `400 Disallowed CORS origin` from Starlette's CORS middleware — by design — and the browser will fail the actual request. This is not a bug in the API; it's the default-deny posture.
+
+The `"*"` wildcard is **accepted but warned** at boot (`config.cors_wildcard` log event) — it disables CORS as a control entirely; only use in development.
+
 ### Production secret handling
 
 The bearer token should be deployed as a **Docker secret** mounted at `/run/secrets/orchestrator_token`, not as an env var. The settings module also supports `ORCH_TOKEN` as an env var for development; if both are set in production, a `config.secret_shadowed_by_env` warning is logged so you can diagnose.

--- a/src/orchestrator/api/_query_helpers.py
+++ b/src/orchestrator/api/_query_helpers.py
@@ -242,12 +242,26 @@ class FilterAllowList:
         object.__setattr__(self, "by_field", dict(by_field))
 
 
+# Issue #87.P5: strict integer literal (digits with optional leading minus
+# only). Rejects `+1`, `1_000`, `0x10`, `0o10`, etc. — Python's `int()` is
+# lenient and accepts forms that no operator would actually type, blurring
+# the wire contract and turning malformed input into "valid" parsed values.
+_STRICT_INT_RE = re.compile(r"^-?\d+$")
+
+
 def _coerce_value(raw: str, value_type: ValueTypeSpec, field_name: str, op: str) -> Any:
     """Coerce a string query-param value to the spec'd Python type, then
     apply per-type validation (UAT-4 S2-D int range, S3-a timestamp format).
+
+    Issue #87.P5: integer parsing uses a strict regex (digits with optional
+    leading minus) before `int()`; Python's parser accepts `+1`, `1_000`,
+    and similar non-canonical forms that should never appear in a wire
+    contract.
     """
     try:
         if value_type is int:
+            if not _STRICT_INT_RE.match(raw):
+                raise ValueError(f"invalid integer literal: {raw!r} (expected ^-?\\d+$)")
             coerced = int(raw)
             if not (INT64_MIN <= coerced <= INT64_MAX):
                 raise ValueError(f"value out of range (signed 64-bit): {coerced}")

--- a/src/orchestrator/api/main.py
+++ b/src/orchestrator/api/main.py
@@ -201,11 +201,23 @@ def create_app() -> FastAPI:
     # OpenAPI security scheme — middleware does the actual enforcement.
     # This block surfaces the bearer scheme in /api/v1/openapi.json so
     # Swagger UI's Authorize button works.
+    # Issue #52: operator-facing description for the bearer scheme so
+    # Swagger UI's Authorize dialog explains where to get the token and
+    # the rotation pointer. Full rotation procedure lives in HANDOFF.md.
     _security_schemes: dict[str, Any] = {
         "bearerAuth": {
             "type": "http",
             "scheme": "bearer",
             "bearerFormat": "opaque",
+            "description": (
+                "API bearer token. Production: deploy as a Docker secret "
+                "mounted at `/run/secrets/orchestrator_token` (32+ ASCII "
+                "chars, whitespace stripped). Development: pass via "
+                "`ORCH_TOKEN` env var. Sent as `Authorization: Bearer "
+                "<token>`. Rotation: see HANDOFF.md (Phase 4). TL;DR — "
+                "generate with `openssl rand -hex 32`, update the Docker "
+                "secret, restart this service AND the Game_shelf consumer."
+            ),
         }
     }
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -231,7 +231,9 @@ async def jobs_pool_seeded(populated_pool):  # noqa: F811
 
 @pytest_asyncio.fixture
 async def manifests_pool_seeded(populated_pool):  # noqa: F811
-    """populated_pool seeded with ~21 manifests across the 5 baseline games.
+    """populated_pool seeded with 21 ADDITIONAL manifests across 5 baseline
+    games. Total manifest count visible to tests: **24** (21 here + 3 from
+    populated_pool, one each for game_id 1/2/3 with version='1.0').
 
     Mix designed for BL9 filter+sort+pagination+include tests:
     - 5 games (ids 1-5) each get 3-5 manifests (history)

--- a/tests/api/test_middleware_body_size_cap.py
+++ b/tests/api/test_middleware_body_size_cap.py
@@ -131,3 +131,140 @@ class TestBodySizeCapLogging:
         events = [json.loads(line) for line in out.splitlines() if line.strip()]
         names = [e.get("event") for e in events]
         assert "api.body_size_cap_exceeded" in names
+
+
+# Issue #51: Hypothesis property tests for BodySizeCapMiddleware streaming
+# path edge cases. Drives the middleware via synthetic ASGI scopes so we
+# can control exact chunk timing — httpx-driven tests can't reliably
+# reproduce "single mega-chunk" vs "many tiny chunks" patterns.
+
+import pytest  # noqa: E402
+from hypothesis import HealthCheck, given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+_CAP_FOR_PROPERTY = 32 * 1024
+
+
+def _make_drive_pair(chunks: list[bytes]):
+    """Build a (receive, send, response_status_holder) trio that feeds
+    `chunks` to the middleware one at a time."""
+    queue: list[tuple[bytes, bool]] = [
+        (chunk, i < len(chunks) - 1) for i, chunk in enumerate(chunks)
+    ]
+    status_holder: dict[str, int] = {}
+
+    async def _receive() -> dict:
+        if not queue:
+            return {"type": "http.request", "body": b"", "more_body": False}
+        body, more = queue.pop(0)
+        return {"type": "http.request", "body": body, "more_body": more}
+
+    async def _send(msg: dict) -> None:
+        if msg["type"] == "http.response.start":
+            status_holder["status"] = msg["status"]
+
+    return _receive, _send, status_holder
+
+
+async def _drive(chunks: list[bytes], cap: int) -> dict[str, int]:
+    """Construct a BodySizeCapMiddleware with a real body-reading
+    downstream, drive it through `chunks`, return the captured response
+    status.
+
+    The downstream does NOT catch `_BodyTooLargeError` — the middleware
+    needs to see it propagate to send 413. (Production downstreams in
+    FastAPI/Starlette also let it propagate.)"""
+    from orchestrator.api.middleware import BodySizeCapMiddleware
+
+    receive, send, status = _make_drive_pair(chunks)
+
+    async def _downstream(scope, recv, snd):
+        # Read the body fully — _BodyTooLargeError propagates to middleware
+        # for the 413 path; normal completion gets a 200.
+        while True:
+            msg = await recv()
+            if msg["type"] == "http.request" and not msg.get("more_body", False):
+                break
+        await snd({"type": "http.response.start", "status": 200, "headers": []})
+        await snd({"type": "http.response.body", "body": b""})
+
+    mw = BodySizeCapMiddleware(_downstream, cap=cap)
+    scope = {"type": "http", "method": "POST", "path": "/x", "headers": []}
+    await mw(scope, receive, send)
+    return status
+
+
+@settings(
+    max_examples=40,
+    deadline=2000,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    chunk_sizes=st.lists(
+        st.integers(min_value=1, max_value=_CAP_FOR_PROPERTY),
+        min_size=1,
+        max_size=20,
+    )
+)
+async def test_under_cap_streaming_passes_property(chunk_sizes):
+    """Property: any chunking pattern whose TOTAL ≤ cap reaches the
+    downstream app (no 413, status=200)."""
+    # Constrain total to be under the cap
+    total = sum(chunk_sizes)
+    if total > _CAP_FOR_PROPERTY:
+        ratio = (_CAP_FOR_PROPERTY - 1) / total
+        chunk_sizes = [max(1, int(c * ratio)) for c in chunk_sizes]
+
+    chunks = [b"x" * sz for sz in chunk_sizes]
+    status = await _drive(chunks, _CAP_FOR_PROPERTY)
+    assert status.get("status") == 200, (
+        f"under-cap chunks={chunk_sizes} (total={sum(chunk_sizes)}) should pass, got {status}"
+    )
+
+
+@settings(
+    max_examples=40,
+    deadline=2000,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    chunk_sizes=st.lists(
+        st.integers(min_value=1024, max_value=8 * 1024),
+        min_size=5,
+        max_size=20,
+    )
+)
+async def test_over_cap_streaming_blocked_property(chunk_sizes):
+    """Property: chunking patterns whose TOTAL > cap get blocked (413
+    or no response — never 200)."""
+    total = sum(chunk_sizes)
+    if total <= _CAP_FOR_PROPERTY:
+        deficit = _CAP_FOR_PROPERTY - total + 1
+        chunk_sizes = [*chunk_sizes, deficit]
+
+    chunks = [b"x" * sz for sz in chunk_sizes]
+    status = await _drive(chunks, _CAP_FOR_PROPERTY)
+    assert status.get("status") in (413, None), (
+        f"over-cap chunks={chunk_sizes} (total={sum(chunk_sizes)}) "
+        f"should 413 or close, got {status}"
+    )
+
+
+class TestBodySizeCapExactBoundary:
+    """Non-property boundary tests for exact-cap and cap+1."""
+
+    @pytest.mark.parametrize("chunk_size", [1, 8, 128, 1024])
+    async def test_exact_cap_various_chunk_sizes_pass(self, chunk_size):
+        cap = 4096
+        n_chunks, remainder = divmod(cap, chunk_size)
+        chunks = [b"x" * chunk_size] * n_chunks
+        if remainder:
+            chunks.append(b"x" * remainder)
+        status = await _drive(chunks, cap)
+        assert status.get("status") == 200
+
+    async def test_cap_plus_one_blocked(self):
+        cap = 4096
+        chunks = [b"x" * (cap + 1)]
+        status = await _drive(chunks, cap)
+        assert status.get("status") == 413

--- a/tests/api/test_query_helpers.py
+++ b/tests/api/test_query_helpers.py
@@ -146,6 +146,35 @@ class TestParseFilters:
         assert result == {"owned": {"eq": 1}}
         assert isinstance(result["owned"]["eq"], int)
 
+    # Issue #87.P5: Python's int() is lenient and accepts forms that no
+    # operator would actually type: `+1` (positive sign), `1_000`
+    # (PEP 515 underscores), leading/trailing whitespace, hex (`0x10`).
+    # The wire contract should reject these so malformed values don't
+    # silently parse to "valid" integers.
+    def test_int_rejects_positive_sign_prefix(self):
+        from orchestrator.api._query_helpers import QueryParamError, parse_filters
+
+        with pytest.raises(QueryParamError, match=r"invalid integer literal"):
+            parse_filters(QueryParams("owned=+1"), allow_list=_games_allow_list())
+
+    def test_int_rejects_underscore_separator(self):
+        from orchestrator.api._query_helpers import QueryParamError, parse_filters
+
+        with pytest.raises(QueryParamError, match=r"invalid integer literal"):
+            parse_filters(QueryParams("size_bytes_gte=1_000"), allow_list=_games_allow_list())
+
+    def test_int_rejects_hex_prefix(self):
+        from orchestrator.api._query_helpers import QueryParamError, parse_filters
+
+        with pytest.raises(QueryParamError, match=r"invalid integer literal"):
+            parse_filters(QueryParams("size_bytes_gte=0x10"), allow_list=_games_allow_list())
+
+    def test_int_accepts_negative(self):
+        from orchestrator.api._query_helpers import parse_filters
+
+        result = parse_filters(QueryParams("size_bytes_gte=-5"), allow_list=_games_allow_list())
+        assert result == {"size_bytes": {"gte": -5}}
+
     def test_unknown_field_raises(self):
         from orchestrator.api._query_helpers import QueryParamError, parse_filters
 


### PR DESCRIPTION
## Summary

Four-issue hardening batch addressing UAT-5 deferred items in a single cohesive PR.

- **#51** (P5) — Hypothesis property tests for `BodySizeCapMiddleware` streaming path (synthetic ASGI scopes; covers chunk patterns httpx can't reproduce) + `TestBodySizeCapExactBoundary` for exact-cap and cap+1 boundaries.
- **#52** — Bearer scheme `description` field in OpenAPI schema explains token source (Docker secret vs env), wire format, and rotation pointer. Swagger UI Authorize dialog now self-documents.
- **#84** — Strict-int validation in `_query_helpers._coerce_value` rejects `+123`, `0x10`, `1_000`, and other Python-parseable forms that aren't canonical wire-format integers. Regex `^-?\d+$` only; INT64 range check unchanged.
- **#87** (P3) — `manifests_pool_seeded` docstring clarifies total visible manifest count (24 = 3 baseline + 21 seeded).
- Docs: new "CORS for browser clients" section in README explains `ORCH_CORS_ORIGINS` default-deny posture with example JSON list values.

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean (80 files)
- [x] `mypy --strict src/` clean (32 source files)
- [x] `gitleaks detect` — no leaks
- [x] `pytest tests/` — 683 pass (1 unrelated pre-existing failure: `test_licenses.py` requires `pip-licenses` CLI absent from this venv)
- [x] 4 new strict-int unit tests in `test_query_helpers.py` cover `+`, `0x`, `_`, and accept-negative
- [x] 2 new `@given` Hypothesis properties + boundary class in `test_middleware_body_size_cap.py`

Closes #51 #52 #84 #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)