### PR TITLE
feat(lancache): ID2 lancache self-test — /health surfaces real reachability

### DIFF
--- a/.claude/build-progress.json
+++ b/.claude/build-progress.json
@@ -11,10 +11,11 @@
     "BL8-F9-jobs-readonly",
     "BL9-F9-manifests-readonly",
     "BL10-F1-steam-auth-substrate",
-    "BL11-library-sync"
+    "BL11-library-sync",
+    "ID2-lancache-self-test"
   ],
-  "features_since_last_test": 0,
-  "features_since_last_health_check": 1,
+  "features_since_last_test": 1,
+  "features_since_last_health_check": 2,
   "test_interval": 2,
   "last_test_session": "2026-05-27",
   "testing_required": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Added — ID2 Lancache self-test — 2026-05-27
+
+Implements the ID2 implicit-dependency feature from `docs/phase-0/frd.md:645` and `docs/phase-1/architecture-proposal.md` — the operator-facing `/api/v1/health` endpoint now surfaces a real `lancache_reachable` boolean derived from an HTTP probe to `<lancache>/lancache-heartbeat`, replacing the BL5 stub-false.
+
+- New `src/orchestrator/lancache/` package with `LancacheProbe` (async, cache-TTL'd, concurrency-safe via `asyncio.Lock`). 16 tests cover happy path, every documented httpx failure mode, TTL cache hit/miss/refresh, concurrent-probe collapse, and URL validation.
+- New Settings fields:
+  - `lancache_heartbeat_url` (default `http://lancache/lancache-heartbeat`)
+  - `lancache_probe_timeout_sec` (default 5.0, range 0–60)
+  - `lancache_probe_cache_ttl_sec` (default 30.0, range 0–600)
+- FastAPI lifespan startup constructs the singleton probe and stashes it on `app.state.lancache_probe`. The `/health` router calls `await probe.probe()` per request (cache-fast — usually no IO).
+- Tests in `tests/api/test_health_endpoint.py` verify the wiring through stub probes; the no-lifespan `unit_app` fixture falls back to `False` instead of crashing.
+
 ### Fixed — Post-UAT-6 SEV-2 batch — 2026-05-27
 
 Closes #107 (licenses enumeration) and #109 (`get_product_info` timeout) — both surfaced by the UAT-6 live operator session against a real Steam account.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -540,4 +540,66 @@ Steam auth-success paths auto-queue a `library_sync` job (best-effort).
 
 ---
 
+## Feature 12: ID2 — Lancache Self-Test
+
+**Phase Built:** 2 (Milestone B, Build Loop 12)
+**Status:** Complete (2026-05-27)
+
+**Summary:** Implements the ID2 implicit-dependency: a self-test that
+exposes `lancache_reachable` on `/api/v1/health` derived from a real
+HTTP probe of the lancache `lancache-heartbeat` endpoint. Replaces the
+BL5 hardcoded `False`. Probe is async, time-bounded (5s timeout
+default), cache-TTL'd (30s default) so /health requests don't hammer
+lancache, and concurrency-safe (asyncio.Lock collapses parallel
+callers onto a single in-flight HTTP request).
+
+**Key Interfaces:**
+  - `src/orchestrator/lancache/__init__.py` — new package marker
+  - `src/orchestrator/lancache/heartbeat.py` — `LancacheProbe` class
+    (`.probe()`, `.last_result()`, `.last_checked_at_mono()`, `.invalidate()`)
+  - `src/orchestrator/api/main.py` lifespan — constructs the probe on
+    boot, stashes on `app.state.lancache_probe`
+  - `src/orchestrator/api/routers/health.py` — `await probe.probe()`
+    per `/health` request; falls back to `False` if probe is absent
+    (e.g., no-lifespan test fixtures)
+  - Settings: `lancache_heartbeat_url`, `lancache_probe_timeout_sec`,
+    `lancache_probe_cache_ttl_sec`
+
+**Locked design decisions:**
+  - **Cache TTL pattern, not polling.** /health is a low-volume endpoint
+    (operator-driven + container HEALTHCHECK every 30s); avoid a
+    background polling task whose lifecycle has to track FastAPI's.
+  - **All failure modes → False.** Connect timeout, read timeout,
+    connect error, non-200, even unexpected exceptions — they all
+    surface as `lancache_reachable: false`. /health only needs the
+    boolean, and the structured log emits the failure cause.
+  - **No DI override of `app.state.lancache_probe` in tests.** The
+    no-lifespan `unit_app` fixture relies on the `getattr(..., None)`
+    fallback in the router; explicit overrides happen via direct
+    `app.state.lancache_probe = stub` assignment (4 tests in
+    `test_health_endpoint.py`).
+
+**Test Coverage:** 16 new tests in `tests/lancache/test_heartbeat.py`
+(initial state, success path, every documented httpx error, TTL cache
+hit/miss/refresh/invalidate, concurrent-probe collapse,
+last_checked_at advancement, URL validation). 4 new tests in
+`tests/api/test_health_endpoint.py` (probe-absent fallback,
+probe-up wiring, probe-down wiring, removal of the now-stale
+"3 stubbed subsystems" assertion). 7 new tests in
+`tests/core/test_settings.py` for the 3 new fields' defaults +
+boundaries. Full suite: 790 pass.
+
+**Related ADRs:**
+  - None new — design lives in FRD ID2 + `docs/phase-1/architecture-proposal.md`
+
+**Known Limitations:**
+  - `/health` still returns 503 because scheduler_running + validator_healthy
+    remain stub-false until those subsystems ship. ID2 alone doesn't flip
+    /health to 200; it makes one of the three "real" instead of stubbed.
+  - The probe's TTL means lancache-down detection latency is up to 30s
+    after the failure starts. Operators who want faster detection can
+    set `ORCH_LANCACHE_PROBE_CACHE_TTL_SEC=5` (or 0 for no caching).
+
+---
+
 <!-- Copy the section above for each new feature. Number sequentially. -->

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ The bearer token (`orchestrator_token`) is the only required field. Every other 
 | `ORCH_DB_MMAP_SIZE_BYTES` | int (0..16 GiB) | `268435456` (256 MiB) | mmap window, bytes (BL4) |
 | `ORCH_DB_JOURNAL_SIZE_LIMIT_BYTES` | int (1 MiB..1 GiB) | `67108864` (64 MiB) | WAL truncate threshold (BL4) |
 | `ORCH_JOBS_WORKER_POLL_INTERVAL_SEC` | float (0.05..60.0) | `1.0` | Empty-queue poll cadence for the jobs worker (BL11) |
+| `ORCH_LANCACHE_HEARTBEAT_URL` | URL | `http://lancache/lancache-heartbeat` | ID2 probe target — set to a 127.0.0.1 path if orchestrator is co-resident with lancache |
+| `ORCH_LANCACHE_PROBE_TIMEOUT_SEC` | float (0..60) | `5.0` | Per-probe httpx timeout |
+| `ORCH_LANCACHE_PROBE_CACHE_TTL_SEC` | float (0..600) | `30.0` | TTL for cached probe result; 0 disables cache |
 
 **DB pool memory baseline:** `(pool_readers + 1) × db_cache_size_kib + db_mmap_size_bytes`. Default config = `9 × 16 MiB + 256 MiB ≈ 400 MiB` resident. On memory-constrained hardware (e.g. DXP4800 NAS at 4 GB total), halve `ORCH_POOL_READERS` and `ORCH_DB_CACHE_SIZE_KIB` together — yields a `5 × 8 MiB + 256 MiB ≈ 296 MiB` profile. See [`FEATURES.md` — Feature 4](FEATURES.md) and [ADR-0011](docs/ADR%20documentation/0011-db-pool-architecture.md).
 

--- a/docs/security-audits/id2-lancache-self-test-security-audit.md
+++ b/docs/security-audits/id2-lancache-self-test-security-audit.md
@@ -1,0 +1,97 @@
+# Security Audit — ID2 Lancache Self-Test
+
+**Feature:** ID2-lancache-self-test
+**Audit date:** 2026-05-27
+**Audited modules:**
+- src/orchestrator/lancache/__init__.py
+- src/orchestrator/lancache/heartbeat.py
+- src/orchestrator/api/main.py (lifespan wiring)
+- src/orchestrator/api/routers/health.py (probe consumption)
+- src/orchestrator/core/settings.py (3 new fields)
+
+<!-- Last Updated: 2026-05-27 -->
+
+## Scope
+
+Post-implementation security review of the lancache heartbeat probe and
+its integration with `/api/v1/health`.
+
+## Methodology
+
+1. ruff / ruff format / mypy --strict — all clean (40 source files)
+2. gitleaks full-repo scan — no leaks
+3. semgrep p/owasp-top-ten on `src/orchestrator/lancache/` — 0 findings
+4. Manual review against threat-model entries TM-012 (log redaction),
+   TM-013 (SSRF), TM-014 (DoS via unbounded retry)
+5. Test coverage review — 27 new tests across 3 files cover the
+   security-relevant edge cases (timeout/error fallback, cache TTL
+   bounds, URL validation)
+
+## Findings
+
+**SEV-1: 0   SEV-2: 0   SEV-3: 0   SEV-4: 0**
+
+No new vulnerabilities introduced.
+
+## Threat-model walk
+
+- **TM-012 (log redaction):** MITIGATED. The probe logs only
+  `url=<configured_url>`, `error=<exception_class>`, `reason=<str(e)[:200]>`,
+  and `reachable=<bool>` — no credentials, no response bodies, no headers.
+  The lancache heartbeat is a public-LAN endpoint with no auth, so even
+  the URL itself isn't sensitive.
+
+- **TM-013 (SSRF — server forces backend to fetch attacker-controlled URLs):**
+  MITIGATED.
+  - The probe URL is configured via `Settings.lancache_heartbeat_url`,
+    which loads only from env vars / Docker secrets / .env files — operator-controlled, not attacker-controlled.
+  - Pydantic validates the URL at startup: rejects empty strings, max
+    length 2048. The `LancacheProbe.__init__` further rejects any URL
+    not starting with `http://` or `https://` — guards against
+    `file://`, `gopher://`, etc. that could exfiltrate via SSRF.
+  - The probe doesn't follow redirects automatically (httpx default
+    is `follow_redirects=False`) — even if lancache is replaced with
+    an attacker-controlled host, redirects don't propagate to other
+    targets.
+  - Probe runs only at /health requests, which are unauthenticated;
+    rate-limiting is handled by the 30s cache TTL — at most ~2 probes
+    per minute regardless of request volume.
+
+- **TM-014 (resource exhaustion via the probe):** MITIGATED.
+  - Per-call timeout: 5.0s (configurable 0–60s). httpx ConnectTimeout +
+    ReadTimeout + TimeoutException all caught.
+  - Cache TTL: 30.0s default (configurable 0–600s). Even if /health is
+    hammered, only one probe fires per TTL window.
+  - Concurrent /health requests serialize on `asyncio.Lock` — verified
+    by `test_concurrent_probes_collapse_to_single_call` (10 parallel
+    callers → 1 outbound HTTP call).
+  - No retry loop on failure. A failed probe simply caches False and
+    waits for the next TTL window. No backpressure, no hammer.
+
+## Defensive-programming review
+
+- `_refresh()` catches `Exception` as a last-resort guard so unexpected
+  failures (DNS pathology, library bugs) don't crash /health. Verified
+  by `test_unexpected_exception_returns_false`.
+- `last_checked_at_mono()` returns `None` until the first probe runs —
+  callers cannot mistakenly believe the cache is fresh before any IO
+  has happened.
+- URL validation happens in `__init__`, not at probe time — fail-fast
+  at lifespan startup if config is malformed.
+
+## Operator surfaces
+
+- `lancache.probe.network_error` (WARN) — every documented network
+  failure mode emits this with the exception class + truncated message.
+- `lancache.probe.unexpected_error` (ERROR) — defensive catch for
+  anything else; emits the exception class.
+- `lancache.probe.state_changed` (INFO) — emits when the probe result
+  flips, allowing operators to correlate lancache-down windows.
+
+No PII, no credentials, no response bodies in any log event.
+
+## Sign-off
+
+No SEV findings. ID2 cleared to ship.
+
+— Senior Security Engineer persona, 2026-05-27

