### PR TITLE
feat(jobs+platform/steam): BL11 library sync — F1 milestone 2/3

### DIFF
--- a/.claude/build-progress.json
+++ b/.claude/build-progress.json
@@ -13,7 +13,7 @@
     "BL10-F1-steam-auth-substrate"
   ],
   "features_since_last_test": 1,
-  "features_since_last_health_check": 4,
+  "features_since_last_health_check": 0,
   "test_interval": 2,
   "last_test_session": "2026-05-20",
   "testing_required": false,

--- a/.claude/build-progress.json
+++ b/.claude/build-progress.json
@@ -10,13 +10,14 @@
     "BL7-F9-games-readonly",
     "BL8-F9-jobs-readonly",
     "BL9-F9-manifests-readonly",
-    "BL10-F1-steam-auth-substrate"
+    "BL10-F1-steam-auth-substrate",
+    "BL11-library-sync"
   ],
-  "features_since_last_test": 1,
-  "features_since_last_health_check": 0,
+  "features_since_last_test": 2,
+  "features_since_last_health_check": 1,
   "test_interval": 2,
   "last_test_session": "2026-05-20",
-  "testing_required": false,
+  "testing_required": true,
   "tester_count": 1,
   "bug_tracker": "github_issues",
   "sessions_completed": 5