--- a/src/orchestrator/api/main.py
+++ b/src/orchestrator/api/main.py
@@ -45,6 +45,7 @@ from orchestrator.db.pool import (
 )
 from orchestrator.jobs.worker import Deps as JobsDeps
 from orchestrator.jobs.worker import worker_loop as jobs_worker_loop
+from orchestrator.lancache.heartbeat import LancacheProbe
 from orchestrator.platform.steam.client import SteamWorkerClient
 
 if TYPE_CHECKING:
@@ -136,12 +137,26 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         poll_interval_sec=settings.jobs_worker_poll_interval_sec,
     )
 
+    # 5. Lancache self-test probe (ID2). Constructed once; the /health
+    # router calls `.probe()` per request, which is cached + concurrency-safe.
+    app.state.lancache_probe = LancacheProbe(
+        url=settings.lancache_heartbeat_url,
+        timeout_sec=settings.lancache_probe_timeout_sec,
+        cache_ttl_sec=settings.lancache_probe_cache_ttl_sec,
+    )
+    log.info(
+        "api.boot.lancache_probe_initialized",
+        url=settings.lancache_heartbeat_url,
+        timeout_sec=settings.lancache_probe_timeout_sec,
+        cache_ttl_sec=settings.lancache_probe_cache_ttl_sec,
+    )
+
     try:
-        # 5. Boot metadata
+        # 6. Boot metadata
         app.state.boot_time = time.monotonic()
         app.state.git_sha = os.environ.get("GIT_SHA", "unknown")
 
-        # 6. Deployment-hardening warning: surface non-loopback bind at boot.
+        # 7. Deployment-hardening warning: surface non-loopback bind at boot.
         # UAT-3 S2-D: detect non-loopback from any of three signals so an
         # operator running `uvicorn --host 0.0.0.0` from the CLI gets the
         # warning even without ORCH_API_HOST set.

--- a/src/orchestrator/api/routers/health.py
+++ b/src/orchestrator/api/routers/health.py
@@ -58,13 +58,22 @@ async def get_health(
     cache_path = Path(settings.lancache_nginx_cache_path)
     cache_volume_mounted = cache_path.is_dir()
 
+    # ID2 lancache reachability probe. `app.state.lancache_probe` is built
+    # in lifespan startup; `probe()` is cache-fast (no IO most of the time)
+    # and concurrency-safe. Tests that use the no-lifespan `unit_app`
+    # fixture omit this state — fall back to False rather than crashing.
+    probe = getattr(request.app.state, "lancache_probe", None)
+    lancache_reachable = False
+    if probe is not None:
+        lancache_reachable = await probe.probe()
+
     body = HealthResponse(
         status="ok" if pool_ok else "degraded",
         version=__version__,
         uptime_sec=int(time.monotonic() - request.app.state.boot_time),
-        # BL5 stubs — real in BL6+ as features land
+        # Remaining BL5 stubs — real when scheduler + validator subsystems ship.
         scheduler_running=False,
-        lancache_reachable=False,
+        lancache_reachable=lancache_reachable,
         cache_volume_mounted=cache_volume_mounted,
         validator_healthy=False,
         # UAT-3 S2-B: /api/v1/health is unauthenticated, so the git_sha

--- a/src/orchestrator/core/settings.py
+++ b/src/orchestrator/core/settings.py
@@ -73,6 +73,20 @@ class Settings(BaseSettings):
     cache_levels: str = Field(default="2:2", pattern=r"^\d+(:\d+)*$")
     chunk_concurrency: int = Field(default=32, ge=1, le=256)
 
+    # --- Lancache self-test (ID2) -----------------------------------
+    # Heartbeat URL — `http://<lancache>/lancache-heartbeat` returns
+    # 200 + identifier string when the lancache nginx is up. Default
+    # uses the compose service name; deployments where the orchestrator
+    # is co-resident with lancache (DNS bypass) should set this to
+    # `http://127.0.0.1/lancache-heartbeat` or similar.
+    lancache_heartbeat_url: str = Field(
+        default="http://lancache/lancache-heartbeat",
+        min_length=1,
+        max_length=2048,
+    )
+    lancache_probe_timeout_sec: float = Field(default=5.0, gt=0.0, le=60.0)
+    lancache_probe_cache_ttl_sec: float = Field(default=30.0, ge=0.0, le=600.0)
+
     # --- Misc --------------------------------------------------------
     manifest_size_cap_bytes: int = Field(default=134_217_728, gt=0)
     epic_refresh_buffer_sec: int = Field(default=600, ge=0)

--- a/src/orchestrator/lancache/__init__.py
+++ b/src/orchestrator/lancache/__init__.py
@@ -1,0 +1,8 @@
+"""Lancache integration subsystem (ID2 self-test + downstream features).
+
+This package owns the orchestrator's interactions with the lancache
+nginx cache as a SERVICE — heartbeat probes for /health, future
+prefill steering, future access-log tailing. The on-disk validator
+(F7, reads `lancache_nginx_cache_path`) is a separate subsystem that
+lives under `orchestrator.validator` when it ships.
+"""

--- a/src/orchestrator/lancache/heartbeat.py
+++ b/src/orchestrator/lancache/heartbeat.py
@@ -1,0 +1,138 @@
+"""Lancache heartbeat probe — ID2 self-test (FRD §5 + Bible §8.4).
+
+GET /lancache-heartbeat against the operator-configured lancache base
+URL. The probe is async, time-bounded (httpx per-call timeout), result-
+cached with a TTL to avoid hammering lancache on every /health call,
+and concurrency-safe (parallel callers collapse onto one in-flight
+request via an asyncio.Lock).
+
+Failure modes are treated uniformly as "not reachable" — connect
+timeout, read timeout, connect error, any non-200 status, even
+unexpected exceptions. The /health surface only needs a boolean.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import TYPE_CHECKING
+
+import httpx
+import structlog
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_log = structlog.get_logger(__name__)
+
+
+class LancacheProbe:
+    """Cached async HTTP probe of `GET <url>` for lancache reachability.
+
+    Lifecycle:
+        - Construct once at FastAPI lifespan startup
+        - `probe()` is awaitable; safe to call concurrently
+        - `last_result()` reads cached value without triggering a call
+        - `invalidate()` forces the next `probe()` to refresh
+    """
+
+    def __init__(
+        self,
+        *,
+        url: str,
+        timeout_sec: float = 5.0,
+        cache_ttl_sec: float = 30.0,
+        monotonic_fn: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if not url:
+            raise ValueError("url must be non-empty")
+        if not url.startswith(("http://", "https://")):
+            raise ValueError(f"url must start with http:// or https://; got {url!r}")
+        if timeout_sec <= 0:
+            raise ValueError("timeout_sec must be positive")
+        if cache_ttl_sec < 0:
+            raise ValueError("cache_ttl_sec must be non-negative")
+
+        self._url = url
+        self._timeout_sec = timeout_sec
+        self._cache_ttl_sec = cache_ttl_sec
+        self._monotonic = monotonic_fn
+
+        self._last_result: bool = False
+        self._last_checked_at_mono: float | None = None
+        # Single lock collapses concurrent probes onto one in-flight call.
+        self._refresh_lock = asyncio.Lock()
+
+    def last_result(self) -> bool:
+        return self._last_result
+
+    def last_checked_at_mono(self) -> float | None:
+        return self._last_checked_at_mono
+
+    def invalidate(self) -> None:
+        """Force the next probe() to ignore the TTL and refresh."""
+        self._last_checked_at_mono = None
+
+    def _cache_fresh(self) -> bool:
+        if self._last_checked_at_mono is None:
+            return False
+        age = self._monotonic() - self._last_checked_at_mono
+        return age < self._cache_ttl_sec
+
+    async def probe(self) -> bool:
+        """Refresh the cached probe result if stale, return the (now-)current
+        value. Never raises — all failure modes return False."""
+        # Fast path: TTL still valid, return cached value without any IO
+        # or lock contention.
+        if self._cache_fresh():
+            return self._last_result
+
+        # Slow path: serialize the refresh so 10 concurrent callers don't
+        # generate 10 outbound HTTP calls. Inside the lock we re-check
+        # freshness; the first caller that arrives does the work, the
+        # rest find a fresh cache and skip.
+        async with self._refresh_lock:
+            if self._cache_fresh():
+                return self._last_result
+            await self._refresh()
+        return self._last_result
+
+    async def _refresh(self) -> None:
+        ok = False
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout_sec) as client:
+                response = await client.get(self._url)
+                ok = response.status_code == 200
+        except (
+            httpx.ConnectTimeout,
+            httpx.ReadTimeout,
+            httpx.ConnectError,
+            httpx.NetworkError,
+            httpx.TimeoutException,
+        ) as e:
+            _log.warning(
+                "lancache.probe.network_error",
+                url=self._url,
+                error=type(e).__name__,
+                reason=str(e)[:200],
+            )
+        except Exception as e:
+            # Defensive: any other exception (DNS pathology, mis-typed
+            # response, library bug) must NOT crash /health.
+            _log.error(
+                "lancache.probe.unexpected_error",
+                url=self._url,
+                error=type(e).__name__,
+                reason=str(e)[:200],
+            )
+
+        previous = self._last_result
+        self._last_result = ok
+        self._last_checked_at_mono = self._monotonic()
+        if ok != previous:
+            _log.info(
+                "lancache.probe.state_changed",
+                url=self._url,
+                reachable=ok,
+                previous=previous,
+            )

--- a/tests/api/test_health_endpoint.py
+++ b/tests/api/test_health_endpoint.py
@@ -35,12 +35,52 @@ class TestHealthShipState:
         # populated_pool fixture has healthy pool → status="ok"
         assert body["status"] == "ok"
 
-    async def test_three_stubbed_subsystems_are_false_in_bl5(self, client):
+    async def test_remaining_stubbed_subsystems_are_false(self, client):
+        """scheduler_running + validator_healthy stay stubbed until those
+        subsystems ship. lancache_reachable is now wired to the probe
+        (ID2); the unit_app fixture omits app.state.lancache_probe so it
+        also reports False — exercised by the next test."""
         r = await client.get("/api/v1/health")
         body = r.json()
         assert body["scheduler_running"] is False
-        assert body["lancache_reachable"] is False
         assert body["validator_healthy"] is False
+
+    async def test_lancache_reachable_false_when_probe_absent(self, client):
+        """The unit_app fixture skips lifespan, so app.state.lancache_probe
+        is not set. /health must fall back to False rather than crashing."""
+        r = await client.get("/api/v1/health")
+        assert r.status_code == 503
+        body = r.json()
+        assert body["lancache_reachable"] is False
+
+    async def test_lancache_reachable_true_when_probe_reports_up(self, client):
+        """Inject a stub probe that always returns True; verify /health
+        surfaces the value."""
+
+        class _StubProbe:
+            async def probe(self):
+                return True
+
+        client._transport.app.state.lancache_probe = _StubProbe()
+        try:
+            r = await client.get("/api/v1/health")
+            body = r.json()
+            assert body["lancache_reachable"] is True
+        finally:
+            del client._transport.app.state.lancache_probe
+
+    async def test_lancache_reachable_false_when_probe_reports_down(self, client):
+        class _StubProbe:
+            async def probe(self):
+                return False
+
+        client._transport.app.state.lancache_probe = _StubProbe()
+        try:
+            r = await client.get("/api/v1/health")
+            body = r.json()
+            assert body["lancache_reachable"] is False
+        finally:
+            del client._transport.app.state.lancache_probe
 
 
 class TestHealthDynamicFields:

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -221,6 +221,39 @@ class TestFieldValidators:
         with pytest.raises(ValidationError):
             Settings(orchestrator_token=VALID_TOKEN, cors_origins=[""])
 
+    def test_lancache_heartbeat_url_default(self):
+        s = Settings(orchestrator_token=VALID_TOKEN)
+        assert s.lancache_heartbeat_url == "http://lancache/lancache-heartbeat"
+
+    def test_lancache_heartbeat_url_rejects_empty(self):
+        with pytest.raises(ValidationError):
+            Settings(orchestrator_token=VALID_TOKEN, lancache_heartbeat_url="")
+
+    def test_lancache_probe_timeout_default(self):
+        s = Settings(orchestrator_token=VALID_TOKEN)
+        assert s.lancache_probe_timeout_sec == 5.0
+
+    def test_lancache_probe_timeout_rejects_zero(self):
+        with pytest.raises(ValidationError):
+            Settings(orchestrator_token=VALID_TOKEN, lancache_probe_timeout_sec=0)
+
+    def test_lancache_probe_timeout_rejects_above_max(self):
+        with pytest.raises(ValidationError):
+            Settings(orchestrator_token=VALID_TOKEN, lancache_probe_timeout_sec=120.0)
+
+    def test_lancache_probe_cache_ttl_default(self):
+        s = Settings(orchestrator_token=VALID_TOKEN)
+        assert s.lancache_probe_cache_ttl_sec == 30.0
+
+    def test_lancache_probe_cache_ttl_accepts_zero(self):
+        """TTL=0 disables caching — useful for diagnostic deployments."""
+        s = Settings(orchestrator_token=VALID_TOKEN, lancache_probe_cache_ttl_sec=0.0)
+        assert s.lancache_probe_cache_ttl_sec == 0.0
+
+    def test_lancache_probe_cache_ttl_rejects_negative(self):
+        with pytest.raises(ValidationError):
+            Settings(orchestrator_token=VALID_TOKEN, lancache_probe_cache_ttl_sec=-1.0)
+
     def test_pool_readers_zero_rejects(self):
         with pytest.raises(ValidationError):
             Settings(orchestrator_token=VALID_TOKEN, pool_readers=0)

--- a/tests/lancache/test_heartbeat.py
+++ b/tests/lancache/test_heartbeat.py
@@ -1,0 +1,200 @@
+"""Tests for orchestrator.lancache.heartbeat — ID2 lancache self-test probe."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from orchestrator.lancache.heartbeat import LancacheProbe
+
+pytestmark = pytest.mark.asyncio
+
+
+URL = "http://lancache:80/lancache-heartbeat"
+
+
+def _ok_response(text: str = "lancache-heartbeat") -> httpx.Response:
+    """Mock a 200 OK heartbeat response."""
+    return httpx.Response(
+        status_code=200,
+        text=text,
+        request=httpx.Request("GET", URL),
+    )
+
+
+def _status_response(status: int) -> httpx.Response:
+    return httpx.Response(
+        status_code=status,
+        text="",
+        request=httpx.Request("GET", URL),
+    )
+
+
+class TestProbeBasics:
+    async def test_initial_state_unreachable(self):
+        """Before any probe runs, `reachable` must report False — we cannot
+        claim a lancache is reachable when we've never asked."""
+        probe = LancacheProbe(url=URL)
+        assert probe.last_result() is False
+        assert probe.last_checked_at_mono() is None
+
+    async def test_success_returns_true_and_caches(self):
+        probe = LancacheProbe(url=URL, cache_ttl_sec=30.0)
+        mock = AsyncMock(return_value=_ok_response())
+        with patch.object(httpx.AsyncClient, "get", new=mock, create=True):
+            result = await probe.probe()
+        assert result is True
+        assert probe.last_result() is True
+        assert probe.last_checked_at_mono() is not None
+        assert mock.call_count == 1
+
+    async def test_non_200_returns_false(self):
+        probe = LancacheProbe(url=URL)
+        for status in (301, 302, 400, 401, 403, 404, 500, 502, 503):
+            mock = AsyncMock(return_value=_status_response(status))
+            with patch.object(httpx.AsyncClient, "get", new=mock, create=True):
+                # Fresh probe each iteration so caching doesn't suppress the call.
+                probe = LancacheProbe(url=URL, cache_ttl_sec=0.0)
+                result = await probe.probe()
+            assert result is False, f"status={status} should report unreachable"
+
+
+class TestErrorHandling:
+    async def test_connect_timeout_returns_false(self):
+        probe = LancacheProbe(url=URL)
+        mock = AsyncMock(side_effect=httpx.ConnectTimeout("simulated"))
+        with patch.object(httpx.AsyncClient, "get", new=mock, create=True):
+            assert await probe.probe() is False
+        assert probe.last_result() is False
+
+    async def test_read_timeout_returns_false(self):
+        probe = LancacheProbe(url=URL)
+        mock = AsyncMock(side_effect=httpx.ReadTimeout("simulated"))
+        with patch.object(httpx.AsyncClient, "get", new=mock, create=True):
+            assert await probe.probe() is False
+
+    async def test_connect_error_returns_false(self):
+        probe = LancacheProbe(url=URL)
+        mock = AsyncMock(side_effect=httpx.ConnectError("dns/conn failure"))
+        with patch.object(httpx.AsyncClient, "get", new=mock, create=True):
+            assert await probe.probe() is False
+
+    async def test_unexpected_exception_returns_false(self):
+        """Defensive: any other exception during probe must NOT crash /health."""
+        probe = LancacheProbe(url=URL)
+        mock = AsyncMock(side_effect=RuntimeError("something weird"))
+        with patch.object(httpx.AsyncClient, "get", new=mock, create=True):
+            assert await probe.probe() is False
+
+
+class TestCaching:
+    async def test_within_ttl_returns_cached_result_without_call(self):
+        probe = LancacheProbe(url=URL, cache_ttl_sec=30.0)
+        mock = AsyncMock(return_value=_ok_response())
+        with patch.object(httpx.AsyncClient, "get", new=mock, create=True):
+            await probe.probe()  # primes the cache
+            await probe.probe()
+            await probe.probe()
+        assert mock.call_count == 1  # only the first call hit httpx
+
+    async def test_ttl_zero_disables_cache(self):
+        probe = LancacheProbe(url=URL, cache_ttl_sec=0.0)
+        mock = AsyncMock(return_value=_ok_response())
+        with patch.object(httpx.AsyncClient, "get", new=mock, create=True):
+            await probe.probe()
+            await probe.probe()
+            await probe.probe()
+        assert mock.call_count == 3
+
+    async def test_expired_ttl_triggers_refresh(self):
+        """Drive monotonic clock manually to advance past TTL."""
+        clock = [1000.0]
+        probe = LancacheProbe(
+            url=URL,
+            cache_ttl_sec=30.0,
+            monotonic_fn=lambda: clock[0],
+        )
+        mock = AsyncMock(return_value=_ok_response())
+        with patch.object(httpx.AsyncClient, "get", new=mock, create=True):
+            await probe.probe()
+            assert mock.call_count == 1
+
+            clock[0] += 20.0  # within TTL
+            await probe.probe()
+            assert mock.call_count == 1
+
+            clock[0] += 15.0  # 35s elapsed total — past 30s TTL
+            await probe.probe()
+            assert mock.call_count == 2
+
+    async def test_invalidate_forces_refresh(self):
+        probe = LancacheProbe(url=URL, cache_ttl_sec=30.0)
+        mock = AsyncMock(return_value=_ok_response())
+        with patch.object(httpx.AsyncClient, "get", new=mock, create=True):
+            await probe.probe()
+            probe.invalidate()
+            await probe.probe()
+        assert mock.call_count == 2
+
+
+class TestConcurrency:
+    async def test_concurrent_probes_collapse_to_single_call(self):
+        """If 10 concurrent /health requests trigger a probe at once,
+        only ONE outbound HTTP call should fire — the rest wait on the
+        in-flight result. Prevents thundering herd against lancache."""
+        probe = LancacheProbe(url=URL, cache_ttl_sec=30.0)
+        gate = asyncio.Event()
+
+        async def slow_get(*_args, **_kwargs):
+            await gate.wait()
+            return _ok_response()
+
+        with patch.object(
+            httpx.AsyncClient, "get", new=AsyncMock(side_effect=slow_get), create=True
+        ) as mock:
+            tasks = [asyncio.create_task(probe.probe()) for _ in range(10)]
+            await asyncio.sleep(0.05)
+            gate.set()
+            results = await asyncio.gather(*tasks)
+            assert all(r is True for r in results)
+            assert mock.call_count == 1
+
+
+class TestLastCheckedAt:
+    async def test_last_checked_at_advances_on_refresh(self):
+        clock = [500.0]
+        probe = LancacheProbe(
+            url=URL,
+            cache_ttl_sec=10.0,
+            monotonic_fn=lambda: clock[0],
+        )
+        mock = AsyncMock(return_value=_ok_response())
+        with patch.object(httpx.AsyncClient, "get", new=mock, create=True):
+            await probe.probe()
+            first = probe.last_checked_at_mono()
+            assert first == 500.0
+
+            clock[0] = 600.0  # past 10s TTL
+            await probe.probe()
+            second = probe.last_checked_at_mono()
+            assert second == 600.0
+            assert second > first
+
+
+class TestUrlValidation:
+    async def test_rejects_empty_url(self):
+        with pytest.raises(ValueError, match="url must be non-empty"):
+            LancacheProbe(url="")
+
+    async def test_rejects_non_http_url(self):
+        """We're probing a known plain-HTTP endpoint inside the LAN — refuse
+        schemes that would either fail or introduce TLS surprises."""
+        with pytest.raises(ValueError, match="url must start with http"):
+            LancacheProbe(url="ftp://lancache/lancache-heartbeat")
+
+    async def test_accepts_http_and_https(self):
+        LancacheProbe(url="http://lancache:80/lancache-heartbeat")
+        LancacheProbe(url="https://lancache.example.com/lancache-heartbeat")


### PR DESCRIPTION
## Summary

Implements **ID2** from `docs/phase-0/frd.md:645` + `docs/phase-1/architecture-proposal.md` — the first of the three subsystems that currently stub `/health` to 503. `lancache_reachable` is now wired to a real HTTP probe of the lancache heartbeat endpoint.

## What landed

- New [`src/orchestrator/lancache/heartbeat.py`](src/orchestrator/lancache/heartbeat.py) — `LancacheProbe` with async httpx probe, TTL-cached result, `asyncio.Lock` to collapse concurrent callers into a single in-flight request. Every failure mode (timeouts, connect error, non-200, even unexpected exceptions) → `False` + structured log; never crashes /health.
- New Settings fields: `lancache_heartbeat_url`, `lancache_probe_timeout_sec`, `lancache_probe_cache_ttl_sec`. Defaults `http://lancache/lancache-heartbeat`, 5.0s, 30.0s respectively.
- FastAPI lifespan constructs the probe once + stashes on `app.state.lancache_probe`; `/health` calls `await probe.probe()` per request (cache-fast).
- Test fixtures without lifespan (`unit_app`) still work — `/health` falls back to `False` when `app.state.lancache_probe` is absent.

## Test plan

- [x] `pytest tests/` — **790 pass** (+27 new in `tests/lancache/test_heartbeat.py` [16] + `tests/api/test_health_endpoint.py` [4] + `tests/core/test_settings.py` [7])
- [x] `ruff check`, `ruff format --check`, `mypy --strict src/` (40 source files), `gitleaks detect`, `semgrep p/owasp-top-ten` — all clean
- [x] Security audit ([`docs/security-audits/id2-lancache-self-test-security-audit.md`](docs/security-audits/id2-lancache-self-test-security-audit.md)) — 0 findings; SSRF guarded via URL scheme allowlist + Pydantic length validation + no redirect following + cache TTL rate-limit

## What /health looks like after this ships

`/health` still returns **503** because `scheduler_running` and `validator_healthy` are stubbed False until those subsystems ship. ID2 ships ONE of the three; the other two are separate upcoming BLs. Operators monitoring lancache reachability via /health get real signal now; the overall 503 status will flip to 200 only when all three are real.

## Sequencing context

- Test-gate counter: 1/2 — one more feature shippable before UAT-N
- F1 BL12 (manifest fetcher) still blocked on operator-driven UAT-7 validation of the post-UAT-6 SEV-2 batch (PR #112)
- Next natural autonomous chunk: scheduler subsystem (would flip `scheduler_running`) or validator subsystem (would flip `validator_healthy`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)