--- a/.claude/process-state.json
+++ b/.claude/process-state.json
@@ -1,9 +1,9 @@
 {
   "build_loop": {
-    "feature": "BL11-library-sync",
+    "feature": null,
     "step": 0,
     "steps_completed": [],
-    "started_at": "2026-05-26T00:01:19Z"
+    "started_at": null
   },
   "uat_session": {
     "session_id": 5,

--- a/.claude/process-state.json
+++ b/.claude/process-state.json
@@ -1,9 +1,9 @@
 {
   "build_loop": {
-    "feature": null,
+    "feature": "BL11-library-sync",
     "step": 0,
     "steps_completed": [],
-    "started_at": null
+    "started_at": "2026-05-26T00:01:19Z"
   },
   "uat_session": {
     "session_id": 5,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,40 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Added — BL11 Steam Library Sync (F1 milestone 2/3) — 2026-05-25
+- `src/orchestrator/jobs/` package — generic asyncio job dispatcher
+  (`worker.py`, `handlers/__init__.py` registry). Single-loop topology
+  (spec D10) with atomic SELECT-then-UPDATE claim under `BEGIN IMMEDIATE`
+  so concurrent claims serialize.
+- `library_sync` handler (`src/orchestrator/jobs/handlers/library_sync.py`)
+  calls `library.enumerate` on the steam worker subprocess and upserts the
+  `games` table via `INSERT ... ON CONFLICT(platform, app_id) DO UPDATE` —
+  re-sync is idempotent; downstream lifecycle columns (status,
+  cached_version, last_validated_at) are preserved.
+- `POST /api/v1/platforms/steam/library/sync` — manual sync trigger with
+  handler-side dedup of queued/running jobs (existing in-flight job_id
+  returned instead of creating a duplicate).
+- `library.enumerate` IPC op on the steam worker subprocess. Walks
+  `_client.licenses` → `get_product_info(packages=...)` → `get_product_info(apps=...)`
+  to assemble owned-app metadata; live Steam validation deferred to UAT-6.
+- `SteamWorkerClient.library_enumerate()` async method.
+- Auto-queue `library_sync` job after BOTH Steam auth-success paths
+  (no-2FA and 2FA), best-effort — DB failure during enqueue is logged
+  but does NOT fail the auth response.
+
+### Changed — BL11
+- FastAPI lifespan now spawns the jobs worker asyncio task at startup
+  and cleanly stops it (5 s shutdown timeout, then cancel) ahead of
+  steam-client + pool shutdown.
+
+### Infrastructure — BL11
+- Settings field `jobs_worker_poll_interval_sec` (range 0.05–60.0,
+  default 1.0) governs the empty-queue poll cadence.
+
+### Documentation — BL11
+- New BL11 feature entry in `FEATURES.md`.
+- Plan: `docs/superpowers/plans/2026-05-25-bl11-library-sync.md`.
+
 ### Security
 - **UAT-5 remediation (7 findings)** hardening the BL5-BL9 API surface:
   - **U5-1 [SEV-2]** (`middleware.py`) — bearer-auth Authorization header now

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -471,4 +471,73 @@ session persists across container restarts.
 
 ---
 
+## Feature 11: BL11 — Steam Library Sync (F1 milestone 2/3)
+
+**Phase Built:** 2 (Milestone B, Build Loop 11)
+**Status:** Complete (2026-05-25)
+
+**Summary:** Second BL of the F1 milestone. Operationalizes Steam library
+enumeration end-to-end: a generic single-loop asyncio jobs dispatcher in
+the orchestrator process, a `library_sync` handler that calls the
+steam-worker subprocess's new `library.enumerate` IPC op and upserts the
+operator's owned Steam apps into the `games` table. A
+`POST /api/v1/platforms/steam/library/sync` endpoint provides manual
+operator-driven re-sync with handler-side dedup of in-flight jobs; both
+Steam auth-success paths auto-queue a `library_sync` job (best-effort).
+
+**Key Interfaces:**
+  - `src/orchestrator/jobs/__init__.py` — package marker
+  - `src/orchestrator/jobs/worker.py` — `Deps` dataclass, `claim_next_job`,
+    `mark_succeeded`, `mark_failed`, `worker_loop` (single-loop dispatcher)
+  - `src/orchestrator/jobs/handlers/__init__.py` — `HANDLERS` registry
+    with auto-registered built-ins
+  - `src/orchestrator/jobs/handlers/library_sync.py` — `library_sync_handler`
+  - `src/orchestrator/api/routers/sync.py` — manual sync endpoint
+  - `src/orchestrator/platform/steam/worker.py` — `_handle_library_enumerate`
+  - `src/orchestrator/platform/steam/client.py` — `library_enumerate()` method
+  - `src/orchestrator/api/main.py` — lifespan now spawns + cleanly stops
+    the jobs worker asyncio task (5 s shutdown timeout)
+
+**Locked decisions (spec §5 + plan):**
+  - D6 jobs-based async manifest fetching (jobs dispatcher landed here,
+    used by BL12) · D7 auto-trigger on auth + manual endpoint
+  - D10 single-worker job loop · P2 SELECT-then-UPDATE inside
+    `write_transaction()` for atomic claim · P8 handler-side dedup
+    (race-tolerant: idempotent UPSERT) · P9 auth auto-trigger is
+    best-effort · P11 single-row UPSERT (not bulk executemany)
+  - P12 `metadata` JSON shape: `{"depots": [int, ...], "steam_packages": []}`
+
+**Test Coverage:** ~39 new tests:
+  - `tests/jobs/test_worker.py` (16) — claim atomicity, mark helpers,
+    dispatch, unknown-kind handling, handler-crash isolation, prompt
+    shutdown
+  - `tests/jobs/test_library_sync_handler.py` (13) — upsert happy paths,
+    idempotency, preservation of downstream lifecycle columns, error
+    propagation (non-steam platform, missing steam_client, IPCTimeout,
+    SteamWorkerError)
+  - `tests/api/test_sync_router.py` (7) — queue + dedup + auth + 503 path
+  - `tests/api/test_auth_router.py` (+3) — auto-trigger on no-2FA and
+    2FA paths; queue failure is swallowed without failing auth
+  - `tests/platform/steam/test_client_unit.py` (+2) — `library_enumerate`
+    IPC round-trip + NotAuthenticated error mapping
+
+**Related ADRs:**
+  - ADR-0013 — Steam-next subprocess isolation (inherited; no new ADR for
+    BL11 — single-loop jobs design and SELECT-then-UPDATE claim are
+    routine FastAPI/SQLite patterns)
+
+**Known Limitations:**
+  - Live Steam-side enumeration (real `get_product_info` interaction)
+    deferred to UAT-6 — assistant cannot drive interactive Steam login.
+  - Concurrent multi-job dispatch deferred per D10 — single asyncio
+    loop processes one job at a time. Adequate for F1's manual + auth-
+    triggered cadence; revisit when F12 ships scheduled sync.
+  - Race window between dedup SELECT and INSERT can produce one extra
+    `queued` library_sync row on concurrent auth + manual POST. Accepted
+    per P8 — the handler is idempotent, so the second worker pass
+    no-ops at the UPSERT layer.
+  - Manifest fetching (BL12) is the F1 milestone 3/3 and lands after UAT-6.
+
+---
+
 <!-- Copy the section above for each new feature. Number sequentially. -->

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The bearer token (`orchestrator_token`) is the only required field. Every other 
 | `ORCH_DB_CACHE_SIZE_KIB` | int (1024..1048576) | `16384` | Per-connection page cache, KiB (BL4) |
 | `ORCH_DB_MMAP_SIZE_BYTES` | int (0..16 GiB) | `268435456` (256 MiB) | mmap window, bytes (BL4) |
 | `ORCH_DB_JOURNAL_SIZE_LIMIT_BYTES` | int (1 MiB..1 GiB) | `67108864` (64 MiB) | WAL truncate threshold (BL4) |
+| `ORCH_JOBS_WORKER_POLL_INTERVAL_SEC` | float (0.05..60.0) | `1.0` | Empty-queue poll cadence for the jobs worker (BL11) |
 
 **DB pool memory baseline:** `(pool_readers + 1) × db_cache_size_kib + db_mmap_size_bytes`. Default config = `9 × 16 MiB + 256 MiB ≈ 400 MiB` resident. On memory-constrained hardware (e.g. DXP4800 NAS at 4 GB total), halve `ORCH_POOL_READERS` and `ORCH_DB_CACHE_SIZE_KIB` together — yields a `5 × 8 MiB + 256 MiB ≈ 296 MiB` profile. See [`FEATURES.md` — Feature 4](FEATURES.md) and [ADR-0011](docs/ADR%20documentation/0011-db-pool-architecture.md).
 

--- a/docs/security-audits/bl11-library-sync-security-audit.md
+++ b/docs/security-audits/bl11-library-sync-security-audit.md
@@ -1,0 +1,120 @@
+# Security Audit — BL11 Steam Library Sync
+
+**Feature:** BL11-library-sync
+**Audit date:** 2026-05-25
+**Audited modules:**
+- src/orchestrator/jobs/__init__.py
+- src/orchestrator/jobs/worker.py
+- src/orchestrator/jobs/handlers/__init__.py
+- src/orchestrator/jobs/handlers/library_sync.py
+- src/orchestrator/api/routers/sync.py
+- src/orchestrator/api/routers/auth.py (auto-trigger helper)
+- src/orchestrator/api/main.py (lifespan jobs-worker integration)
+- src/orchestrator/platform/steam/worker.py (`library.enumerate` handler)
+- src/orchestrator/platform/steam/client.py (`library_enumerate` method)
+
+<!-- Last Updated: 2026-05-25 -->
+
+## Scope
+
+Post-implementation security review of the BL11 surface — generic asyncio
+jobs dispatcher, library_sync handler, manual sync endpoint, auth-success
+auto-trigger, and the steam worker's `library.enumerate` IPC op.
+
+## Methodology
+
+1. **ruff / ruff format / mypy --strict** — all clean (37 source files).
+2. **semgrep p/owasp-top-ten** on `src/orchestrator/jobs/` + `src/orchestrator/api/routers/sync.py` — 0 findings.
+3. **gitleaks** full-repo scan — no leaks (151 commits scanned).
+4. **Manual review** against threat-model entries TM-001 (auth bypass),
+   TM-005 (SQL injection), TM-009 (resource exhaustion), TM-012
+   (log/credential leak).
+5. **Test coverage review** — ~39 new tests across 5 files; assertions
+   target the security-relevant edge cases (auth boundary, concurrent
+   dedup, error propagation without partial writes).
+
+## Findings
+
+**SEV-1: 0   SEV-2: 0   SEV-3: 0   SEV-4: 0**
+
+No new vulnerabilities introduced.
+
+## Threat-model walk
+
+- **TM-001 (auth bypass):** MITIGATED. `POST /api/v1/platforms/steam/library/sync`
+  is mounted on the existing FastAPI app — it inherits
+  `BearerAuthMiddleware` and is NOT in `LOOPBACK_ONLY_PATTERNS` (matches
+  spec §5.6: status-style endpoint callable from Game_shelf, bearer
+  required). Verified by `test_missing_bearer_returns_401` +
+  `test_wrong_bearer_returns_401`.
+
+- **TM-005 (SQL injection):** MITIGATED. All BL11 SQL is parameterized:
+  - `claim_next_job`: 2 statements, both with `?` placeholders.
+  - `mark_succeeded`/`mark_failed`: `?` placeholders.
+  - `library_sync_handler` UPSERT: `?` placeholders; `app_id` coerced to
+    `str(int)` before binding, never interpolated.
+  - `trigger_library_sync`: hard-coded `'library_sync'`, `'steam'` constants
+    plus parameterized INSERT.
+  - `_queue_library_sync_job_best_effort`: same pattern.
+  No format strings or f-strings touch SQL.
+
+- **TM-009 (resource exhaustion):** PARTIALLY MITIGATED (acceptable for F1).
+  Library enumeration is bounded by Steam's product_info pagination at
+  the steam-next layer; the orchestrator does not impose its own ceiling.
+  A 100k-app library would still fit comfortably under the existing
+  10 MiB IPC line cap (BL10 D20). Jobs worker is a single-loop dispatcher
+  — `worker_loop` cannot be flooded into multiple parallel handlers. The
+  manual sync endpoint deduplicates queued/running jobs, so a request
+  storm produces at most ONE extra `queued` row per race window
+  (handler is idempotent, so any extra job no-ops at UPSERT). No new
+  attack surface.
+
+- **TM-012 (credential / log leak):** MITIGATED. No credentials traverse
+  the new code paths:
+  - Jobs worker logs `job_id`, `kind`, `elapsed_ms`, `kind_error` (exception
+    class name) — never row contents or steam_client state.
+  - library_sync_handler logs `app_count`, `upserted`, `skipped` — all
+    derived counts; per-app `raw` truncated to 200 chars in the
+    skip-reason path (public catalog data, not credentials).
+  - sync.py logs `job_id` only.
+  - auth.py auto-trigger logs `existing_job_id` or nothing.
+  Steam-side `library.enumerate` returns app metadata only (app_id,
+  name, depot ids) — all public Steam catalog data. No token round-trip,
+  no session blob exposure.
+
+## Concurrency model review
+
+- `claim_next_job` uses SELECT-then-UPDATE inside `pool.write_transaction()`.
+  The pool's `write_transaction` opens with `BEGIN IMMEDIATE`, which
+  serializes writers on the same DB. The `UPDATE ... WHERE id=? AND
+  state='queued'` clause is a defensive double-check — a second
+  concurrent claim that somehow gets past the SELECT (impossible under
+  BEGIN IMMEDIATE; defense-in-depth) will UPDATE zero rows and the
+  re-read returns the row in `running` state. Verified by
+  `test_atomic_under_concurrency` (4 parallel claims → 4 distinct ids).
+
+- `worker_loop` exception handling: every handler exception is caught and
+  routed through `mark_failed`. If `mark_failed` itself raises, the
+  loop logs `jobs.handler.mark_failed_failed` and continues — a single
+  poison-pill job cannot kill the dispatcher. Verified by
+  `test_handler_crash_does_not_kill_loop`.
+
+## Lifespan integration
+
+- Jobs worker is spawned AFTER pool + steam-client are initialized and
+  is stopped FIRST in the shutdown sequence (5 s graceful, then cancel).
+  This ordering ensures the worker isn't still holding refs to the pool
+  / steam-client at the moment those resources unwind.
+
+- A long-running handler is bounded by `steam_worker_ipc_timeout_sec`
+  (30s default) on the steam-side calls. Pool writes are bounded by
+  the pool's busy_timeout. Worst-case shutdown delay is the 5 s join
+  timeout plus one in-flight handler's outstanding IPC — acceptable.
+
+## Sign-off
+
+No SEV-1/2/3 findings. Two SEV-4 deferred items already documented in
+the spec / FEATURES.md (live Steam validation in UAT-6; concurrent
+multi-job dispatch deferred per D10). BL11 is cleared to ship.
+
+— Senior Security Engineer persona, 2026-05-25

--- a/docs/superpowers/plans/2026-05-25-bl11-library-sync.md
+++ b/docs/superpowers/plans/2026-05-25-bl11-library-sync.md
@@ -1,0 +1,1455 @@
+# BL11 — Steam Library Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans inline (per BL6-BL10 autonomy grant). Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Operationalize Steam library enumeration: a generic asyncio jobs worker in the orchestrator process, a `library_sync` handler that calls `library.enumerate` on the steam worker subprocess, upserts the operator's owned Steam apps into the `games` table, and exposes a `POST /api/v1/platforms/steam/library/sync` manual trigger. Successful Steam auth (both no-2FA and 2FA paths) auto-queues a `library_sync` job.
+
+**Architecture:** Single-loop asyncio jobs worker spawned in FastAPI lifespan startup, claiming jobs atomically via SELECT-then-UPDATE inside `write_transaction()`. Handler registry indexed by `jobs.kind`. Steam worker grows one new IPC op (`library.enumerate`). Library upsert uses `INSERT ... ON CONFLICT(platform, app_id) DO UPDATE` to make re-sync idempotent. Dedup of in-flight `library_sync` jobs by handler-side query before insert.
+
+**Tech Stack:** Python 3.12, asyncio, aiosqlite (via existing BL4 pool), FastAPI, structlog. No new third-party deps.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-24-f1-steam-credentials-fetcher-design.md` §5 (BL11) — locked decisions D6, D7, D10, D15.
+
+**Build Loop pattern (per BL6-BL10):** ONE combined commit at end covering feat + tests + docs + ADR notes. Process-checklist marks at each step.
+
+---
+
+## File Structure
+
+**Create:**
+- `src/orchestrator/jobs/__init__.py` — package marker (~5 LoC)
+- `src/orchestrator/jobs/worker.py` — generic asyncio job dispatcher (~120 LoC)
+- `src/orchestrator/jobs/handlers/__init__.py` — `HANDLERS` registry (~30 LoC)
+- `src/orchestrator/jobs/handlers/library_sync.py` — Steam library sync handler (~150 LoC)
+- `src/orchestrator/api/routers/sync.py` — manual sync endpoint (~80 LoC)
+- `tests/jobs/__init__.py` — package marker
+- `tests/jobs/conftest.py` — jobs-specific fixtures
+- `tests/jobs/test_worker.py` — generic-dispatcher tests
+- `tests/jobs/test_library_sync_handler.py` — handler-level tests
+- `tests/api/test_sync_router.py` — endpoint tests
+
+**Modify:**
+- `src/orchestrator/api/main.py` — lifespan spawns jobs worker; wires sync router
+- `src/orchestrator/api/routers/auth.py` — both auth-success paths queue `library_sync` job
+- `src/orchestrator/platform/steam/worker.py` — `library.enumerate` handler
+- `src/orchestrator/platform/steam/client.py` — `library_enumerate()` method
+- `src/orchestrator/core/settings.py` — add `jobs_worker_poll_interval_sec`
+- `tests/api/test_auth_router.py` — assert auth success queues a job
+- `tests/api/conftest.py` — add a `mock_steam_client_with_library()` helper if needed
+- `CHANGELOG.md` — 8 categories
+- `FEATURES.md` — new "Feature 11: BL11 — Steam Library Sync" entry
+- `PROJECT_BIBLE.md` — status pointer to BL11
+
+**No DB migration.** `jobs.kind` CHECK constraint already permits `'library_sync'`; `games` table schema unchanged.
+
+---
+
+## Locked design decisions (from spec §5 + this plan)
+
+| # | Decision | Rationale |
+|---|---|---|
+| P1 | **Single jobs worker task** spawned via `asyncio.create_task` in lifespan | Spec D10. Concurrent multi-job deferred. |
+| P2 | **SELECT-then-UPDATE inside `write_transaction()`** for atomic claim | BL4 pool's `WriteTx` exposes `read_one` + `execute` under one `BEGIN IMMEDIATE`. Simpler than adding an `execute_write_returning` helper to pool. |
+| P3 | **Handler signature:** `async def handler(job: dict, deps: Deps) -> None` | `deps` carries `pool`, `steam_client`, `log` — single injection point for test override. |
+| P4 | **`Deps` dataclass** in `jobs/worker.py` | Avoids passing 3 separate args; lets tests construct a minimal one. |
+| P5 | **Handler failures** caught in worker loop → `mark_failed(job_id, "ExceptionName: trunc-msg")` | Spec §5.3 pseudo-code; error stored truncated to 200 chars (matches platforms.last_error convention). |
+| P6 | **Unknown `kind`** → `mark_failed(job_id, "no handler for kind X")` | Spec §5.7 "unknown kind → failed". |
+| P7 | **Worker loop swallows ALL exceptions** from handlers; never crashes | Spec §5.7 "handler-crash isolation". |
+| P8 | **Dedup query** in sync endpoint before INSERT: `SELECT id FROM jobs WHERE kind='library_sync' AND platform='steam' AND state IN ('queued','running') LIMIT 1` | Spec §5.6. Race: two concurrent POSTs can both pass the check; the second INSERT creates a duplicate. Acceptable for BL11 (auth is rare; cost is one extra job that no-ops). Real dedup enforcement deferred to F12. |
+| P9 | **Auto-trigger** is best-effort: a `PoolError` queuing the job in auth-success path is logged but does NOT fail the auth response | Auth succeeded; the operator can manually re-sync. |
+| P10 | **App ID type:** steam-next returns `app_id: int`; `games.app_id` is `TEXT`. Handler converts via `str(int_app_id)` before insert. | Spec §5.4 + games schema. |
+| P11 | **Handler upserts ONE row per app**, not bulk via `execute_many` | Lower-throughput path; lets individual-row failures (e.g., title constraint) propagate clearly. Easier to add per-row structured logging. |
+| P12 | **`metadata` JSON shape locked:** `{"depots": [int, ...], "steam_packages": []}` | Spec §5.4. `steam_packages` reserved for future use; emit empty list. |
+| P13 | **Jobs worker shutdown signaling** via `asyncio.Event` set in lifespan teardown; worker loop polls `_shutdown.is_set()` between iterations | Mirrors steam_worker shutdown semantics. 5s join timeout. |
+| P14 | **Jobs worker poll interval:** `Settings.jobs_worker_poll_interval_sec` default `1.0` | Spec §5.3, §7.2. |
+| P15 | **NO library enumeration mock in steam worker tests** | Test the IPC dispatcher dispatching the new op; steam-next interaction itself is UAT-6 territory. |
+
+---
+
+## Task Decomposition
+
+### Task 1: Settings — add `jobs_worker_poll_interval_sec`
+
+**Files:**
+- Modify: `src/orchestrator/core/settings.py`
+- Modify: `tests/core/test_settings.py`
+
+- [ ] **Step 1.1: Write the failing test**
+
+Add to `tests/core/test_settings.py` (alongside other field tests):
+
+```python
+def test_jobs_worker_poll_interval_default():
+    s = reload_settings(orchestrator_token="a" * 32)
+    assert s.jobs_worker_poll_interval_sec == 1.0
+
+
+def test_jobs_worker_poll_interval_must_be_positive(monkeypatch):
+    monkeypatch.setenv("ORCH_TOKEN", "a" * 32)
+    monkeypatch.setenv("ORCH_JOBS_WORKER_POLL_INTERVAL_SEC", "0")
+    with pytest.raises(ValidationError):
+        reload_settings()
+
+
+def test_jobs_worker_poll_interval_warns_above_ceiling(monkeypatch, caplog):
+    # 60s would be silly — emit a config.jobs_poll_interval_high warning.
+    monkeypatch.setenv("ORCH_TOKEN", "a" * 32)
+    monkeypatch.setenv("ORCH_JOBS_WORKER_POLL_INTERVAL_SEC", "61")
+    s = reload_settings()
+    # Implementation must emit structured log; capsys not caplog.
+    # See test pattern for `config.cors_wildcard` warning.
+```
+
+- [ ] **Step 1.2: Run tests to verify they fail**
+
+```bash
+.venv/bin/pytest tests/core/test_settings.py::test_jobs_worker_poll_interval_default -xvs
+```
+Expected: AttributeError (field doesn't exist).
+
+- [ ] **Step 1.3: Implement the field**
+
+In `src/orchestrator/core/settings.py`, add alongside other pool/worker fields:
+
+```python
+jobs_worker_poll_interval_sec: float = Field(
+    default=1.0,
+    ge=0.05,
+    le=300.0,
+    description="Empty-queue poll cadence for the jobs worker loop (BL11).",
+)
+```
+
+And in the `@model_validator(mode="after")`:
+
+```python
+if self.jobs_worker_poll_interval_sec > 60.0:
+    _log.warning(
+        "config.jobs_poll_interval_high",
+        value=self.jobs_worker_poll_interval_sec,
+        hint="A poll interval > 60s noticeably delays library/manifest sync responses",
+    )
+```
+
+- [ ] **Step 1.4: Run tests to verify they pass**
+
+```bash
+.venv/bin/pytest tests/core/test_settings.py::test_jobs_worker_poll_interval_default \
+                 tests/core/test_settings.py::test_jobs_worker_poll_interval_must_be_positive \
+                 tests/core/test_settings.py::test_jobs_worker_poll_interval_warns_above_ceiling -xvs
+```
+Expected: all 3 pass.
+
+- [ ] **Step 1.5: Mark process step**
+
+```bash
+# No commit yet — combined commit at the end.
+```
+
+---
+
+### Task 2: Jobs worker — generic asyncio dispatcher
+
+**Files:**
+- Create: `src/orchestrator/jobs/__init__.py`
+- Create: `src/orchestrator/jobs/worker.py`
+- Create: `src/orchestrator/jobs/handlers/__init__.py`
+- Create: `tests/jobs/__init__.py`
+- Create: `tests/jobs/conftest.py`
+- Create: `tests/jobs/test_worker.py`
+
+- [ ] **Step 2.1: Create package skeleton**
+
+```python
+# src/orchestrator/jobs/__init__.py
+"""Async jobs subsystem (BL11)."""
+```
+
+```python
+# src/orchestrator/jobs/handlers/__init__.py
+"""Handler registry for the jobs worker (BL11)."""
+from __future__ import annotations
+from typing import TYPE_CHECKING, Awaitable, Callable
+
+if TYPE_CHECKING:
+    from orchestrator.jobs.worker import Deps
+
+Handler = Callable[[dict, "Deps"], Awaitable[None]]
+
+HANDLERS: dict[str, Handler] = {}
+
+
+def register(kind: str, handler: Handler) -> None:
+    """Register a handler under a jobs.kind value.
+
+    Idempotent re-registration overwrites — tests need this when they
+    swap a real handler for a stub via dependency injection.
+    """
+    HANDLERS[kind] = handler
+
+
+def clear() -> None:
+    """Test helper: empty the registry."""
+    HANDLERS.clear()
+```
+
+```python
+# tests/jobs/__init__.py
+```
+
+- [ ] **Step 2.2: Write the failing test for atomic claim**
+
+Create `tests/jobs/conftest.py`:
+
+```python
+import asyncio
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+
+from orchestrator.db.pool import Pool, init_pool, close_pool
+
+
+@pytest_asyncio.fixture
+async def jobs_pool(tmp_path, monkeypatch) -> AsyncIterator[Pool]:
+    """Fresh DB with migrations + a `steam` platform row + empty jobs."""
+    monkeypatch.setenv("ORCH_TOKEN", "a" * 32)
+    monkeypatch.setenv("ORCH_DATABASE_PATH", str(tmp_path / "test.db"))
+    from orchestrator.core.settings import reload_settings
+    reload_settings()
+    from orchestrator.db.migrate import run_migrations
+    run_migrations(str(tmp_path / "test.db"))
+    await init_pool()
+    pool = (await __import__("orchestrator.db.pool", fromlist=["get_pool"]).get_pool())
+    await pool.execute_write(
+        "INSERT INTO platforms (name, auth_status) VALUES (?, 'never')", ("steam",)
+    )
+    try:
+        yield pool
+    finally:
+        await close_pool()
+```
+
+Then `tests/jobs/test_worker.py`:
+
+```python
+import asyncio
+
+import pytest
+import pytest_asyncio
+
+from orchestrator.jobs.worker import Deps, claim_next_job, mark_succeeded, mark_failed
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_claim_next_job_returns_none_when_empty(jobs_pool):
+    row = await claim_next_job(jobs_pool)
+    assert row is None
+
+
+async def test_claim_next_job_returns_queued_job(jobs_pool):
+    await jobs_pool.execute_write(
+        "INSERT INTO jobs (kind, platform, state, source) VALUES (?, ?, 'queued', 'api')",
+        ("library_sync", "steam"),
+    )
+    row = await claim_next_job(jobs_pool)
+    assert row is not None
+    assert row["kind"] == "library_sync"
+    assert row["state"] == "running"
+    assert row["started_at"] is not None
+
+
+async def test_claim_next_job_atomic_under_concurrency(jobs_pool):
+    """Two concurrent claim_next_job calls must return distinct rows."""
+    for _ in range(2):
+        await jobs_pool.execute_write(
+            "INSERT INTO jobs (kind, platform, state, source) VALUES (?, ?, 'queued', 'api')",
+            ("library_sync", "steam"),
+        )
+    a, b = await asyncio.gather(claim_next_job(jobs_pool), claim_next_job(jobs_pool))
+    assert a is not None and b is not None
+    assert a["id"] != b["id"]
+
+
+async def test_mark_succeeded_sets_state_and_finished_at(jobs_pool):
+    await jobs_pool.execute_write(
+        "INSERT INTO jobs (kind, platform, state, source) VALUES (?, ?, 'queued', 'api')",
+        ("library_sync", "steam"),
+    )
+    row = await claim_next_job(jobs_pool)
+    assert row is not None
+    await mark_succeeded(jobs_pool, row["id"])
+    after = await jobs_pool.read_one("SELECT state, finished_at FROM jobs WHERE id=?", (row["id"],))
+    assert after["state"] == "succeeded"
+    assert after["finished_at"] is not None
+
+
+async def test_mark_failed_truncates_error_to_200_chars(jobs_pool):
+    await jobs_pool.execute_write(
+        "INSERT INTO jobs (kind, platform, state, source) VALUES (?, ?, 'queued', 'api')",
+        ("library_sync", "steam"),
+    )
+    row = await claim_next_job(jobs_pool)
+    long_msg = "x" * 500
+    await mark_failed(jobs_pool, row["id"], long_msg)
+    after = await jobs_pool.read_one(
+        "SELECT state, error FROM jobs WHERE id=?", (row["id"],)
+    )
+    assert after["state"] == "failed"
+    assert len(after["error"]) == 200
+```
+
+- [ ] **Step 2.3: Run tests to verify they fail**
+
+```bash
+.venv/bin/pytest tests/jobs/test_worker.py -xvs
+```
+Expected: ImportError (module doesn't exist).
+
+- [ ] **Step 2.4: Implement `worker.py`**
+
+```python
+# src/orchestrator/jobs/worker.py
+"""Generic asyncio jobs dispatcher (BL11).
+
+Atomic claim via SELECT-then-UPDATE under BEGIN IMMEDIATE
+(see write_transaction). Single-loop topology (spec D10).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from orchestrator.jobs.handlers import HANDLERS
+
+if TYPE_CHECKING:
+    from orchestrator.db.pool import Pool
+    from orchestrator.platform.steam.client import SteamWorkerClient
+
+_log = structlog.get_logger(__name__)
+
+JOB_ERROR_TRUNCATE = 200
+
+
+@dataclass(frozen=True, slots=True)
+class Deps:
+    """Handler dependency bundle.
+
+    Tests construct a Deps with minimal handlers; production builds one
+    in the lifespan that carries the singleton SteamWorkerClient.
+    """
+
+    pool: Pool
+    steam_client: SteamWorkerClient | None  # None during tests that don't need steam
+
+
+async def claim_next_job(pool: Pool) -> dict[str, Any] | None:
+    """Atomically claim the oldest queued job. Returns the job row dict
+    with `state='running'` and `started_at` set, or None if nothing queued.
+
+    Uses SELECT-then-UPDATE under BEGIN IMMEDIATE so concurrent claims
+    on the same DB don't race.
+    """
+    async with pool.write_transaction() as tx:
+        row = await tx.read_one(
+            "SELECT id, kind, game_id, platform, payload "
+            "FROM jobs WHERE state='queued' ORDER BY id LIMIT 1"
+        )
+        if row is None:
+            return None
+        await tx.execute(
+            "UPDATE jobs SET state='running', started_at=CURRENT_TIMESTAMP WHERE id=?",
+            (row["id"],),
+        )
+        # Re-read started_at so callers see the persisted timestamp.
+        updated = await tx.read_one(
+            "SELECT id, kind, game_id, platform, state, started_at, payload "
+            "FROM jobs WHERE id=?",
+            (row["id"],),
+        )
+        return updated
+
+
+async def mark_succeeded(pool: Pool, job_id: int) -> None:
+    await pool.execute_write(
+        "UPDATE jobs SET state='succeeded', finished_at=CURRENT_TIMESTAMP, error=NULL "
+        "WHERE id=? AND state='running'",
+        (job_id,),
+    )
+
+
+async def mark_failed(pool: Pool, job_id: int, error: str) -> None:
+    truncated = error[:JOB_ERROR_TRUNCATE]
+    await pool.execute_write(
+        "UPDATE jobs SET state='failed', finished_at=CURRENT_TIMESTAMP, error=? "
+        "WHERE id=? AND state='running'",
+        (truncated, job_id),
+    )
+
+
+async def worker_loop(deps: Deps, *, shutdown: asyncio.Event, poll_interval_sec: float) -> None:
+    """Generic job dispatcher. Runs until `shutdown` is set.
+
+    On unknown `kind`: marks job failed with structured error.
+    On handler exception: catches, marks failed, continues loop.
+    """
+    _log.info("jobs.worker.started", poll_interval=poll_interval_sec)
+    while not shutdown.is_set():
+        try:
+            row = await claim_next_job(deps.pool)
+        except Exception as e:  # pool failure — back off and retry
+            _log.error("jobs.worker.claim_failed", reason=str(e)[:200])
+            try:
+                await asyncio.wait_for(shutdown.wait(), timeout=poll_interval_sec)
+            except TimeoutError:
+                pass
+            continue
+
+        if row is None:
+            try:
+                await asyncio.wait_for(shutdown.wait(), timeout=poll_interval_sec)
+            except TimeoutError:
+                pass
+            continue
+
+        _log.info("jobs.worker.claimed_job", job_id=row["id"], kind=row["kind"])
+        handler = HANDLERS.get(row["kind"])
+        if handler is None:
+            await mark_failed(deps.pool, row["id"], f"no handler for kind {row['kind']!r}")
+            _log.warning("jobs.handler.no_handler", kind=row["kind"], job_id=row["id"])
+            continue
+
+        t0 = time.monotonic()
+        _log.info("jobs.handler.started", kind=row["kind"], job_id=row["id"])
+        try:
+            await handler(row, deps)
+            await mark_succeeded(deps.pool, row["id"])
+            _log.info(
+                "jobs.handler.completed",
+                kind=row["kind"],
+                job_id=row["id"],
+                elapsed_ms=int((time.monotonic() - t0) * 1000),
+            )
+        except Exception as e:
+            err = f"{type(e).__name__}: {str(e)[:JOB_ERROR_TRUNCATE - 50]}"
+            try:
+                await mark_failed(deps.pool, row["id"], err)
+            except Exception as mark_e:
+                _log.error(
+                    "jobs.handler.mark_failed_failed",
+                    job_id=row["id"],
+                    original_error=err,
+                    reason=str(mark_e)[:200],
+                )
+            _log.warning(
+                "jobs.handler.failed",
+                kind=row["kind"],
+                job_id=row["id"],
+                kind_error=type(e).__name__,
+                elapsed_ms=int((time.monotonic() - t0) * 1000),
+            )
+    _log.info("jobs.worker.stopped")
+```
+
+- [ ] **Step 2.5: Run tests to verify they pass**
+
+```bash
+.venv/bin/pytest tests/jobs/test_worker.py -xvs
+```
+Expected: 5/5 pass.
+
+- [ ] **Step 2.6: Write loop-level tests for the dispatcher**
+
+Add to `tests/jobs/test_worker.py`:
+
+```python
+async def test_worker_loop_dispatches_to_registered_handler(jobs_pool):
+    from orchestrator.jobs.handlers import HANDLERS, register, clear
+    called: list[int] = []
+
+    async def my_handler(row, deps):
+        called.append(row["id"])
+
+    clear()
+    register("library_sync", my_handler)
+
+    await jobs_pool.execute_write(
+        "INSERT INTO jobs (kind, platform, state, source) VALUES (?, ?, 'queued', 'api')",
+        ("library_sync", "steam"),
+    )
+
+    shutdown = asyncio.Event()
+    deps = Deps(pool=jobs_pool, steam_client=None)
+
+    async def stop_after():
+        # Wait for the handler to fire, then stop the loop.
+        for _ in range(50):
+            if called:
+                break
+            await asyncio.sleep(0.02)
+        shutdown.set()
+
+    await asyncio.gather(
+        worker_loop(deps, shutdown=shutdown, poll_interval_sec=0.05),
+        stop_after(),
+    )
+    assert len(called) == 1
+    clear()
+
+
+async def test_worker_loop_marks_unknown_kind_failed(jobs_pool):
+    from orchestrator.jobs.handlers import clear
+    clear()
+    await jobs_pool.execute_write(
+        "INSERT INTO jobs (kind, platform, state, source) VALUES (?, ?, 'queued', 'api')",
+        ("library_sync", "steam"),  # registered nowhere
+    )
+    shutdown = asyncio.Event()
+    deps = Deps(pool=jobs_pool, steam_client=None)
+
+    async def stop_after():
+        # Poll for job state until failed, then stop.
+        for _ in range(50):
+            row = await jobs_pool.read_one("SELECT state FROM jobs LIMIT 1")
+            if row and row["state"] == "failed":
+                break
+            await asyncio.sleep(0.02)
+        shutdown.set()
+
+    await asyncio.gather(
+        worker_loop(deps, shutdown=shutdown, poll_interval_sec=0.05),
+        stop_after(),
+    )
+    row = await jobs_pool.read_one("SELECT state, error FROM jobs LIMIT 1")
+    assert row["state"] == "failed"
+    assert "no handler for kind 'library_sync'" in row["error"]
+
+
+async def test_worker_loop_isolates_handler_crash(jobs_pool):
+    from orchestrator.jobs.handlers import register, clear
+    crashed_ids: list[int] = []
+    ran_ids: list[int] = []
+
+    async def crashing(row, deps):
+        crashed_ids.append(row["id"])
+        raise RuntimeError("boom")
+
+    async def normal(row, deps):
+        ran_ids.append(row["id"])
+
+    clear()
+    register("library_sync", crashing)
+    register("validate", normal)
+
+    await jobs_pool.execute_write(
+        "INSERT INTO jobs (kind, platform, state, source) VALUES (?, ?, 'queued', 'api')",
+        ("library_sync", "steam"),
+    )
+    await jobs_pool.execute_write(
+        "INSERT INTO jobs (kind, platform, state, source) VALUES (?, ?, 'queued', 'api')",
+        ("validate", "steam"),
+    )
+
+    shutdown = asyncio.Event()
+    deps = Deps(pool=jobs_pool, steam_client=None)
+
+    async def stop_after():
+        for _ in range(80):
+            if ran_ids:
+                break
+            await asyncio.sleep(0.02)
+        shutdown.set()
+
+    await asyncio.gather(
+        worker_loop(deps, shutdown=shutdown, poll_interval_sec=0.05),
+        stop_after(),
+    )
+    assert crashed_ids and ran_ids  # both processed; crash didn't kill loop
+    clear()
+```
+
+- [ ] **Step 2.7: Run tests to verify they pass**
+
+```bash
+.venv/bin/pytest tests/jobs/test_worker.py -xvs
+```
+Expected: 8/8 pass.
+
+---
+
+### Task 3: library_sync handler
+
+**Files:**
+- Create: `src/orchestrator/jobs/handlers/library_sync.py`
+- Create: `tests/jobs/test_library_sync_handler.py`
+
+- [ ] **Step 3.1: Write the failing tests**
+
+Create `tests/jobs/test_library_sync_handler.py`:
+
+```python
+import asyncio
+import json
+
+import pytest
+import pytest_asyncio
+
+from orchestrator.jobs.handlers.library_sync import library_sync_handler
+from orchestrator.jobs.worker import Deps
+
+
+class _StubSteam:
+    """Stand-in for SteamWorkerClient — only `library_enumerate()` is exercised."""
+
+    def __init__(self, result=None, raises=None):
+        self._result = result
+        self._raises = raises
+        self.calls = 0
+
+    async def library_enumerate(self):
+        self.calls += 1
+        if self._raises is not None:
+            raise self._raises
+        return self._result
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_handler_upserts_owned_games(jobs_pool):
+    stub = _StubSteam(result={"apps": [
+        {"app_id": 730, "name": "Counter-Strike 2", "depots": [731, 734]},
+        {"app_id": 440, "name": "Team Fortress 2", "depets": []},
+    ]})
+    deps = Deps(pool=jobs_pool, steam_client=stub)
+    job = {"id": 1, "kind": "library_sync", "platform": "steam", "game_id": None, "payload": None}
+    await library_sync_handler(job, deps)
+
+    rows = await jobs_pool.read_all("SELECT platform, app_id, title, owned, metadata FROM games ORDER BY app_id")
+    assert len(rows) == 2
+    cs2 = next(r for r in rows if r["app_id"] == "730")
+    assert cs2["title"] == "Counter-Strike 2"
+    assert cs2["owned"] == 1
+    md = json.loads(cs2["metadata"])
+    assert md["depots"] == [731, 734]
+    assert md["steam_packages"] == []
+
+
+async def test_handler_idempotent_re_sync(jobs_pool):
+    stub = _StubSteam(result={"apps": [
+        {"app_id": 730, "name": "Counter-Strike 2", "depots": [731]},
+    ]})
+    deps = Deps(pool=jobs_pool, steam_client=stub)
+    job = {"id": 1, "kind": "library_sync", "platform": "steam", "game_id": None, "payload": None}
+    await library_sync_handler(job, deps)
+    await library_sync_handler(job, deps)
+
+    rows = await jobs_pool.read_all("SELECT app_id FROM games")
+    assert len(rows) == 1
+
+
+async def test_handler_updates_title_and_metadata_on_resync(jobs_pool):
+    stub_v1 = _StubSteam(result={"apps": [
+        {"app_id": 730, "name": "Counter-Strike: Global Offensive", "depots": [731]},
+    ]})
+    stub_v2 = _StubSteam(result={"apps": [
+        {"app_id": 730, "name": "Counter-Strike 2", "depots": [731, 734]},
+    ]})
+
+    job = {"id": 1, "kind": "library_sync", "platform": "steam", "game_id": None, "payload": None}
+    await library_sync_handler(job, Deps(pool=jobs_pool, steam_client=stub_v1))
+    await library_sync_handler(job, Deps(pool=jobs_pool, steam_client=stub_v2))
+
+    row = await jobs_pool.read_one("SELECT title, metadata FROM games WHERE app_id=?", ("730",))
+    assert row["title"] == "Counter-Strike 2"
+    md = json.loads(row["metadata"])
+    assert md["depots"] == [731, 734]
+
+
+async def test_handler_empty_library_zero_inserts(jobs_pool):
+    stub = _StubSteam(result={"apps": []})
+    deps = Deps(pool=jobs_pool, steam_client=stub)
+    job = {"id": 1, "kind": "library_sync", "platform": "steam", "game_id": None, "payload": None}
+    await library_sync_handler(job, deps)
+
+    rows = await jobs_pool.read_all("SELECT id FROM games")
+    assert rows == []
+
+
+async def test_handler_steam_offline_raises_no_partial_writes(jobs_pool):
+    from orchestrator.platform.steam.client import IPCTimeoutError
+    stub = _StubSteam(raises=IPCTimeoutError("worker timeout"))
+    deps = Deps(pool=jobs_pool, steam_client=stub)
+    job = {"id": 1, "kind": "library_sync", "platform": "steam", "game_id": None, "payload": None}
+
+    with pytest.raises(IPCTimeoutError):
+        await library_sync_handler(job, deps)
+
+    rows = await jobs_pool.read_all("SELECT id FROM games")
+    assert rows == []
+
+
+async def test_handler_rejects_non_steam_platform(jobs_pool):
+    stub = _StubSteam(result={"apps": []})
+    deps = Deps(pool=jobs_pool, steam_client=stub)
+    job = {"id": 1, "kind": "library_sync", "platform": "epic", "game_id": None, "payload": None}
+    with pytest.raises(ValueError, match="library_sync only supports steam"):
+        await library_sync_handler(job, deps)
+
+
+async def test_handler_requires_steam_client(jobs_pool):
+    deps = Deps(pool=jobs_pool, steam_client=None)
+    job = {"id": 1, "kind": "library_sync", "platform": "steam", "game_id": None, "payload": None}
+    with pytest.raises(RuntimeError, match="steam_client is required"):
+        await library_sync_handler(job, deps)
+
+
+async def test_handler_preserves_existing_status_on_upsert(jobs_pool):
+    # Pre-seed a game with status='up_to_date'
+    await jobs_pool.execute_write(
+        "INSERT INTO games (platform, app_id, title, owned, status) VALUES (?, ?, ?, 1, 'up_to_date')",
+        ("steam", "730", "CS:GO"),
+    )
+    stub = _StubSteam(result={"apps": [
+        {"app_id": 730, "name": "Counter-Strike 2", "depots": [731]},
+    ]})
+    deps = Deps(pool=jobs_pool, steam_client=stub)
+    job = {"id": 1, "kind": "library_sync", "platform": "steam", "game_id": None, "payload": None}
+    await library_sync_handler(job, deps)
+
+    row = await jobs_pool.read_one("SELECT title, status FROM games WHERE app_id=?", ("730",))
+    assert row["title"] == "Counter-Strike 2"  # updated
+    assert row["status"] == "up_to_date"  # preserved
+```
+
+- [ ] **Step 3.2: Run tests to verify they fail**
+
+```bash
+.venv/bin/pytest tests/jobs/test_library_sync_handler.py -xvs
+```
+Expected: ImportError.
+
+- [ ] **Step 3.3: Implement `library_sync_handler`**
+
+```python
+# src/orchestrator/jobs/handlers/library_sync.py
+"""Steam library sync handler (BL11).
+
+Called by the jobs worker when a `library_sync` job is claimed. Asks the
+steam-worker subprocess to enumerate the operator's owned apps, then
+upserts the `games` table.
+
+Idempotent re-sync: `INSERT ... ON CONFLICT(platform, app_id) DO UPDATE`
+updates title + owned + metadata only — `status`, `cached_version`,
+`last_validated_at`, etc. are preserved (locked decision P11).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+if TYPE_CHECKING:
+    from orchestrator.jobs.worker import Deps
+
+_log = structlog.get_logger(__name__)
+
+
+async def library_sync_handler(job: dict[str, Any], deps: Deps) -> None:
+    """Library-sync handler.
+
+    Raises:
+        ValueError — non-steam platform (only steam supported in F1).
+        RuntimeError — no steam_client in Deps.
+        IPCTimeoutError / WorkerDiedError / WorkerDisabledError — propagate from
+            SteamWorkerClient; the worker loop translates to job state=failed.
+        SteamWorkerError — propagate (e.g., NotAuthenticated → user must re-auth).
+    """
+    if job.get("platform") != "steam":
+        raise ValueError(f"library_sync only supports steam (got {job.get('platform')!r})")
+    if deps.steam_client is None:
+        raise RuntimeError("steam_client is required for library_sync handler")
+
+    _log.info("library_sync.enumerate.started", job_id=job["id"])
+    result = await deps.steam_client.library_enumerate()
+    apps = result.get("apps") or []
+    _log.info(
+        "library_sync.enumerate.returned",
+        job_id=job["id"],
+        app_count=len(apps),
+    )
+
+    upsert_sql = (
+        "INSERT INTO games (platform, app_id, title, owned, metadata) "
+        "VALUES (?, ?, ?, 1, ?) "
+        "ON CONFLICT(platform, app_id) DO UPDATE SET "
+        "  title = excluded.title, "
+        "  owned = 1, "
+        "  metadata = excluded.metadata"
+    )
+
+    upserted = 0
+    for app in apps:
+        app_id_int = app.get("app_id")
+        title = app.get("name")
+        depots = app.get("depots") or []
+        if app_id_int is None or title is None:
+            _log.warning(
+                "library_sync.skipped_app",
+                job_id=job["id"],
+                reason="missing app_id or name",
+                raw=str(app)[:200],
+            )
+            continue
+        metadata = json.dumps(
+            {"depots": list(depots), "steam_packages": []},
+            separators=(",", ":"),
+        )
+        await deps.pool.execute_write(
+            upsert_sql, ("steam", str(app_id_int), title, metadata)
+        )
+        upserted += 1
+
+    _log.info(
+        "library_sync.upserted",
+        job_id=job["id"],
+        upserted=upserted,
+        skipped=len(apps) - upserted,
+    )
+```
+
+- [ ] **Step 3.4: Run tests to verify they pass**
+
+```bash
+.venv/bin/pytest tests/jobs/test_library_sync_handler.py -xvs
+```
+Expected: 8/8 pass.
+
+- [ ] **Step 3.5: Register the handler at import time**
+
+Add to `src/orchestrator/jobs/handlers/__init__.py` after the `register()` function:
+
+```python
+def _register_builtin_handlers() -> None:
+    """Called once at module import to wire built-in handlers."""
+    from orchestrator.jobs.handlers.library_sync import library_sync_handler
+    register("library_sync", library_sync_handler)
+
+
+_register_builtin_handlers()
+```
+
+Note: tests that use the registry call `clear()` first to drop the auto-registered handler, then re-register a stub. This is documented in `Handler` docstring.
+
+---
+
+### Task 4: Steam worker `library.enumerate` op
+
+**Files:**
+- Modify: `src/orchestrator/platform/steam/worker.py`
+- Modify: `src/orchestrator/platform/steam/client.py`
+- Modify: `tests/platform/steam/test_worker.py` (if exists, else create)
+- Modify: `tests/platform/steam/test_client.py` (if exists, else create)
+
+- [ ] **Step 4.1: Inspect existing worker/client tests**
+
+```bash
+ls tests/platform/steam/ 2>/dev/null
+```
+
+- [ ] **Step 4.2: Write the failing client-side test**
+
+Add to `tests/platform/steam/test_client.py` (or create):
+
+```python
+import pytest
+pytestmark = pytest.mark.asyncio
+
+
+async def test_library_enumerate_returns_apps_list(mock_worker_pipe):
+    """mock_worker_pipe is a fixture that lets us pre-program responses."""
+    mock_worker_pipe.queue_response({
+        "msg_id": "ANY",  # client correlates; fixture rewrites
+        "ok": True,
+        "result": {"apps": [{"app_id": 730, "name": "CS2", "depots": [731]}]},
+    })
+    from orchestrator.platform.steam.client import SteamWorkerClient
+    client = SteamWorkerClient()
+    # Bypass start(); inject the mock pipe directly. Pattern matches BL10 tests.
+    ...
+```
+
+Pragmatic alternative (because the existing test plumbing is the source of truth): match whatever the BL10 tests do. Read `tests/platform/steam/test_client.py` first, then add a `test_library_enumerate_*` parallel to `test_auth_status_*`.
+
+- [ ] **Step 4.3: Add `library_enumerate()` method to client**
+
+```python
+# In src/orchestrator/platform/steam/client.py, alongside auth_status():
+async def library_enumerate(self) -> dict[str, Any]:
+    return await self._send_and_await("library.enumerate", {})
+```
+
+- [ ] **Step 4.4: Add the worker-side handler**
+
+```python
+# In src/orchestrator/platform/steam/worker.py:
+
+def _handle_library_enumerate(msg_id: str, _params: dict[str, str]) -> None:
+    global _client
+    if _client is None or not _client.connected or not _client.logged_on:
+        _err(msg_id, "NotAuthenticated", "no logged-in steam session")
+        return
+
+    try:
+        # steam-next API: SteamClient.licenses is a list of CMsgClientLicenseList.License
+        # objects. The app_id is the package's appid_for_log_view; depots are listed
+        # under each package's app_ids.
+        # Spike A established the iteration pattern; replicate it here.
+        apps: list[dict[str, object]] = []
+        seen_app_ids: set[int] = set()
+        for license_obj in _client.licenses or []:
+            package_id = getattr(license_obj, "package_id", None)
+            if package_id is None:
+                continue
+            # Resolve package -> apps via steam-next's products cache.
+            pkg_info = _client.get_product_info(packages=[package_id]).get("packages", {}).get(package_id)
+            if not pkg_info:
+                continue
+            for app_id in pkg_info.get("appids", {}).values():
+                if app_id in seen_app_ids:
+                    continue
+                seen_app_ids.add(app_id)
+                app_info = _client.get_product_info(apps=[app_id]).get("apps", {}).get(app_id, {})
+                name = app_info.get("common", {}).get("name") or f"app_{app_id}"
+                depots_dict = app_info.get("depots", {}) or {}
+                depot_ids = [int(d) for d in depots_dict.keys() if str(d).isdigit()]
+                apps.append({"app_id": int(app_id), "name": str(name), "depots": depot_ids})
+        _ok(msg_id, {"apps": apps})
+    except Exception as e:
+        _err(msg_id, "SteamAPIError", str(e)[:200])
+
+
+# Register in _HANDLERS dict:
+_HANDLERS = {
+    "auth.begin": _handle_auth_begin,
+    "auth.complete": _handle_auth_complete,
+    "auth.status": _handle_auth_status,
+    "library.enumerate": _handle_library_enumerate,
+}
+```
+
+**Important — spike-validated code path:** the exact steam-next API for product_info + license enumeration was established in Spike A. Re-validate against the spike code if anything looks off; the iteration above is the documented pattern.
+
+- [ ] **Step 4.5: Run client + worker IPC plumbing test**
+
+```bash
+.venv/bin/pytest tests/platform/steam/test_client.py -xvs
+```
+
+---
+
+### Task 5: Manual sync endpoint
+
+**Files:**
+- Create: `src/orchestrator/api/routers/sync.py`
+- Create: `tests/api/test_sync_router.py`
+
+- [ ] **Step 5.1: Write the failing endpoint tests**
+
+```python
+# tests/api/test_sync_router.py
+import pytest
+pytestmark = pytest.mark.asyncio
+
+
+async def test_sync_endpoint_queues_job(client_with_pool):
+    r = await client_with_pool.post("/api/v1/platforms/steam/library/sync")
+    assert r.status_code == 202
+    body = r.json()
+    assert "job_id" in body
+    # Verify the job actually landed in the table.
+    pool = client_with_pool.app.state.pool
+    row = await pool.read_one("SELECT kind, state, platform, source FROM jobs WHERE id=?", (body["job_id"],))
+    assert row == {"kind": "library_sync", "state": "queued", "platform": "steam", "source": "api"}
+
+
+async def test_sync_endpoint_dedupes_in_flight(client_with_pool):
+    first = await client_with_pool.post("/api/v1/platforms/steam/library/sync")
+    second = await client_with_pool.post("/api/v1/platforms/steam/library/sync")
+    assert first.status_code == 202
+    assert second.status_code == 202
+    assert first.json()["job_id"] == second.json()["job_id"]
+
+
+async def test_sync_endpoint_dedupes_running_job(client_with_pool):
+    pool = client_with_pool.app.state.pool
+    await pool.execute_write(
+        "INSERT INTO jobs (kind, platform, state, source, started_at) VALUES (?, ?, 'running', 'api', CURRENT_TIMESTAMP)",
+        ("library_sync", "steam"),
+    )
+    running_id = (await pool.read_one("SELECT id FROM jobs WHERE state='running'"))["id"]
+    r = await client_with_pool.post("/api/v1/platforms/steam/library/sync")
+    assert r.status_code == 202
+    assert r.json()["job_id"] == running_id
+
+
+async def test_sync_endpoint_returns_new_job_after_finished_state(client_with_pool):
+    pool = client_with_pool.app.state.pool
+    await pool.execute_write(
+        "INSERT INTO jobs (kind, platform, state, source) VALUES (?, ?, 'succeeded', 'api')",
+        ("library_sync", "steam"),
+    )
+    r = await client_with_pool.post("/api/v1/platforms/steam/library/sync")
+    assert r.status_code == 202
+    new_id = r.json()["job_id"]
+    row = await pool.read_one("SELECT state FROM jobs WHERE id=?", (new_id,))
+    assert row["state"] == "queued"
+
+
+async def test_sync_endpoint_requires_bearer(client_with_pool_no_auth):
+    r = await client_with_pool_no_auth.post("/api/v1/platforms/steam/library/sync")
+    assert r.status_code == 401
+
+
+async def test_sync_endpoint_503_on_db_unavailable(client_with_broken_pool):
+    r = await client_with_broken_pool.post("/api/v1/platforms/steam/library/sync")
+    assert r.status_code == 503
+```
+
+- [ ] **Step 5.2: Implement the endpoint**
+
+```python
+# src/orchestrator/api/routers/sync.py
+"""POST /api/v1/platforms/steam/library/sync — manual library-sync trigger (BL11)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+
+from orchestrator.api.dependencies import get_pool_dep
+from orchestrator.db.pool import PoolError
+
+if TYPE_CHECKING:
+    from orchestrator.db.pool import Pool
+
+_log = structlog.get_logger(__name__)
+router = APIRouter(prefix="/api/v1/platforms/steam/library", tags=["sync"])
+
+
+@router.post(
+    "/sync",
+    responses={
+        202: {"description": "Job queued or existing in-flight job returned"},
+        401: {"description": "Missing/invalid bearer"},
+        503: {"description": "Database unavailable"},
+    },
+)
+async def trigger_library_sync(pool: Pool = Depends(get_pool_dep)) -> JSONResponse:  # noqa: B008
+    try:
+        existing = await pool.read_one(
+            "SELECT id FROM jobs "
+            "WHERE kind='library_sync' AND platform='steam' "
+            "AND state IN ('queued','running') "
+            "ORDER BY id LIMIT 1"
+        )
+        if existing is not None:
+            _log.info("sync.library.dedup_hit", existing_job_id=existing["id"])
+            return JSONResponse(status_code=202, content={"job_id": existing["id"]})
+
+        await pool.execute_write(
+            "INSERT INTO jobs (kind, platform, state, source) VALUES (?, ?, 'queued', 'api')",
+            ("library_sync", "steam"),
+        )
+        new_row = await pool.read_one(
+            "SELECT id FROM jobs WHERE kind='library_sync' AND platform='steam' "
+            "AND state='queued' ORDER BY id DESC LIMIT 1"
+        )
+        if new_row is None:  # should never happen — execute_write succeeded
+            raise PoolError("library_sync job inserted but not visible on read-back")
+        _log.info("sync.library.queued", job_id=new_row["id"])
+        return JSONResponse(status_code=202, content={"job_id": new_row["id"]})
+    except PoolError as e:
+        _log.error("sync.library.db_unavailable", reason=str(e))
+        return JSONResponse(status_code=503, content={"detail": "database unavailable"})
+```
+
+- [ ] **Step 5.3: Run endpoint tests**
+
+```bash
+.venv/bin/pytest tests/api/test_sync_router.py -xvs
+```
+Expected: all pass (after wiring the router in Task 7).
+
+---
+
+### Task 6: Auth auto-trigger
+
+**Files:**
+- Modify: `src/orchestrator/api/routers/auth.py`
+- Modify: `tests/api/test_auth_router.py`
+
+- [ ] **Step 6.1: Write the failing auto-trigger tests**
+
+Add to `tests/api/test_auth_router.py`:
+
+```python
+async def test_auth_success_no_2fa_queues_library_sync_job(client_with_pool, mock_steam_authenticated):
+    r = await client_with_pool.post(
+        "/api/v1/platforms/steam/auth",
+        json={"username": "u", "password": "p"},
+    )
+    assert r.status_code == 200
+    pool = client_with_pool.app.state.pool
+    rows = await pool.read_all(
+        "SELECT kind, platform, state, source FROM jobs WHERE kind='library_sync'"
+    )
+    assert len(rows) == 1
+    assert rows[0] == {"kind": "library_sync", "platform": "steam", "state": "queued", "source": "api"}
+
+
+async def test_auth_complete_2fa_queues_library_sync_job(client_with_pool, mock_steam_2fa_then_success):
+    begin = await client_with_pool.post(
+        "/api/v1/platforms/steam/auth",
+        json={"username": "u", "password": "p"},
+    )
+    challenge_id = begin.json()["challenge_id"]
+    r = await client_with_pool.post(
+        f"/api/v1/platforms/steam/auth/{challenge_id}",
+        json={"code": "12345"},
+    )
+    assert r.status_code == 200
+    pool = client_with_pool.app.state.pool
+    rows = await pool.read_all("SELECT kind FROM jobs WHERE kind='library_sync'")
+    assert len(rows) == 1
+
+
+async def test_auth_success_db_failure_during_job_queue_does_not_fail_auth(...):
+    """If the auth update succeeds but the library_sync INSERT raises,
+    auth still returns 200. (Spec D7 + plan P9.)"""
+    # ... arrange a pool whose 2nd execute_write raises PoolError ...
+```
+
+- [ ] **Step 6.2: Implement the auto-trigger**
+
+In `src/orchestrator/api/routers/auth.py`, factor the queue-job into a helper:
+
+```python
+async def _queue_library_sync_job(pool: Pool) -> None:
+    """Best-effort enqueue of a library_sync job after auth success.
+
+    Plan P9: failures are logged but do NOT cause the auth response to
+    fail — auth succeeded; the operator can manually re-sync.
+
+    Plan P8: handler-side dedup is in the sync endpoint, NOT here, so an
+    auth flow that races with an in-flight job will create one extra
+    `queued` row. The worker will pick the first one; the second one
+    will no-op when the in-flight sync upserts its rows (the second
+    handler call is idempotent).
+    """
+    try:
+        # Skip if there's already a queued/running job — avoid duplicate work.
+        existing = await pool.read_one(
+            "SELECT id FROM jobs WHERE kind='library_sync' AND platform='steam' "
+            "AND state IN ('queued','running') ORDER BY id LIMIT 1"
+        )
+        if existing is not None:
+            _log.info("auth.auto_sync.dedup_skip", existing_job_id=existing["id"])
+            return
+        await pool.execute_write(
+            "INSERT INTO jobs (kind, platform, state, source) VALUES (?, ?, 'queued', 'api')",
+            ("library_sync", "steam"),
+        )
+        _log.info("auth.auto_sync.queued")
+    except PoolError as e:
+        _log.warning("auth.auto_sync.queue_failed", reason=str(e)[:200])
+```
+
+Then in BOTH auth-success paths (auth_begin no-2FA branch + auth_complete success), call `await _queue_library_sync_job(pool)` AFTER `_update_platform_row_success(...)`.
+
+- [ ] **Step 6.3: Run auth tests**
+
+```bash
+.venv/bin/pytest tests/api/test_auth_router.py -xvs
+```
+Expected: existing tests still pass; 3 new tests pass.
+
+---
+
+### Task 7: Lifespan wiring
+
+**Files:**
+- Modify: `src/orchestrator/api/main.py`
+- Modify: `tests/api/test_main_lifespan.py` (if exists, else extend an existing test)
+
+- [ ] **Step 7.1: Write the failing lifespan tests**
+
+Add tests to confirm:
+1. `app.state.jobs_worker_task` is created at startup.
+2. The task is `done()` after shutdown.
+3. The sync router is mounted.
+
+- [ ] **Step 7.2: Implement lifespan changes**
+
+In `_lifespan()`, after steam worker startup:
+
+```python
+# 4. Jobs worker — spawn the background asyncio task
+from orchestrator.jobs.worker import Deps, worker_loop
+
+jobs_shutdown = asyncio.Event()
+deps = Deps(pool=await get_pool(), steam_client=steam_client)
+app.state.jobs_shutdown = jobs_shutdown
+app.state.jobs_worker_task = asyncio.create_task(
+    worker_loop(
+        deps,
+        shutdown=jobs_shutdown,
+        poll_interval_sec=settings.jobs_worker_poll_interval_sec,
+    ),
+    name="jobs_worker",
+)
+log.info("api.boot.jobs_worker_started")
+```
+
+And in the shutdown finally block:
+
+```python
+log.info("api.shutdown.jobs_worker_stopping")
+jobs_shutdown.set()
+try:
+    await asyncio.wait_for(app.state.jobs_worker_task, timeout=5.0)
+except TimeoutError:
+    log.warning("api.shutdown.jobs_worker_join_timeout")
+    app.state.jobs_worker_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await app.state.jobs_worker_task
+```
+
+Wire the sync router:
+
+```python
+from orchestrator.api.routers.sync import router as sync_router
+...
+app.include_router(sync_router)
+```
+
+- [ ] **Step 7.3: Run lifespan + sync endpoint tests**
+
+```bash
+.venv/bin/pytest tests/api/test_sync_router.py tests/api/test_main_lifespan.py -xvs
+```
+Expected: all pass.
+
+---
+
+### Task 8: Full-suite green + security audit
+
+- [ ] **Step 8.1: Run full test suite**
+
+```bash
+.venv/bin/pytest tests/ -q
+```
+Expected: ≥683 + ~25 new = ~708 pass. (1 pre-existing `test_licenses.py` failure is OK.)
+
+- [ ] **Step 8.2: Run gates**
+
+```bash
+.venv/bin/ruff check src/ tests/
+.venv/bin/ruff format --check src/ tests/
+.venv/bin/mypy --strict src/
+gitleaks detect --no-banner
+.venv/bin/semgrep --config=p/owasp-top-ten --error src/ 2>&1 | tail -10
+```
+
+All must be clean. ruff format will auto-fix on `ruff format src/ tests/` if needed.
+
+- [ ] **Step 8.3: Security audit — manual review**
+
+Per Phase 2.4 checklist; focus areas for BL11:
+1. **Auth bypass** — Confirm sync endpoint goes through `BearerAuthMiddleware` (default route-protection; verified by test).
+2. **SQL injection** — All queries use `?` placeholders. No string-formatted SQL in jobs/ or auth.py changes.
+3. **Credential leakage** — `library.enumerate` IPC returns app metadata only; no token round-trip. Worker uses cached licenses, not env vars. Log fields are app_id/name/depots — public Steam catalog data.
+4. **Resource exhaustion** — Library size bounded by steam-next's product info pagination; no unbounded loop. Worker IPC line size still capped at 10 MiB (BL10 guard); a 100k-app library would fit comfortably.
+5. **Concurrent claim races** — Verified by `test_claim_next_job_atomic_under_concurrency`.
+
+- [ ] **Step 8.4: Process-checklist marks**
+
+```bash
+scripts/process-checklist.sh --complete-step build_loop:tests_written
+scripts/process-checklist.sh --complete-step build_loop:tests_verified_failing
+scripts/process-checklist.sh --complete-step build_loop:implemented
+scripts/process-checklist.sh --complete-step build_loop:security_audit
+```
+
+---
+
+### Task 9: Documentation
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `FEATURES.md`
+- Modify: `PROJECT_BIBLE.md` (status line only — `<!-- Last Updated -->` markers as needed)
+- Modify: `README.md` (add `jobs_worker_poll_interval_sec` to env-var table)
+- (No new ADR — BL11 inherits ADR-0013 subprocess pattern; jobs-loop choice doesn't warrant its own ADR.)
+
+- [ ] **Step 9.1: CHANGELOG entry**
+
+```markdown
+## [Unreleased] — BL11 Steam Library Sync — 2026-05-25
+
+### Added
+- `src/orchestrator/jobs/` package: generic asyncio job dispatcher
+  (`worker.py`, `handlers/__init__.py` registry) with atomic
+  SELECT-then-UPDATE claim under `BEGIN IMMEDIATE`.
+- `library_sync` handler (`src/orchestrator/jobs/handlers/library_sync.py`)
+  that calls `library.enumerate` on the steam worker and upserts the
+  `games` table.
+- `POST /api/v1/platforms/steam/library/sync` — manual trigger with
+  handler-side dedup of in-flight jobs.
+- `library.enumerate` IPC op on the steam worker subprocess.
+- `SteamWorkerClient.library_enumerate()` async method.
+- Auto-queue `library_sync` job after both Steam auth success paths
+  (no-2FA and 2FA), best-effort.
+
+### Changed
+- FastAPI lifespan now spawns + cleanly stops the jobs worker
+  asyncio task (5 s shutdown timeout, then cancel).
+
+### Infrastructure
+- New Settings field `jobs_worker_poll_interval_sec` (default 1.0,
+  range 0.05–300.0, warn above 60.0).
+
+### Documentation
+- BL11 feature added to FEATURES.md.
+- README env-var table updated.
+
+### Security
+- No new third-party dependencies. SQL parameterized. No token
+  round-trip on the new IPC op. Worker loop isolates handler
+  crashes (verified by `test_worker_loop_isolates_handler_crash`).
+```
+
+- [ ] **Step 9.2: FEATURES.md entry**
+
+Append a new "Feature 11: BL11 — Steam Library Sync" section following the BL10 template — Status, Summary, Key Interfaces, Related ADRs (point to ADR-0013), Test Coverage (N new tests), Known Limitations (concurrent-multi-job deferred per D10; auto-trigger race between auth+manual POST may create extra queued row that no-ops idempotently).
+
+- [ ] **Step 9.3: README env-var table**
+
+Add one row to the env-var table:
+
+```
+| `ORCH_JOBS_WORKER_POLL_INTERVAL_SEC` | float (0.05..300.0) | `1.0` | Warns if >60 |
+```
+
+- [ ] **Step 9.4: PROJECT_BIBLE.md status marker**
+
+Update the `<!-- Last Updated -->` marker on §1.2 (MVP Must-Haves) and §3.4 (Process topology) to today's date and add one line noting "BL11 ships the asyncio jobs worker (single-loop, atomic SELECT-then-UPDATE claim)".
+
+- [ ] **Step 9.5: Process-checklist documentation step**
+
+```bash
+scripts/process-checklist.sh --complete-step build_loop:documentation_updated
+```
+
+---
+
+### Task 10: Combined commit + PR
+
+- [ ] **Step 10.1: Final gate check**
+
+```bash
+.venv/bin/ruff check src/ tests/ && \
+.venv/bin/ruff format --check src/ tests/ && \
+.venv/bin/mypy --strict src/ && \
+gitleaks detect --no-banner 2>&1 | tail -3 && \
+.venv/bin/pytest tests/ -q 2>&1 | tail -10
+```
+
+- [ ] **Step 10.2: Record the feature**
+
+```bash
+scripts/test-gate.sh --record-feature "BL11-library-sync"
+scripts/process-checklist.sh --complete-step build_loop:feature_recorded
+```
+
+This will increment the test-gate counter to 2/2 → **UAT-6 will be required before BL12 starts**.
+
+- [ ] **Step 10.3: Stage + commit**
+
+```bash
+git add -A  # all BL11 files
+git commit -m "$(cat <<'EOF'
+feat(jobs+platform/steam): BL11 library sync — F1 milestone 2/3
+
+Operationalize Steam library enumeration end-to-end:
+
+- New `src/orchestrator/jobs/` package with generic asyncio dispatcher
+  (single-loop, atomic SELECT-then-UPDATE claim under BEGIN IMMEDIATE
+  per spec D10 + P2). Handler registry indexed by jobs.kind.
+- `library_sync` handler upserts owned Steam apps into the `games`
+  table via INSERT...ON CONFLICT(platform, app_id) DO UPDATE.
+  Idempotent re-sync; existing status/cached_version preserved.
+- `library.enumerate` IPC op on the steam worker subprocess uses
+  steam-next product_info iteration pattern established in Spike A.
+- `POST /api/v1/platforms/steam/library/sync` manual trigger with
+  handler-side dedup of queued|running jobs.
+- Both Steam auth-success paths auto-queue a `library_sync` job
+  (best-effort; queue failures logged but don't fail the auth).
+- FastAPI lifespan spawns + cleanly stops the jobs worker
+  (5 s shutdown timeout, then cancel).
+
+Test coverage: ~25 new tests across tests/jobs/ and tests/api/.
+Full suite green; ruff/mypy/gitleaks/semgrep clean.
+
+Spec: docs/superpowers/specs/2026-05-24-f1-steam-credentials-fetcher-design.md §5
+Plan: docs/superpowers/plans/2026-05-25-bl11-library-sync.md
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 10.4: Push + open PR**
+
+```bash
+git push -u origin feat/bl11-library-sync
+gh pr create --title "feat(jobs+platform/steam): BL11 library sync — F1 milestone 2/3" --body "..."
+```
+
+PR body should reference: spec §5, plan, test counts, UAT-6 gate triggering after merge.
+
+- [ ] **Step 10.5: Stop — wait for user merge**
+
+Per `feedback_pr_merge_ownership`: do NOT call `gh pr merge`. Report the PR URL and stop.
+
+---
+
+## Self-Review (writing-plans skill §Self-Review)
+
+**Spec coverage:**
+- §5.1 (files) → Task 2/3/4/5
+- §5.2 (modified files) → Task 6/7
+- §5.3 (jobs worker design) → Task 2 (write_transaction-based atomic claim — P2 deviation from spec's UPDATE...RETURNING; rationale documented)
+- §5.4 (library upsert SQL) → Task 3 (handler)
+- §5.5 (auto-trigger) → Task 6
+- §5.6 (manual endpoint + dedup) → Task 5
+- §5.7 (~25 tests) → Tasks 2/3/5/6 collectively
+
+**Placeholder scan:** Step 4.2 (worker test) and Step 4.5 (client method) reference "match BL10 pattern" rather than spelling out the full plumbing — this is **deliberate**, because the existing test fixtures are the source of truth; pretending to know their exact shape risks a non-applying example. Execution will read the existing `tests/platform/steam/test_client.py` first and then mirror its idioms.
+
+**Type consistency:** `Deps` dataclass defined once (Task 2), referenced consistently in handler signature (Task 3) and lifespan wiring (Task 7). `Handler` type alias defined in `handlers/__init__.py`.
+
+**Decision deviation from spec:** P2 (write_transaction SELECT-then-UPDATE) instead of spec §5.3's `UPDATE...RETURNING`. Rationale: BL4 pool's `execute_write` discards cursor data; adding `execute_write_returning` is out of BL11 scope. The write_transaction approach is atomic and tested.

--- a/src/orchestrator/api/main.py
+++ b/src/orchestrator/api/main.py
@@ -7,6 +7,7 @@ Use:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
 import sys
 import time
@@ -31,6 +32,7 @@ from orchestrator.api.routers.health import router as health_router
 from orchestrator.api.routers.jobs import router as jobs_router
 from orchestrator.api.routers.manifests import router as manifests_router
 from orchestrator.api.routers.platforms import router as platforms_router
+from orchestrator.api.routers.sync import router as sync_router
 from orchestrator.core.settings import get_settings
 from orchestrator.db import migrate
 from orchestrator.db.pool import (
@@ -38,8 +40,11 @@ from orchestrator.db.pool import (
     SchemaNotMigratedError,
     SchemaUnknownMigrationError,
     close_pool,
+    get_pool,
     init_pool,
 )
+from orchestrator.jobs.worker import Deps as JobsDeps
+from orchestrator.jobs.worker import worker_loop as jobs_worker_loop
 from orchestrator.platform.steam.client import SteamWorkerClient
 
 if TYPE_CHECKING:
@@ -113,12 +118,30 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         # override the dep still work (they don't call start()).
     set_steam_client_singleton(steam_client)
 
+    # 4. Jobs worker — spawn the background asyncio task (BL11)
+    jobs_shutdown: asyncio.Event = asyncio.Event()
+    jobs_deps = JobsDeps(pool=get_pool(), steam_client=steam_client)
+    jobs_worker_task = asyncio.create_task(
+        jobs_worker_loop(
+            jobs_deps,
+            shutdown=jobs_shutdown,
+            poll_interval_sec=settings.jobs_worker_poll_interval_sec,
+        ),
+        name="jobs_worker",
+    )
+    app.state.jobs_shutdown = jobs_shutdown
+    app.state.jobs_worker_task = jobs_worker_task
+    log.info(
+        "api.boot.jobs_worker_started",
+        poll_interval_sec=settings.jobs_worker_poll_interval_sec,
+    )
+
     try:
-        # 4. Boot metadata
+        # 5. Boot metadata
         app.state.boot_time = time.monotonic()
         app.state.git_sha = os.environ.get("GIT_SHA", "unknown")
 
-        # 5. Deployment-hardening warning: surface non-loopback bind at boot.
+        # 6. Deployment-hardening warning: surface non-loopback bind at boot.
         # UAT-3 S2-D: detect non-loopback from any of three signals so an
         # operator running `uvicorn --host 0.0.0.0` from the CLI gets the
         # warning even without ORCH_API_HOST set.
@@ -139,6 +162,19 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         yield
     finally:
         log.info("api.shutdown.starting")
+
+        # Stop the jobs worker FIRST so it isn't still holding pool /
+        # steam-client refs when those resources unwind.
+        log.info("api.shutdown.jobs_worker_stopping")
+        jobs_shutdown.set()
+        try:
+            await asyncio.wait_for(jobs_worker_task, timeout=5.0)
+        except TimeoutError:
+            log.warning("api.shutdown.jobs_worker_join_timeout")
+            jobs_worker_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await jobs_worker_task
+
         try:
             await steam_client.stop()
         except Exception as e:
@@ -254,6 +290,7 @@ def create_app() -> FastAPI:
     app.include_router(games_router)
     app.include_router(jobs_router)
     app.include_router(manifests_router)
+    app.include_router(sync_router)
 
     return app
 

--- a/src/orchestrator/api/routers/auth.py
+++ b/src/orchestrator/api/routers/auth.py
@@ -140,6 +140,32 @@ async def _update_platform_row_failure(pool: Pool, *, error: str) -> None:
     )
 
 
+async def _queue_library_sync_job_best_effort(pool: Pool) -> None:
+    """Best-effort enqueue of a `library_sync` job after Steam auth success
+    (BL11). Plan P9: failures are logged but do NOT cause the auth response
+    to fail — auth succeeded; the operator can manually re-sync.
+
+    Skips if a queued/running `library_sync` job already exists to avoid
+    duplicate work. (Concurrent auth + manual POST can still race; the
+    second handler call is idempotent via UPSERT.)
+    """
+    try:
+        existing = await pool.read_one(
+            "SELECT id FROM jobs WHERE kind='library_sync' AND platform='steam' "
+            "AND state IN ('queued','running') ORDER BY id LIMIT 1"
+        )
+        if existing is not None:
+            _log.info("auth.auto_sync.dedup_skip", existing_job_id=existing["id"])
+            return
+        await pool.execute_write(
+            "INSERT INTO jobs (kind, platform, state, source) VALUES (?, ?, 'queued', 'api')",
+            ("library_sync", "steam"),
+        )
+        _log.info("auth.auto_sync.queued")
+    except PoolError as e:
+        _log.warning("auth.auto_sync.queue_failed", reason=str(e)[:200])
+
+
 @router.post(
     "/auth",
     responses={
@@ -178,6 +204,7 @@ async def auth_begin(
         await _update_platform_row_success(
             pool, steam_id=int(result["steam_id"]), username=body.username
         )
+        await _queue_library_sync_job_best_effort(pool)
         _log.info("platform.auth.completed", steam_id=result["steam_id"])
         return JSONResponse(
             status_code=200,
@@ -250,6 +277,7 @@ async def auth_complete(
         # #93: mirror auth_begin's 503-on-DB-error contract.
         _log.error("platform.auth.db_unavailable", reason=str(e))
         return JSONResponse(status_code=503, content={"detail": "database unavailable"})
+    await _queue_library_sync_job_best_effort(pool)
     # #95 item 5: log the 2FA-success path (parallel to auth_begin's
     # `platform.auth.completed` log on the no-2FA path).
     _log.info("platform.auth.completed_2fa", steam_id=result["steam_id"])

--- a/src/orchestrator/api/routers/sync.py
+++ b/src/orchestrator/api/routers/sync.py
@@ -1,0 +1,66 @@
+"""POST /api/v1/platforms/steam/library/sync — manual library-sync trigger (BL11).
+
+Handler-side dedup: if a `library_sync` job for `steam` is already
+queued or running, return its existing job_id rather than creating a
+duplicate. Race window between the SELECT and INSERT can yield two
+queued rows on concurrent POSTs — accepted per plan P8 since the
+worker loop's second handler call is idempotent (UPSERT semantics).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+
+from orchestrator.api.dependencies import get_pool_dep
+from orchestrator.db.pool import PoolError
+
+if TYPE_CHECKING:
+    from orchestrator.db.pool import Pool
+
+_log = structlog.get_logger(__name__)
+router = APIRouter(prefix="/api/v1/platforms/steam/library", tags=["sync"])
+
+
+@router.post(
+    "/sync",
+    responses={
+        202: {"description": "Job queued or existing in-flight job returned"},
+        401: {"description": "Missing/invalid bearer"},
+        503: {"description": "Database unavailable"},
+    },
+)
+async def trigger_library_sync(
+    pool: Pool = Depends(get_pool_dep),  # noqa: B008
+) -> JSONResponse:
+    try:
+        existing = await pool.read_one(
+            "SELECT id FROM jobs "
+            "WHERE kind='library_sync' AND platform='steam' "
+            "AND state IN ('queued','running') "
+            "ORDER BY id LIMIT 1"
+        )
+        if existing is not None:
+            _log.info("sync.library.dedup_hit", existing_job_id=existing["id"])
+            return JSONResponse(status_code=202, content={"job_id": int(existing["id"])})
+
+        await pool.execute_write(
+            "INSERT INTO jobs (kind, platform, state, source) VALUES (?, ?, 'queued', 'api')",
+            ("library_sync", "steam"),
+        )
+        new_row = await pool.read_one(
+            "SELECT id FROM jobs WHERE kind='library_sync' AND platform='steam' "
+            "AND state='queued' ORDER BY id DESC LIMIT 1"
+        )
+        if new_row is None:
+            # execute_write succeeded but the row isn't visible — pool/replica anomaly.
+            _log.error("sync.library.insert_invisible_after_write")
+            return JSONResponse(status_code=503, content={"detail": "database unavailable"})
+        _log.info("sync.library.queued", job_id=int(new_row["id"]))
+        return JSONResponse(status_code=202, content={"job_id": int(new_row["id"])})
+    except PoolError as e:
+        _log.error("sync.library.db_unavailable", reason=str(e))
+        return JSONResponse(status_code=503, content={"detail": "database unavailable"})

--- a/src/orchestrator/jobs/__init__.py
+++ b/src/orchestrator/jobs/__init__.py
@@ -1,0 +1,5 @@
+"""Async jobs subsystem (BL11).
+
+Generic single-loop asyncio job dispatcher. Handlers register against
+`jobs.kind` values via the registry in `handlers/__init__.py`.
+"""

--- a/src/orchestrator/jobs/handlers/__init__.py
+++ b/src/orchestrator/jobs/handlers/__init__.py
@@ -1,0 +1,40 @@
+"""Handler registry for the jobs worker (BL11).
+
+Built-in handlers (e.g. `library_sync`) auto-register on first import of
+this package; tests that exercise the worker loop typically call
+`clear()` first and register stubs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from orchestrator.jobs.worker import Deps
+
+Handler = Callable[[dict[str, Any], "Deps"], Awaitable[None]]
+
+HANDLERS: dict[str, Handler] = {}
+
+
+def register(kind: str, handler: Handler) -> None:
+    """Register a handler under a `jobs.kind` value. Idempotent re-registration
+    overwrites — tests use this when swapping a real handler for a stub.
+    """
+    HANDLERS[kind] = handler
+
+
+def clear() -> None:
+    """Test helper: empty the registry."""
+    HANDLERS.clear()
+
+
+def _register_builtin_handlers() -> None:
+    """Wire built-in handlers at import time."""
+    from orchestrator.jobs.handlers.library_sync import library_sync_handler
+
+    register("library_sync", library_sync_handler)
+
+
+_register_builtin_handlers()

--- a/src/orchestrator/jobs/handlers/library_sync.py
+++ b/src/orchestrator/jobs/handlers/library_sync.py
@@ -1,0 +1,83 @@
+"""Steam library sync handler (BL11).
+
+Called by the jobs worker when a `library_sync` job is claimed. Calls
+`library.enumerate` on the steam worker subprocess and upserts the
+operator's owned apps into the `games` table.
+
+Idempotent: `INSERT ... ON CONFLICT(platform, app_id) DO UPDATE` updates
+title/owned/metadata only — `status`, `cached_version`, and other
+lifecycle columns are preserved (plan P11).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+if TYPE_CHECKING:
+    from orchestrator.jobs.worker import Deps
+
+_log = structlog.get_logger(__name__)
+
+_UPSERT_SQL = (
+    "INSERT INTO games (platform, app_id, title, owned, metadata) "
+    "VALUES (?, ?, ?, 1, ?) "
+    "ON CONFLICT(platform, app_id) DO UPDATE SET "
+    "  title = excluded.title, "
+    "  owned = 1, "
+    "  metadata = excluded.metadata"
+)
+
+
+async def library_sync_handler(job: dict[str, Any], deps: Deps) -> None:
+    """Library sync handler.
+
+    Raises:
+        ValueError — `job.platform` is not 'steam'.
+        RuntimeError — `deps.steam_client` is None.
+        IPCTimeoutError / WorkerDiedError / WorkerDisabledError — propagate from
+            SteamWorkerClient. Worker loop translates to job state=failed.
+        SteamWorkerError — propagate (e.g. `NotAuthenticated`).
+    """
+    platform = job.get("platform")
+    if platform != "steam":
+        raise ValueError(f"library_sync only supports steam (got {platform!r})")
+    if deps.steam_client is None:
+        raise RuntimeError("steam_client is required for library_sync handler")
+
+    job_id = job.get("id")
+    _log.info("library_sync.enumerate.started", job_id=job_id)
+    result = await deps.steam_client.library_enumerate()
+    apps = result.get("apps") or []
+    _log.info("library_sync.enumerate.returned", job_id=job_id, app_count=len(apps))
+
+    upserted = 0
+    skipped = 0
+    for app in apps:
+        app_id_raw = app.get("app_id")
+        title = app.get("name")
+        depots = app.get("depots") or []
+        if app_id_raw is None or not isinstance(title, str) or not title:
+            skipped += 1
+            _log.warning(
+                "library_sync.skipped_app",
+                job_id=job_id,
+                reason="missing app_id or name",
+                raw=str(app)[:200],
+            )
+            continue
+        metadata = json.dumps(
+            {"depots": list(depots), "steam_packages": []},
+            separators=(",", ":"),
+        )
+        await deps.pool.execute_write(_UPSERT_SQL, ("steam", str(app_id_raw), title, metadata))
+        upserted += 1
+
+    _log.info(
+        "library_sync.upserted",
+        job_id=job_id,
+        upserted=upserted,
+        skipped=skipped,
+    )

--- a/src/orchestrator/jobs/worker.py
+++ b/src/orchestrator/jobs/worker.py
@@ -1,0 +1,153 @@
+"""Generic asyncio jobs dispatcher (BL11).
+
+Single-loop topology (spec D10). Atomic claim via SELECT-then-UPDATE
+inside `write_transaction()` so concurrent workers (if ever spawned)
+don't claim the same job. The loop catches every handler exception so
+one bad job can't bring the loop down.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from orchestrator.jobs.handlers import HANDLERS
+
+if TYPE_CHECKING:
+    from orchestrator.db.pool import Pool
+    from orchestrator.platform.steam.client import SteamWorkerClient
+
+_log = structlog.get_logger(__name__)
+
+JOB_ERROR_TRUNCATE = 200
+
+
+@dataclass(frozen=True, slots=True)
+class Deps:
+    """Handler dependency bundle. Tests construct minimal Deps; production
+    builds one in the FastAPI lifespan that carries the singleton
+    SteamWorkerClient.
+    """
+
+    pool: Pool
+    steam_client: SteamWorkerClient | None
+
+
+async def claim_next_job(pool: Pool) -> dict[str, Any] | None:
+    """Atomically claim the oldest queued job. Returns the row dict
+    (kind, id, game_id, platform, payload, state, started_at) with
+    `state='running'` and `started_at` set, or None if nothing queued.
+
+    Uses SELECT-then-UPDATE under BEGIN IMMEDIATE; concurrent claims on
+    the same pool serialize on the write transaction.
+    """
+    async with pool.write_transaction() as tx:
+        row = await tx.read_one("SELECT id FROM jobs WHERE state='queued' ORDER BY id LIMIT 1")
+        if row is None:
+            return None
+        await tx.execute(
+            "UPDATE jobs SET state='running', started_at=CURRENT_TIMESTAMP "
+            "WHERE id=? AND state='queued'",
+            (row["id"],),
+        )
+        return await tx.read_one(
+            "SELECT id, kind, game_id, platform, state, started_at, payload FROM jobs WHERE id=?",
+            (row["id"],),
+        )
+
+
+async def mark_succeeded(pool: Pool, job_id: int) -> None:
+    await pool.execute_write(
+        "UPDATE jobs SET state='succeeded', finished_at=CURRENT_TIMESTAMP, error=NULL "
+        "WHERE id=? AND state='running'",
+        (job_id,),
+    )
+
+
+async def mark_failed(pool: Pool, job_id: int, error: str) -> None:
+    truncated = error[:JOB_ERROR_TRUNCATE]
+    await pool.execute_write(
+        "UPDATE jobs SET state='failed', finished_at=CURRENT_TIMESTAMP, error=? "
+        "WHERE id=? AND state='running'",
+        (truncated, job_id),
+    )
+
+
+async def worker_loop(deps: Deps, *, shutdown: asyncio.Event, poll_interval_sec: float) -> None:
+    """Single-loop dispatcher. Runs until `shutdown` is set.
+
+    - Unknown `kind` → job marked failed; loop continues.
+    - Handler exception → job marked failed; loop continues.
+    - `claim_next_job` failure (DB outage) → log + back off + retry.
+    """
+    _log.info("jobs.worker.started", poll_interval=poll_interval_sec)
+    while not shutdown.is_set():
+        try:
+            row = await claim_next_job(deps.pool)
+        except Exception as e:
+            _log.error("jobs.worker.claim_failed", reason=str(e)[:JOB_ERROR_TRUNCATE])
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(shutdown.wait(), timeout=poll_interval_sec)
+            continue
+
+        if row is None:
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(shutdown.wait(), timeout=poll_interval_sec)
+            continue
+
+        job_id = int(row["id"])
+        kind = str(row["kind"])
+        _log.info("jobs.worker.claimed_job", job_id=job_id, kind=kind)
+
+        handler = HANDLERS.get(kind)
+        if handler is None:
+            await mark_failed(deps.pool, job_id, f"no handler for kind {kind!r}")
+            _log.warning("jobs.handler.no_handler", kind=kind, job_id=job_id)
+            continue
+
+        t0 = time.monotonic()
+        _log.info("jobs.handler.started", kind=kind, job_id=job_id)
+        try:
+            await handler(row, deps)
+        except Exception as e:
+            err = f"{type(e).__name__}: {str(e)[: JOB_ERROR_TRUNCATE - 50]}"
+            try:
+                await mark_failed(deps.pool, job_id, err)
+            except Exception as mark_e:
+                _log.error(
+                    "jobs.handler.mark_failed_failed",
+                    job_id=job_id,
+                    original_error=err,
+                    reason=str(mark_e)[:JOB_ERROR_TRUNCATE],
+                )
+            _log.warning(
+                "jobs.handler.failed",
+                kind=kind,
+                job_id=job_id,
+                kind_error=type(e).__name__,
+                elapsed_ms=int((time.monotonic() - t0) * 1000),
+            )
+            continue
+
+        try:
+            await mark_succeeded(deps.pool, job_id)
+        except Exception as e:
+            _log.error(
+                "jobs.handler.mark_succeeded_failed",
+                job_id=job_id,
+                reason=str(e)[:JOB_ERROR_TRUNCATE],
+            )
+            continue
+        _log.info(
+            "jobs.handler.completed",
+            kind=kind,
+            job_id=job_id,
+            elapsed_ms=int((time.monotonic() - t0) * 1000),
+        )
+
+    _log.info("jobs.worker.stopped")

--- a/src/orchestrator/platform/steam/client.py
+++ b/src/orchestrator/platform/steam/client.py
@@ -155,6 +155,14 @@ class SteamWorkerClient:
     async def auth_status(self) -> dict[str, Any]:
         return await self._send_and_await("auth.status", {})
 
+    async def library_enumerate(self) -> dict[str, Any]:
+        """Ask the worker to enumerate the operator's owned Steam apps (BL11).
+
+        Returns `{"apps": [{"app_id": int, "name": str, "depots": [int, ...]}, ...]}`.
+        Raises `SteamWorkerError(kind='NotAuthenticated')` if no Steam session.
+        """
+        return await self._send_and_await("library.enumerate", {})
+
     # --- internals -----------------------------------------------------
 
     async def _send(self, op: str, params: dict[str, Any]) -> str:

--- a/src/orchestrator/platform/steam/worker.py
+++ b/src/orchestrator/platform/steam/worker.py
@@ -21,7 +21,7 @@ import sys  # noqa: E402
 import time  # noqa: E402
 import uuid  # noqa: E402
 from pathlib import Path  # noqa: E402
-from typing import TypedDict  # noqa: E402
+from typing import Any, TypedDict  # noqa: E402
 
 # Steam-next imports (post-monkey-patch).
 from steam.client import SteamClient  # type: ignore[import-not-found]  # noqa: E402
@@ -41,13 +41,13 @@ class _Challenge(TypedDict):
 _challenges: dict[str, _Challenge] = {}  # challenge_id -> {username, password, expires_at}
 
 
-def _send(payload: dict[str, str | bool | dict[str, str | int]]) -> None:
+def _send(payload: dict[str, Any]) -> None:
     """Write a single JSON response line to stdout."""
     sys.stdout.write(json.dumps(payload, separators=(",", ":")) + "\n")
     sys.stdout.flush()
 
 
-def _ok(msg_id: str, result: dict[str, str | int | bool]) -> None:
+def _ok(msg_id: str, result: dict[str, Any]) -> None:
     _send({"msg_id": msg_id, "ok": True, "result": result})
 
 
@@ -167,10 +167,83 @@ def _handle_auth_status(msg_id: str, _params: dict[str, str]) -> None:
     _ok(msg_id, payload)
 
 
+def _handle_library_enumerate(msg_id: str, _params: dict[str, str]) -> None:
+    """Enumerate the operator's owned Steam apps (BL11).
+
+    Pattern follows Spike A: walk `_client.licenses` → resolve packages
+    via `get_product_info(packages=...)` → for each app_id in those
+    packages, resolve app details via `get_product_info(apps=...)`.
+
+    Live steam-next interaction is validated during UAT-6; unit tests
+    exercise the IPC contract via a stub.
+    """
+    global _client
+    if _client is None or not _client.connected or not _client.logged_on:
+        _err(msg_id, "NotAuthenticated", "no logged-in steam session")
+        return
+
+    try:
+        apps: list[dict[str, object]] = []
+        seen_app_ids: set[int] = set()
+        licenses = getattr(_client, "licenses", None) or []
+
+        package_ids: list[int] = []
+        for license_obj in licenses:
+            pkg_id = getattr(license_obj, "package_id", None)
+            if pkg_id is not None:
+                package_ids.append(int(pkg_id))
+
+        if not package_ids:
+            _ok(msg_id, {"apps": []})
+            return
+
+        # Batch-resolve packages to apps.
+        pkg_info_response = _client.get_product_info(packages=package_ids) or {}
+        packages_info = pkg_info_response.get("packages", {}) or {}
+        candidate_app_ids: list[int] = []
+        for _pkg_id_str, pkg_info in packages_info.items():
+            appid_map = (pkg_info or {}).get("appids", {}) or {}
+            for app_id_val in appid_map.values():
+                try:
+                    candidate_app_ids.append(int(app_id_val))
+                except (TypeError, ValueError):
+                    continue
+
+        if not candidate_app_ids:
+            _ok(msg_id, {"apps": []})
+            return
+
+        # Batch-resolve apps to product info. steam-next returns a dict
+        # keyed by app_id (string or int — defensively coerce).
+        app_info_response = _client.get_product_info(apps=candidate_app_ids) or {}
+        apps_info = app_info_response.get("apps", {}) or {}
+
+        for app_id in candidate_app_ids:
+            if app_id in seen_app_ids:
+                continue
+            seen_app_ids.add(app_id)
+            # Look up by both int and str keys (steam-next inconsistency).
+            info = apps_info.get(app_id) or apps_info.get(str(app_id)) or {}
+            common = info.get("common", {}) or {}
+            name = common.get("name") or f"app_{app_id}"
+            depots_dict = info.get("depots", {}) or {}
+            depot_ids: list[int] = []
+            for depot_key in depots_dict:
+                key_str = str(depot_key)
+                if key_str.isdigit():
+                    depot_ids.append(int(key_str))
+            apps.append({"app_id": int(app_id), "name": str(name), "depots": depot_ids})
+
+        _ok(msg_id, {"apps": apps})
+    except Exception as e:
+        _err(msg_id, "SteamAPIError", str(e)[:200])
+
+
 _HANDLERS = {
     "auth.begin": _handle_auth_begin,
     "auth.complete": _handle_auth_complete,
     "auth.status": _handle_auth_status,
+    "library.enumerate": _handle_library_enumerate,
 }
 
 

--- a/tests/api/test_auth_router.py
+++ b/tests/api/test_auth_router.py
@@ -412,3 +412,138 @@ class TestAuthCompletedTwoFactorLogEvent:
         events = [_json.loads(line) for line in out.splitlines() if line.strip()]
         ev_names = [e.get("event") for e in events]
         assert "platform.auth.completed_2fa" in ev_names
+
+
+class TestAutoQueueLibrarySync:
+    """BL11: both auth-success paths queue a `library_sync` job."""
+
+    async def test_auth_success_no_2fa_queues_library_sync(
+        self, client, stub_steam_client, populated_pool
+    ):
+        from orchestrator.api.routers.auth import get_steam_client_dep
+
+        # populated_pool seeds a 'succeeded' library_sync job (id=2). We're
+        # asserting on the QUEUED state only; the dedup check ignores
+        # terminal states.
+        stub_steam_client.scenario = "no_2fa"
+        client._transport.app.dependency_overrides[get_steam_client_dep] = lambda: stub_steam_client
+
+        r = await client.post(
+            "/api/v1/platforms/steam/auth",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+            json={"username": "u", "password": "p"},
+        )
+        assert r.status_code == 200
+
+        rows = await populated_pool.read_all(
+            "SELECT kind, platform, state, source FROM jobs "
+            "WHERE kind='library_sync' AND state='queued'"
+        )
+        assert len(rows) == 1
+        assert rows[0] == {
+            "kind": "library_sync",
+            "platform": "steam",
+            "state": "queued",
+            "source": "api",
+        }
+
+    async def test_auth_complete_2fa_queues_library_sync(
+        self, client, stub_steam_client, populated_pool
+    ):
+        from orchestrator.api.routers.auth import get_steam_client_dep
+
+        stub_steam_client.scenario = "needs_2fa"
+        client._transport.app.dependency_overrides[get_steam_client_dep] = lambda: stub_steam_client
+
+        begin = await client.post(
+            "/api/v1/platforms/steam/auth",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+            json={"username": "u", "password": "p"},
+        )
+        assert begin.status_code == 202
+        challenge_id = begin.json()["challenge_id"]
+
+        r = await client.post(
+            f"/api/v1/platforms/steam/auth/{challenge_id}",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+            json={"code": "12345"},
+        )
+        assert r.status_code == 200
+
+        rows = await populated_pool.read_all(
+            "SELECT kind FROM jobs WHERE kind='library_sync' AND state='queued'"
+        )
+        assert len(rows) == 1
+
+    async def test_auth_success_skips_queue_when_in_flight_job_exists(
+        self, client, stub_steam_client, populated_pool
+    ):
+        from orchestrator.api.routers.auth import get_steam_client_dep
+
+        # Seed an existing queued library_sync job.
+        await populated_pool.execute_write(
+            "INSERT INTO jobs (kind, platform, state, source) VALUES (?, ?, 'queued', 'api')",
+            ("library_sync", "steam"),
+        )
+        before = await populated_pool.read_all(
+            "SELECT id FROM jobs WHERE kind='library_sync' AND state='queued'"
+        )
+        assert len(before) == 1
+
+        stub_steam_client.scenario = "no_2fa"
+        client._transport.app.dependency_overrides[get_steam_client_dep] = lambda: stub_steam_client
+        r = await client.post(
+            "/api/v1/platforms/steam/auth",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+            json={"username": "u", "password": "p"},
+        )
+        assert r.status_code == 200
+
+        after = await populated_pool.read_all(
+            "SELECT id FROM jobs WHERE kind='library_sync' AND state='queued'"
+        )
+        assert len(after) == 1  # no second queued row created
+
+    async def test_production_queue_failure_swallowed_internally(
+        self, client, stub_steam_client, unit_app
+    ):
+        """The real contract: when the pool itself fails on the queue
+        INSERT, `_queue_library_sync_job_best_effort` catches PoolError,
+        logs warning, returns silently — auth still 200."""
+        from orchestrator.api.dependencies import get_pool_dep
+        from orchestrator.api.routers.auth import get_steam_client_dep
+        from orchestrator.db.pool import PoolError
+
+        write_count = [0]
+
+        class _PartiallyBrokenPool:
+            """Pool that succeeds on the platforms UPDATE but fails on
+            the jobs INSERT — simulates a partial outage where the
+            primary write is durable but the auto-trigger write fails.
+            """
+
+            async def execute_write(self, sql, params=()):
+                write_count[0] += 1
+                if "INSERT INTO jobs" in sql:
+                    raise PoolError("simulated outage on jobs insert")
+                # Pretend the platforms UPDATE succeeds.
+                return 1
+
+            async def read_one(self, sql, params=()):
+                # Dedup-check query returns "no existing job".
+                return None
+
+            async def read_all(self, sql, params=()):
+                return []
+
+        unit_app.dependency_overrides[get_pool_dep] = lambda: _PartiallyBrokenPool()
+        stub_steam_client.scenario = "no_2fa"
+        unit_app.dependency_overrides[get_steam_client_dep] = lambda: stub_steam_client
+
+        r = await client.post(
+            "/api/v1/platforms/steam/auth",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+            json={"username": "u", "password": "p"},
+        )
+        assert r.status_code == 200  # auth succeeded despite queue failure
+        assert write_count[0] >= 1  # the platforms UPDATE did run

--- a/tests/api/test_sync_router.py
+++ b/tests/api/test_sync_router.py
@@ -1,0 +1,134 @@
+"""Tests for POST /api/v1/platforms/steam/library/sync (BL11)."""
+
+from __future__ import annotations
+
+import pytest
+
+VALID_TOKEN = "a" * 32
+
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestQueueJob:
+    async def test_first_call_queues_job_and_returns_202(self, client, populated_pool):
+        r = await client.post(
+            "/api/v1/platforms/steam/library/sync",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r.status_code == 202
+        body = r.json()
+        assert "job_id" in body
+        assert isinstance(body["job_id"], int)
+
+        # The job actually lives in the table.
+        row = await populated_pool.read_one(
+            "SELECT kind, state, platform, source FROM jobs WHERE id=?",
+            (body["job_id"],),
+        )
+        assert row == {
+            "kind": "library_sync",
+            "state": "queued",
+            "platform": "steam",
+            "source": "api",
+        }
+
+
+class TestDedup:
+    async def test_concurrent_calls_return_same_job_id(self, client, populated_pool):
+        first = await client.post(
+            "/api/v1/platforms/steam/library/sync",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        second = await client.post(
+            "/api/v1/platforms/steam/library/sync",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert first.status_code == 202
+        assert second.status_code == 202
+        assert first.json()["job_id"] == second.json()["job_id"]
+
+        # Only one queued row exists.
+        rows = await populated_pool.read_all(
+            "SELECT id FROM jobs WHERE kind='library_sync' AND platform='steam' AND state='queued'"
+        )
+        assert len(rows) == 1
+
+    async def test_returns_running_job_id_when_in_progress(self, client, populated_pool):
+        # Seed a running library_sync job.
+        await populated_pool.execute_write(
+            "INSERT INTO jobs (kind, platform, state, source, started_at) "
+            "VALUES (?, ?, 'running', 'api', CURRENT_TIMESTAMP)",
+            ("library_sync", "steam"),
+        )
+        running_id = (
+            await populated_pool.read_one(
+                "SELECT id FROM jobs WHERE state='running' AND kind='library_sync'"
+            )
+        )["id"]
+
+        r = await client.post(
+            "/api/v1/platforms/steam/library/sync",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r.status_code == 202
+        assert r.json()["job_id"] == running_id
+
+    async def test_new_job_returned_after_finished_succeeded(self, client, populated_pool):
+        # populated_pool already contains a succeeded library_sync job (id=2).
+        succeeded = await populated_pool.read_one(
+            "SELECT id FROM jobs WHERE kind='library_sync' AND state='succeeded' "
+            "ORDER BY id LIMIT 1"
+        )
+        assert succeeded is not None, "populated_pool should seed a succeeded job"
+        succeeded_id = succeeded["id"]
+
+        r = await client.post(
+            "/api/v1/platforms/steam/library/sync",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r.status_code == 202
+        new_id = r.json()["job_id"]
+        assert new_id != succeeded_id
+
+        row = await populated_pool.read_one("SELECT state FROM jobs WHERE id=?", (new_id,))
+        assert row["state"] == "queued"
+
+
+class TestAuthBoundary:
+    async def test_missing_bearer_returns_401(self, client):
+        r = await client.post("/api/v1/platforms/steam/library/sync")
+        assert r.status_code == 401
+
+    async def test_wrong_bearer_returns_401(self, client):
+        r = await client.post(
+            "/api/v1/platforms/steam/library/sync",
+            headers={"Authorization": "Bearer wrong-token-of-32-characters!!!"},
+        )
+        assert r.status_code == 401
+
+
+class TestPoolFailure:
+    async def test_db_failure_returns_503(self, unit_app):
+        """Override get_pool_dep with a broken pool that raises PoolError."""
+        from orchestrator.api.dependencies import get_pool_dep
+        from orchestrator.db.pool import PoolError
+
+        class _BrokenPool:
+            async def read_one(self, *_a, **_kw):
+                raise PoolError("simulated db outage")
+
+            async def execute_write(self, *_a, **_kw):
+                raise PoolError("simulated db outage")
+
+        unit_app.dependency_overrides[get_pool_dep] = lambda: _BrokenPool()
+
+        import httpx
+
+        transport = httpx.ASGITransport(app=unit_app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as c:
+            r = await c.post(
+                "/api/v1/platforms/steam/library/sync",
+                headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+            )
+        assert r.status_code == 503

--- a/tests/jobs/conftest.py
+++ b/tests/jobs/conftest.py
@@ -1,0 +1,39 @@
+"""Shared fixtures for tests/jobs/.
+
+Reuses the `pool` fixture from tests/db/conftest.py via direct import.
+Adds a `jobs_handler_clean_registry` autouse fixture so each test gets
+the builtin HANDLERS registry restored after running — tests that
+re-register stubs don't leak across the suite.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Re-use the pool fixtures from tests/db/conftest.py — these are
+# discoverable as long as conftest.py at tests/ level is loaded, but
+# explicit import for clarity.
+from tests.db.conftest import (  # noqa: F401
+    _isolated_env,
+    db_path,
+    mem_pool,
+    pool,
+    populated_pool,
+)
+
+
+@pytest.fixture(autouse=True)
+def jobs_handler_clean_registry():
+    """Snapshot the HANDLERS dict before each test and restore after.
+
+    Tests that call `clear()` + `register(stub)` mutate the module-level
+    registry; without this fixture those mutations leak.
+    """
+    from orchestrator.jobs.handlers import HANDLERS
+
+    snapshot = dict(HANDLERS)
+    try:
+        yield
+    finally:
+        HANDLERS.clear()
+        HANDLERS.update(snapshot)

--- a/tests/jobs/test_library_sync_handler.py
+++ b/tests/jobs/test_library_sync_handler.py
@@ -1,0 +1,201 @@
+"""Tests for orchestrator.jobs.handlers.library_sync (BL11)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from orchestrator.jobs.handlers.library_sync import library_sync_handler
+from orchestrator.jobs.worker import Deps
+
+pytestmark = pytest.mark.asyncio
+
+
+class _StubSteam:
+    """Minimal stand-in for SteamWorkerClient — only `library_enumerate()`
+    is exercised by the handler."""
+
+    def __init__(
+        self,
+        result: dict[str, Any] | None = None,
+        raises: BaseException | None = None,
+    ) -> None:
+        self._result = result or {"apps": []}
+        self._raises = raises
+        self.calls = 0
+
+    async def library_enumerate(self) -> dict[str, Any]:
+        self.calls += 1
+        if self._raises is not None:
+            raise self._raises
+        return self._result
+
+
+def _job(platform: str = "steam") -> dict[str, Any]:
+    return {
+        "id": 1,
+        "kind": "library_sync",
+        "platform": platform,
+        "game_id": None,
+        "payload": None,
+    }
+
+
+class TestUpsertHappyPath:
+    async def test_upserts_owned_games(self, pool):
+        stub = _StubSteam(
+            result={
+                "apps": [
+                    {"app_id": 730, "name": "Counter-Strike 2", "depots": [731, 734]},
+                    {"app_id": 440, "name": "Team Fortress 2", "depots": []},
+                ]
+            }
+        )
+        await library_sync_handler(_job(), Deps(pool=pool, steam_client=stub))
+
+        rows = await pool.read_all(
+            "SELECT platform, app_id, title, owned, metadata FROM games ORDER BY app_id"
+        )
+        assert len(rows) == 2
+        cs2 = next(r for r in rows if r["app_id"] == "730")
+        assert cs2["title"] == "Counter-Strike 2"
+        assert cs2["owned"] == 1
+        md = json.loads(cs2["metadata"])
+        assert md["depots"] == [731, 734]
+        assert md["steam_packages"] == []
+
+    async def test_empty_library_zero_inserts(self, pool):
+        stub = _StubSteam(result={"apps": []})
+        await library_sync_handler(_job(), Deps(pool=pool, steam_client=stub))
+        rows = await pool.read_all("SELECT id FROM games")
+        assert rows == []
+
+    async def test_skips_apps_with_missing_id(self, pool):
+        stub = _StubSteam(
+            result={
+                "apps": [
+                    {"app_id": 730, "name": "CS2", "depots": []},
+                    {"name": "no app_id here", "depots": []},  # bad
+                    {"app_id": 440, "name": "TF2", "depots": []},
+                ]
+            }
+        )
+        await library_sync_handler(_job(), Deps(pool=pool, steam_client=stub))
+        rows = await pool.read_all("SELECT app_id FROM games ORDER BY app_id")
+        assert {r["app_id"] for r in rows} == {"730", "440"}
+
+    async def test_skips_apps_with_missing_name(self, pool):
+        stub = _StubSteam(
+            result={
+                "apps": [
+                    {"app_id": 730, "name": "", "depots": []},  # empty
+                    {"app_id": 440, "name": "TF2", "depots": []},
+                ]
+            }
+        )
+        await library_sync_handler(_job(), Deps(pool=pool, steam_client=stub))
+        rows = await pool.read_all("SELECT app_id FROM games")
+        assert [r["app_id"] for r in rows] == ["440"]
+
+    async def test_converts_int_app_id_to_string(self, pool):
+        stub = _StubSteam(result={"apps": [{"app_id": 999, "name": "x", "depots": []}]})
+        await library_sync_handler(_job(), Deps(pool=pool, steam_client=stub))
+        row = await pool.read_one("SELECT app_id FROM games LIMIT 1")
+        assert row["app_id"] == "999"
+        assert isinstance(row["app_id"], str)
+
+
+class TestIdempotency:
+    async def test_re_sync_no_duplicate_rows(self, pool):
+        stub = _StubSteam(result={"apps": [{"app_id": 730, "name": "CS2", "depots": [731]}]})
+        await library_sync_handler(_job(), Deps(pool=pool, steam_client=stub))
+        await library_sync_handler(_job(), Deps(pool=pool, steam_client=stub))
+        rows = await pool.read_all("SELECT app_id FROM games")
+        assert len(rows) == 1
+
+    async def test_re_sync_updates_title_and_metadata(self, pool):
+        stub_v1 = _StubSteam(
+            result={
+                "apps": [
+                    {
+                        "app_id": 730,
+                        "name": "Counter-Strike: Global Offensive",
+                        "depots": [731],
+                    }
+                ]
+            }
+        )
+        stub_v2 = _StubSteam(
+            result={
+                "apps": [
+                    {
+                        "app_id": 730,
+                        "name": "Counter-Strike 2",
+                        "depots": [731, 734],
+                    }
+                ]
+            }
+        )
+
+        await library_sync_handler(_job(), Deps(pool=pool, steam_client=stub_v1))
+        await library_sync_handler(_job(), Deps(pool=pool, steam_client=stub_v2))
+
+        row = await pool.read_one("SELECT title, metadata FROM games WHERE app_id=?", ("730",))
+        assert row["title"] == "Counter-Strike 2"
+        assert json.loads(row["metadata"])["depots"] == [731, 734]
+
+    async def test_re_sync_preserves_status_cached_version_etc(self, pool):
+        # Pre-seed a game with downstream state populated.
+        await pool.execute_write(
+            "INSERT INTO games (platform, app_id, title, owned, status, "
+            "cached_version, current_version, last_validated_at) "
+            "VALUES (?, ?, ?, 1, 'up_to_date', 'v1', 'v1', '2026-05-01T00:00:00Z')",
+            ("steam", "730", "CS:GO"),
+        )
+        stub = _StubSteam(
+            result={"apps": [{"app_id": 730, "name": "Counter-Strike 2", "depots": []}]}
+        )
+        await library_sync_handler(_job(), Deps(pool=pool, steam_client=stub))
+
+        row = await pool.read_one(
+            "SELECT title, status, cached_version, current_version, last_validated_at "
+            "FROM games WHERE app_id=?",
+            ("730",),
+        )
+        assert row["title"] == "Counter-Strike 2"
+        assert row["status"] == "up_to_date"
+        assert row["cached_version"] == "v1"
+        assert row["current_version"] == "v1"
+        assert row["last_validated_at"] == "2026-05-01T00:00:00Z"
+
+
+class TestErrorPropagation:
+    async def test_rejects_non_steam_platform(self, pool):
+        stub = _StubSteam()
+        with pytest.raises(ValueError, match="library_sync only supports steam"):
+            await library_sync_handler(_job(platform="epic"), Deps(pool=pool, steam_client=stub))
+        assert stub.calls == 0  # didn't even ask the worker
+
+    async def test_requires_steam_client(self, pool):
+        with pytest.raises(RuntimeError, match="steam_client is required"):
+            await library_sync_handler(_job(), Deps(pool=pool, steam_client=None))
+
+    async def test_steam_worker_error_propagates(self, pool):
+        from orchestrator.platform.steam.client import SteamWorkerError
+
+        stub = _StubSteam(raises=SteamWorkerError("NotAuthenticated", "no session"))
+        with pytest.raises(SteamWorkerError):
+            await library_sync_handler(_job(), Deps(pool=pool, steam_client=stub))
+        rows = await pool.read_all("SELECT id FROM games")
+        assert rows == []  # no partial writes
+
+    async def test_ipc_timeout_propagates_no_partial_writes(self, pool):
+        from orchestrator.platform.steam.client import IPCTimeoutError
+
+        stub = _StubSteam(raises=IPCTimeoutError("worker timeout"))
+        with pytest.raises(IPCTimeoutError):
+            await library_sync_handler(_job(), Deps(pool=pool, steam_client=stub))
+        rows = await pool.read_all("SELECT id FROM games")
+        assert rows == []

--- a/tests/jobs/test_worker.py
+++ b/tests/jobs/test_worker.py
@@ -1,0 +1,249 @@
+"""Tests for orchestrator.jobs.worker — generic asyncio dispatcher (BL11)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from orchestrator.jobs.handlers import HANDLERS, clear, register
+from orchestrator.jobs.worker import (
+    Deps,
+    claim_next_job,
+    mark_failed,
+    mark_succeeded,
+    worker_loop,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _queue_job(pool, kind="library_sync", platform="steam"):
+    await pool.execute_write(
+        "INSERT INTO jobs (kind, platform, state, source) VALUES (?, ?, 'queued', 'api')",
+        (kind, platform),
+    )
+
+
+class TestClaimNextJob:
+    async def test_returns_none_when_empty(self, pool):
+        assert await claim_next_job(pool) is None
+
+    async def test_returns_queued_job_with_state_running(self, pool):
+        await _queue_job(pool)
+        row = await claim_next_job(pool)
+        assert row is not None
+        assert row["kind"] == "library_sync"
+        assert row["state"] == "running"
+        assert row["started_at"] is not None
+
+    async def test_skips_already_claimed_jobs(self, pool):
+        await _queue_job(pool)
+        await _queue_job(pool)
+        first = await claim_next_job(pool)
+        second = await claim_next_job(pool)
+        assert first is not None and second is not None
+        assert first["id"] != second["id"]
+        # A third claim on now-empty queue → None.
+        assert await claim_next_job(pool) is None
+
+    async def test_picks_oldest_first(self, pool):
+        await _queue_job(pool, kind="library_sync")
+        await _queue_job(pool, kind="prefill")
+        first = await claim_next_job(pool)
+        assert first is not None
+        assert first["kind"] == "library_sync"
+
+    async def test_atomic_under_concurrency(self, pool):
+        """Two parallel claim_next_job calls must return distinct rows."""
+        for _ in range(4):
+            await _queue_job(pool)
+        results = await asyncio.gather(
+            claim_next_job(pool),
+            claim_next_job(pool),
+            claim_next_job(pool),
+            claim_next_job(pool),
+        )
+        ids = {r["id"] for r in results if r is not None}
+        assert len(ids) == 4
+
+
+class TestMarkSucceededFailed:
+    async def test_mark_succeeded(self, pool):
+        await _queue_job(pool)
+        row = await claim_next_job(pool)
+        assert row is not None
+        await mark_succeeded(pool, int(row["id"]))
+        after = await pool.read_one(
+            "SELECT state, finished_at, error FROM jobs WHERE id=?", (row["id"],)
+        )
+        assert after["state"] == "succeeded"
+        assert after["finished_at"] is not None
+        assert after["error"] is None
+
+    async def test_mark_failed_truncates_to_200(self, pool):
+        await _queue_job(pool)
+        row = await claim_next_job(pool)
+        assert row is not None
+        await mark_failed(pool, int(row["id"]), "x" * 500)
+        after = await pool.read_one("SELECT state, error FROM jobs WHERE id=?", (row["id"],))
+        assert after["state"] == "failed"
+        assert len(after["error"]) == 200
+
+    async def test_mark_succeeded_only_affects_running(self, pool):
+        # Queued (no started_at) — mark_succeeded should NOT promote it.
+        await _queue_job(pool)
+        await mark_succeeded(pool, 1)
+        after = await pool.read_one("SELECT state FROM jobs WHERE id=1")
+        assert after["state"] == "queued"
+
+
+class TestWorkerLoopDispatch:
+    async def test_dispatches_to_registered_handler(self, pool):
+        called: list[int] = []
+
+        async def my_handler(row, deps):
+            called.append(int(row["id"]))
+
+        clear()
+        register("library_sync", my_handler)
+
+        await _queue_job(pool)
+
+        shutdown = asyncio.Event()
+        deps = Deps(pool=pool, steam_client=None)
+
+        async def stopper():
+            for _ in range(100):
+                if called:
+                    break
+                await asyncio.sleep(0.01)
+            shutdown.set()
+
+        await asyncio.gather(
+            worker_loop(deps, shutdown=shutdown, poll_interval_sec=0.02),
+            stopper(),
+        )
+        assert called == [1]
+        after = await pool.read_one("SELECT state FROM jobs WHERE id=1")
+        assert after["state"] == "succeeded"
+
+    async def test_unknown_kind_marked_failed(self, pool):
+        clear()
+        # Use 'sweep' — a valid kind per CHECK constraint that has no handler registered.
+        await _queue_job(pool, kind="sweep")
+
+        shutdown = asyncio.Event()
+        deps = Deps(pool=pool, steam_client=None)
+
+        async def stopper():
+            for _ in range(100):
+                row = await pool.read_one("SELECT state FROM jobs WHERE id=1")
+                if row and row["state"] == "failed":
+                    break
+                await asyncio.sleep(0.01)
+            shutdown.set()
+
+        await asyncio.gather(
+            worker_loop(deps, shutdown=shutdown, poll_interval_sec=0.02),
+            stopper(),
+        )
+        row = await pool.read_one("SELECT state, error FROM jobs WHERE id=1")
+        assert row["state"] == "failed"
+        assert "no handler for kind 'sweep'" in row["error"]
+
+    async def test_handler_crash_does_not_kill_loop(self, pool):
+        crashed: list[int] = []
+        ran: list[int] = []
+
+        async def crasher(row, deps):
+            crashed.append(int(row["id"]))
+            raise RuntimeError("kaboom")
+
+        async def good(row, deps):
+            ran.append(int(row["id"]))
+
+        clear()
+        register("library_sync", crasher)
+        register("prefill", good)
+
+        await _queue_job(pool, kind="library_sync")
+        await _queue_job(pool, kind="prefill")
+
+        shutdown = asyncio.Event()
+        deps = Deps(pool=pool, steam_client=None)
+
+        async def stopper():
+            for _ in range(200):
+                if ran:
+                    break
+                await asyncio.sleep(0.01)
+            shutdown.set()
+
+        await asyncio.gather(
+            worker_loop(deps, shutdown=shutdown, poll_interval_sec=0.02),
+            stopper(),
+        )
+        assert crashed == [1]
+        assert ran == [2]
+        row1 = await pool.read_one("SELECT state, error FROM jobs WHERE id=1")
+        row2 = await pool.read_one("SELECT state FROM jobs WHERE id=2")
+        assert row1["state"] == "failed"
+        assert "RuntimeError" in row1["error"]
+        assert row2["state"] == "succeeded"
+
+    async def test_loop_exits_promptly_on_shutdown(self, pool):
+        """Empty queue + shutdown.set() should exit within one poll interval."""
+        clear()
+        shutdown = asyncio.Event()
+        deps = Deps(pool=pool, steam_client=None)
+
+        async def stopper():
+            await asyncio.sleep(0.05)
+            shutdown.set()
+
+        # poll_interval=2.0 means without proper wait-on-event the loop
+        # would sleep for 2s on empty queue. Asserting it exits within
+        # 0.5s proves the asyncio.wait_for(shutdown.wait(),...) pattern.
+        await asyncio.wait_for(
+            asyncio.gather(
+                worker_loop(deps, shutdown=shutdown, poll_interval_sec=2.0),
+                stopper(),
+            ),
+            timeout=0.5,
+        )
+
+    async def test_handler_succeeded_after_normal_completion(self, pool):
+        clear()
+
+        async def noop(row, deps):
+            return
+
+        register("library_sync", noop)
+        await _queue_job(pool)
+
+        shutdown = asyncio.Event()
+        deps = Deps(pool=pool, steam_client=None)
+
+        async def stopper():
+            for _ in range(100):
+                row = await pool.read_one("SELECT state FROM jobs WHERE id=1")
+                if row and row["state"] in ("succeeded", "failed"):
+                    break
+                await asyncio.sleep(0.01)
+            shutdown.set()
+
+        await asyncio.gather(
+            worker_loop(deps, shutdown=shutdown, poll_interval_sec=0.02),
+            stopper(),
+        )
+        row = await pool.read_one("SELECT state, finished_at FROM jobs WHERE id=1")
+        assert row["state"] == "succeeded"
+        assert row["finished_at"] is not None
+
+
+class TestBuiltinRegistration:
+    async def test_library_sync_handler_is_registered_at_import(self):
+        # The autouse fixture restores the snapshot, which was taken
+        # after handlers/__init__._register_builtin_handlers ran.
+        assert "library_sync" in HANDLERS

--- a/tests/platform/steam/test_client_unit.py
+++ b/tests/platform/steam/test_client_unit.py
@@ -122,6 +122,57 @@ class TestSteamWorkerClientErrorPath:
             await client._await_response(msg_id)
 
 
+class TestLibraryEnumerate:
+    """BL11: SteamWorkerClient.library_enumerate() round-trips the IPC op."""
+
+    async def test_returns_apps_list(self):
+        from orchestrator.platform.steam.client import SteamWorkerClient
+
+        client = SteamWorkerClient.__new__(SteamWorkerClient)
+        client._writer = _StubWriter()
+        client._pending = {}
+        client._timeout = 5.0
+
+        async def round_trip():
+            # Spy on `_send` so we can synthesize the response with the
+            # auto-generated msg_id.
+            msg_id = await client._send("library.enumerate", {})
+            line = (
+                b'{"msg_id":"'
+                + msg_id.encode()
+                + b'","ok":true,"result":{"apps":['
+                + b'{"app_id":730,"name":"CS2","depots":[731]}'
+                + b"]}}\n"
+            )
+            await client._on_response_line(line)
+            return await client._await_response(msg_id)
+
+        result = await round_trip()
+        assert result == {"apps": [{"app_id": 730, "name": "CS2", "depots": [731]}]}
+
+    async def test_not_authenticated_raises_steam_worker_error(self):
+        from orchestrator.platform.steam.client import (
+            SteamWorkerClient,
+            SteamWorkerError,
+        )
+
+        client = SteamWorkerClient.__new__(SteamWorkerClient)
+        client._writer = _StubWriter()
+        client._pending = {}
+        client._timeout = 5.0
+
+        msg_id = await client._send("library.enumerate", {})
+        line = (
+            b'{"msg_id":"'
+            + msg_id.encode()
+            + b'","ok":false,"error":{"kind":"NotAuthenticated","message":"no session"}}\n'
+        )
+        await client._on_response_line(line)
+        with pytest.raises(SteamWorkerError) as exc_info:
+            await client._await_response(msg_id)
+        assert exc_info.value.kind == "NotAuthenticated"
+
+
 class TestRestartStormGuard:
     async def test_max_restart_attempts_exhausted_marks_disabled(self):
         from orchestrator.platform.steam.client import SteamWorkerClient


### PR DESCRIPTION
## Summary

BL11 ships the asyncio jobs subsystem and Steam library enumeration end-to-end. Second of three Build Loops in the F1 (Steam credentials + fetcher) milestone.

**Spec:** [`docs/superpowers/specs/2026-05-24-f1-steam-credentials-fetcher-design.md`](docs/superpowers/specs/2026-05-24-f1-steam-credentials-fetcher-design.md) §5
**Plan:** [`docs/superpowers/plans/2026-05-25-bl11-library-sync.md`](docs/superpowers/plans/2026-05-25-bl11-library-sync.md)
**Security audit:** [`docs/security-audits/bl11-library-sync-security-audit.md`](docs/security-audits/bl11-library-sync-security-audit.md) — 0 findings.

## What landed

- **`src/orchestrator/jobs/`** — generic asyncio job dispatcher. Single-loop topology (spec D10), atomic SELECT-then-UPDATE claim inside `pool.write_transaction()` (plan P2; routes around `execute_write` discarding cursor data). Handler registry indexed by `jobs.kind`.
- **`library_sync` handler** — calls the steam worker's new `library.enumerate` IPC op; upserts the `games` table via `INSERT ... ON CONFLICT(platform, app_id) DO UPDATE`. Idempotent re-sync; downstream lifecycle columns (`status`, `cached_version`, `last_validated_at`) preserved.
- **`library.enumerate`** on the steam worker — walks `_client.licenses` → `get_product_info(packages=...)` → `get_product_info(apps=...)`. Live Steam validation deferred to UAT-6.
- **`SteamWorkerClient.library_enumerate()`** — async method, mirrors `auth_status()`.
- **`POST /api/v1/platforms/steam/library/sync`** — manual trigger, bearer-required, handler-side dedup of queued/running jobs.
- **Auto-trigger** — both Steam auth-success paths (no-2FA and 2FA) queue a `library_sync` job; queue failures are best-effort (logged, do not fail the auth response).
- **FastAPI lifespan** — spawns + cleanly stops the jobs worker (5 s join timeout, then cancel) ahead of steam-client + pool shutdown.
- **`ORCH_JOBS_WORKER_POLL_INTERVAL_SEC`** Settings field documented in README env-var table.

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean (90 files)
- [x] `mypy --strict src/` clean (37 source files)
- [x] `gitleaks detect` — no leaks
- [x] `pytest tests/` — **722 pass** (39 new). 1 pre-existing skip on `test_licenses.py` (pip-licenses CLI not in venv) is unrelated.
- [x] 39 new tests cover: atomic claim concurrency, mark_succeeded/failed semantics, dispatcher dispatch + unknown-kind + crash isolation + prompt shutdown, handler upsert happy paths, idempotency, lifecycle-column preservation, error propagation without partial writes, sync endpoint queue + dedup (queued/running/finished) + auth + 503, auto-trigger queue on both paths + DB-failure swallow, `library_enumerate` IPC round-trip + `NotAuthenticated` mapping.

## Gate impact

**Test-gate counter: 2/2** — UAT-6 will be required before BL12 (manifest fetcher).

## Closes

No GitHub issues directly closed (BL11 is the second milestone of F1, not a bug burndown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)