### PR TITLE
feat(jobs): ID6 startup job reaper — clean orphaned running jobs at boot

### DIFF
--- a/.claude/build-progress.json
+++ b/.claude/build-progress.json
@@ -11,10 +11,11 @@
     "BL8-F9-jobs-readonly",
     "BL9-F9-manifests-readonly",
     "BL10-F1-steam-auth-substrate",
-    "BL11-library-sync"
+    "BL11-library-sync",
+    "ID6-startup-job-reaper"
   ],
-  "features_since_last_test": 0,
-  "features_since_last_health_check": 1,
+  "features_since_last_test": 1,
+  "features_since_last_health_check": 2,
   "test_interval": 2,
   "last_test_session": "2026-05-27",
   "testing_required": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Added — ID6 Startup Job Reaper — 2026-05-27
+
+Implements `docs/phase-0/frd.md:649` ID6 — the "startup reaper for abandoned jobs" requirement. Closes the SEV-3 deployment-shape finding F-UAT6-8 (stale `library_sync` jobs surviving container restarts forever).
+
+- New `src/orchestrator/jobs/reaper.py` with `reap_running_jobs(pool) -> int`. Single atomic `UPDATE jobs SET state='failed', error=..., finished_at=CURRENT_TIMESTAMP WHERE state='running'`.
+- FastAPI lifespan calls the reaper after pool init but before the jobs worker task spawns — orphans get cleaned before the new worker could conceivably mis-claim them. Defensive try/except around the call so a failed reap doesn't abort boot.
+- Tests: 7 unit tests in `tests/jobs/test_reaper.py` (empty table, no-running, single, multiple, mixed-states, idempotency, error-message length contract). 3 integration tests in `tests/api/test_lifespan_reaper.py` driving the real lifespan via `asgi_lifespan.LifespanManager` — seeds an orphaned `running` job pre-boot, verifies it's flipped to `failed` post-boot.
+
 ### Fixed — Post-UAT-6 SEV-2 batch — 2026-05-27
 
 Closes #107 (licenses enumeration) and #109 (`get_product_info` timeout) — both surfaced by the UAT-6 live operator session against a real Steam account.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -540,4 +540,56 @@ Steam auth-success paths auto-queue a `library_sync` job (best-effort).
 
 ---
 
+## Feature 13: ID6 — Startup Job Reaper
+
+**Phase Built:** 2 (Milestone B, Build Loop 13)
+**Status:** Complete (2026-05-27)
+
+**Summary:** FastAPI lifespan startup now marks every job in
+`state='running'` as `failed` BEFORE the BL11 jobs worker spawns. The
+previous worker (in the prior orchestrator process) died with its
+container; those rows are orphaned and would otherwise sit `running`
+forever, blocking the manual-sync dedup check and confusing
+operators. Atomic single-`UPDATE` reap; idempotent; defensive
+try/except around the call so a database hiccup at boot doesn't
+abort startup.
+
+**Key Interfaces:**
+  - `src/orchestrator/jobs/reaper.py` — `reap_running_jobs(pool) -> int`
+  - `src/orchestrator/api/main.py` lifespan step 2b — invokes the reaper
+    after `init_pool()` and before the steam worker / jobs worker spawn
+
+**Design decisions:**
+  - **Reap-all-on-boot** (not "reap stale by started_at age"). The
+    orchestrator owns the worker process; if the orchestrator process
+    is starting, no other process can be holding a legitimate
+    `running` job. Single-orchestrator deployment is locked per
+    PROJECT_BIBLE §3.1 / Intake §6.4 — multi-orchestrator concurrency
+    is explicitly out of scope.
+  - **Boot continues on reaper failure.** A database hiccup during
+    the reap shouldn't prevent the orchestrator from serving /health
+    or accepting auth requests. The error is logged at ERROR; orphans
+    remain `running` until the next successful boot.
+
+**Test Coverage:** 10 new tests:
+  - 7 unit (empty, no-running, single, multiple, mixed-states,
+    idempotency, error-message-length-contract)
+  - 3 integration via `asgi_lifespan.LifespanManager` (orphan reaped
+    on boot, terminal states untouched, empty table boots cleanly)
+
+**Related ADRs:**
+  - None new — design follows FRD §5 ID6 directly.
+
+**Known Limitations:**
+  - The reaper marks ALL `running` jobs failed, even if a developer
+    is intentionally testing a long-running flow that survives a
+    re-create. Use `--reload`-aware development setups or temporarily
+    move the job to a non-running state before restart.
+  - No "reaped-at" timestamp — failed jobs from the reaper are
+    indistinguishable from failed jobs from handler exceptions
+    except via the `error` column substring match. Acceptable for
+    MVP; revisit when telemetry needs grow.
+
+---
+
 <!-- Copy the section above for each new feature. Number sequentially. -->

--- a/docs/security-audits/id6-startup-job-reaper-security-audit.md
+++ b/docs/security-audits/id6-startup-job-reaper-security-audit.md
@@ -1,0 +1,76 @@
+# Security Audit — ID6 Startup Job Reaper
+
+**Feature:** ID6-startup-job-reaper
+**Audit date:** 2026-05-27
+**Audited modules:**
+- src/orchestrator/jobs/reaper.py
+- src/orchestrator/api/main.py (lifespan integration)
+
+<!-- Last Updated: 2026-05-27 -->
+
+## Scope
+
+Post-implementation security review of the startup orphan-job reaper.
+
+## Methodology
+
+1. ruff / ruff format / mypy --strict — all clean (39 source files)
+2. gitleaks full-repo scan — no leaks
+3. semgrep p/owasp-top-ten on `src/orchestrator/jobs/reaper.py` — 0 findings
+4. Manual review against threat-model entries TM-005 (SQL injection),
+   TM-014 (boot-time resource pressure)
+
+## Findings
+
+**SEV-1: 0   SEV-2: 0   SEV-3: 0   SEV-4: 0**
+
+No new vulnerabilities introduced.
+
+## Threat-model walk
+
+- **TM-005 (SQL injection):** MITIGATED. Single SQL statement,
+  parameterized — `?` placeholder for the error message string,
+  hard-coded constants for state values. No user input reaches the
+  query. The `REAPER_ERROR_MESSAGE` constant is a module-level string
+  literal, not an argument.
+
+- **TM-014 (boot-time resource pressure):** MITIGATED. Single
+  atomic `UPDATE` (no loop, no per-row processing). For N orphan
+  rows, SQLite touches at most N rows in one statement; even
+  pathological "orphan-storm" cases (thousands of rows) execute in
+  milliseconds. The lifespan wraps the call in `try/except Exception`
+  so a database hiccup doesn't abort boot — failed reap logs at
+  ERROR; boot continues. The jobs worker that spawns next won't
+  claim `running` rows anyway (its SELECT filters `state='queued'`),
+  so a missed reap is recoverable on the next restart.
+
+## Defensive-programming review
+
+- Lifespan ordering: reaper runs BEFORE `jobs_worker_task` is created.
+  Even if the reaper takes longer than expected, the new worker
+  cannot race into the orphan rows because it hasn't been spawned yet.
+- The reaper does NOT modify `started_at` on the reaped rows —
+  diagnostic data ("how long was this job running before crash?")
+  is preserved.
+- The reaper does NOT touch `payload` — any IPC context that future
+  forensics need is retained.
+
+## Operator surfaces
+
+- `jobs.reaper.reaped_orphans` (WARN) — emitted when count > 0.
+  Surfaces that the previous orchestrator process did not shut down
+  cleanly.
+- `jobs.reaper.no_orphans` (INFO) — emitted when nothing to reap.
+  Normal boot path.
+- `api.boot.reaped_orphan_jobs` (WARN) — lifespan-level wrapper log
+  with the same count.
+- `api.boot.reaper_failed` (ERROR) — defensive catch path; never
+  expected in normal operation.
+
+No PII, no credentials, no job-payload contents in any log event.
+
+## Sign-off
+
+No SEV findings. ID6 cleared to ship.
+
+— Senior Security Engineer persona, 2026-05-27

--- a/src/orchestrator/api/main.py
+++ b/src/orchestrator/api/main.py
@@ -43,6 +43,7 @@ from orchestrator.db.pool import (
     get_pool,
     init_pool,
 )
+from orchestrator.jobs.reaper import reap_running_jobs
 from orchestrator.jobs.worker import Deps as JobsDeps
 from orchestrator.jobs.worker import worker_loop as jobs_worker_loop
 from orchestrator.platform.steam.client import SteamWorkerClient
@@ -105,6 +106,21 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         raise SystemExit(1) from None
 
     pool_initialized = True
+
+    # 2b. Startup job reaper (ID6) — mark all `state='running'` jobs as
+    # `failed` before the jobs worker starts polling. The previous worker
+    # process died with the previous orchestrator container; those rows
+    # are orphaned. Reap before the worker spawns so we don't race a
+    # newly-claimed job into the failed bucket.
+    try:
+        reaped = await reap_running_jobs(get_pool())
+        if reaped > 0:
+            log.warning("api.boot.reaped_orphan_jobs", count=reaped)
+    except Exception as e:
+        # Defensive: a failed reap shouldn't abort boot — the job rows are
+        # still recoverable manually, and the jobs worker won't claim
+        # `running` rows anyway (it filters `state='queued'`).
+        log.error("api.boot.reaper_failed", reason=str(e)[:200])
 
     # 3. Steam worker startup
     steam_client = SteamWorkerClient()

--- a/src/orchestrator/jobs/reaper.py
+++ b/src/orchestrator/jobs/reaper.py
@@ -1,0 +1,47 @@
+"""Startup reaper for orphaned `running` jobs (ID6).
+
+Any `jobs` row with `state='running'` at orchestrator startup is by
+definition orphaned: the worker process that claimed it died with the
+previous orchestrator process (the jobs worker runs inside the same
+container; it cannot survive a container restart). The reaper marks
+those rows `failed` atomically BEFORE the new jobs worker starts
+polling — otherwise the same job would be claim-by-current-worker'd
+or stay stuck `running` forever, depending on the handler.
+
+Surfaced by UAT-6 deployment-shape audit (finding F-UAT6-8) plus
+FRD §5 ID6 requirement. Called from `_lifespan` after pool init and
+before `jobs_worker_task` is spawned.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+
+if TYPE_CHECKING:
+    from orchestrator.db.pool import Pool
+
+_log = structlog.get_logger(__name__)
+
+REAPER_ERROR_MESSAGE = "orchestrator restarted while job was running (ID6 reaper)"
+
+
+async def reap_running_jobs(pool: Pool) -> int:
+    """Mark every `state='running'` job as `failed` with a uniform error
+    message. Returns the number of rows touched.
+
+    Logs at WARN when reaping > 0 rows (surface that the previous process
+    didn't shut down cleanly) and at INFO when there's nothing to reap
+    (the normal, no-prior-crash case).
+    """
+    rowcount = await pool.execute_write(
+        "UPDATE jobs SET state='failed', finished_at=CURRENT_TIMESTAMP, error=? "
+        "WHERE state='running'",
+        (REAPER_ERROR_MESSAGE,),
+    )
+    if rowcount > 0:
+        _log.warning("jobs.reaper.reaped_orphans", count=rowcount)
+    else:
+        _log.info("jobs.reaper.no_orphans")
+    return rowcount

--- a/tests/api/test_lifespan_reaper.py
+++ b/tests/api/test_lifespan_reaper.py
@@ -1,0 +1,113 @@
+"""Integration test for ID6: the reaper runs in FastAPI lifespan startup
+and cleans up orphaned `running` jobs before the worker spawns."""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from orchestrator.jobs.reaper import REAPER_ERROR_MESSAGE
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_running_job(db_path: str) -> int:
+    """Insert a `state='running'` row directly via aiosqlite — bypasses
+    the orchestrator pool because the test runs before/around lifespan
+    startup."""
+    async with aiosqlite.connect(db_path) as conn:
+        await conn.execute(
+            "INSERT INTO jobs (kind, platform, state, source, started_at) "
+            "VALUES ('library_sync', 'steam', 'running', 'api', "
+            "'2026-05-27 09:00:00')"
+        )
+        await conn.commit()
+        async with conn.execute("SELECT id FROM jobs ORDER BY id DESC LIMIT 1") as cur:
+            row = await cur.fetchone()
+            return row[0]
+
+
+async def _read_job_state(db_path: str, job_id: int) -> tuple[str, str | None]:
+    async with (
+        aiosqlite.connect(db_path) as conn,
+        conn.execute("SELECT state, error FROM jobs WHERE id=?", (job_id,)) as cur,
+    ):
+        row = await cur.fetchone()
+        return row[0], row[1]
+
+
+class TestLifespanReaperIntegration:
+    async def test_orphan_running_job_is_reaped_at_boot(self, db_path, monkeypatch):
+        """Seed a job in state='running' BEFORE lifespan, boot the app,
+        verify the row was flipped to 'failed' with the reaper's error
+        message."""
+        from asgi_lifespan import LifespanManager
+
+        from orchestrator.api.main import create_app
+
+        monkeypatch.setenv("ORCH_DATABASE_PATH", str(db_path))
+
+        # Pre-seed the orphan BEFORE lifespan opens the pool.
+        job_id = await _seed_running_job(str(db_path))
+
+        app = create_app()
+        async with LifespanManager(app):
+            # Lifespan startup completed; reaper has run.
+            state, error = await _read_job_state(str(db_path), job_id)
+
+        assert state == "failed"
+        assert error == REAPER_ERROR_MESSAGE
+
+    async def test_non_running_jobs_untouched_by_reaper(self, db_path, monkeypatch):
+        """Succeeded/failed/cancelled rows must NOT be modified by the reaper
+        — only `running` is orphaned.
+
+        Note: this test intentionally excludes `queued` because the BL11
+        jobs worker spawns inside lifespan and would legitimately claim
+        a queued row during the test window (then fail it because no
+        steam client is authenticated). That's worker behavior, not
+        reaper behavior. The reaper's contract is "running → failed";
+        queued is the worker's domain.
+        """
+        from asgi_lifespan import LifespanManager
+
+        from orchestrator.api.main import create_app
+
+        monkeypatch.setenv("ORCH_DATABASE_PATH", str(db_path))
+
+        # Seed terminal states only (no queued — see docstring).
+        async with aiosqlite.connect(str(db_path)) as conn:
+            for state in ("succeeded", "failed", "cancelled"):
+                await conn.execute(
+                    "INSERT INTO jobs (kind, platform, state, source, "
+                    "started_at, finished_at) "
+                    "VALUES ('library_sync', 'steam', ?, 'api', "
+                    "'2026-05-27 09:00:00', '2026-05-27 09:05:00')",
+                    (state,),
+                )
+            await conn.commit()
+            async with conn.execute("SELECT id, state FROM jobs ORDER BY id") as cur:
+                rows_before = [(r[0], r[1]) for r in await cur.fetchall()]
+
+        app = create_app()
+        async with LifespanManager(app):
+            pass  # lifespan startup + shutdown both run
+
+        async with (
+            aiosqlite.connect(str(db_path)) as conn,
+            conn.execute("SELECT id, state FROM jobs ORDER BY id") as cur,
+        ):
+            rows_after = [(r[0], r[1]) for r in await cur.fetchall()]
+
+        assert rows_before == rows_after
+
+    async def test_empty_jobs_table_boots_cleanly(self, db_path, monkeypatch):
+        from asgi_lifespan import LifespanManager
+
+        from orchestrator.api.main import create_app
+
+        monkeypatch.setenv("ORCH_DATABASE_PATH", str(db_path))
+
+        app = create_app()
+        async with LifespanManager(app):
+            pass  # boot + shutdown should not raise

--- a/tests/jobs/test_reaper.py
+++ b/tests/jobs/test_reaper.py
@@ -1,0 +1,100 @@
+"""Tests for orchestrator.jobs.reaper (ID6 startup job reaper)."""
+
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.jobs.reaper import REAPER_ERROR_MESSAGE, reap_running_jobs
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _insert_job(pool, kind="library_sync", state="queued", started_at=None):
+    """Insert a job row with the given state. Returns the new id."""
+    sql = "INSERT INTO jobs (kind, platform, state, source, started_at) VALUES (?, ?, ?, 'api', ?)"
+    await pool.execute_write(sql, (kind, "steam", state, started_at))
+    row = await pool.read_one("SELECT id FROM jobs ORDER BY id DESC LIMIT 1")
+    return row["id"]
+
+
+class TestReaper:
+    async def test_empty_jobs_table_returns_zero(self, pool):
+        assert await reap_running_jobs(pool) == 0
+
+    async def test_no_running_jobs_returns_zero(self, pool):
+        # Seed queued + succeeded + failed; none of these should be touched.
+        await _insert_job(pool, state="queued")
+        await _insert_job(pool, state="succeeded", started_at="2026-05-27 10:00:00")
+        await _insert_job(pool, state="failed", started_at="2026-05-27 10:00:00")
+        await _insert_job(pool, state="cancelled", started_at="2026-05-27 10:00:00")
+
+        n = await reap_running_jobs(pool)
+        assert n == 0
+        # Other states unchanged
+        rows = await pool.read_all("SELECT state FROM jobs ORDER BY id")
+        assert [r["state"] for r in rows] == [
+            "queued",
+            "succeeded",
+            "failed",
+            "cancelled",
+        ]
+
+    async def test_single_running_job_is_reaped(self, pool):
+        job_id = await _insert_job(pool, state="running", started_at="2026-05-27 09:59:00")
+        n = await reap_running_jobs(pool)
+        assert n == 1
+
+        row = await pool.read_one(
+            "SELECT state, error, finished_at, started_at FROM jobs WHERE id=?",
+            (job_id,),
+        )
+        assert row["state"] == "failed"
+        assert row["error"] == REAPER_ERROR_MESSAGE
+        assert row["finished_at"] is not None
+        assert row["started_at"] == "2026-05-27 09:59:00"  # preserved
+
+    async def test_multiple_running_jobs_all_reaped(self, pool):
+        ids = []
+        for _ in range(5):
+            ids.append(await _insert_job(pool, state="running", started_at="2026-05-27 09:59:00"))
+        n = await reap_running_jobs(pool)
+        assert n == 5
+
+        rows = await pool.read_all("SELECT id, state, error FROM jobs ORDER BY id")
+        for row in rows:
+            assert row["state"] == "failed"
+            assert row["error"] == REAPER_ERROR_MESSAGE
+
+    async def test_mixed_states_only_running_reaped(self, pool):
+        await _insert_job(pool, state="queued")
+        await _insert_job(pool, state="running", started_at="2026-05-27 09:59:00")
+        await _insert_job(pool, state="succeeded", started_at="2026-05-27 09:55:00")
+        await _insert_job(pool, state="running", started_at="2026-05-27 09:58:00")
+        await _insert_job(pool, state="cancelled")
+
+        n = await reap_running_jobs(pool)
+        assert n == 2
+
+        rows = await pool.read_all("SELECT state FROM jobs ORDER BY id")
+        # original: queued, running, succeeded, running, cancelled
+        # after:    queued, failed,  succeeded, failed,  cancelled
+        assert [r["state"] for r in rows] == [
+            "queued",
+            "failed",
+            "succeeded",
+            "failed",
+            "cancelled",
+        ]
+
+    async def test_idempotent(self, pool):
+        """Second invocation reaps nothing (already-failed jobs are not
+        re-touched)."""
+        await _insert_job(pool, state="running", started_at="2026-05-27 09:59:00")
+        assert await reap_running_jobs(pool) == 1
+        assert await reap_running_jobs(pool) == 0
+
+    async def test_error_message_truncates_under_jobs_constraint(self, pool):
+        """Defensive: REAPER_ERROR_MESSAGE must fit within the orchestrator's
+        own 200-char truncation convention (jobs.error). The constant
+        itself is well under, but assert the contract."""
+        assert len(REAPER_ERROR_MESSAGE) <= 200


### PR DESCRIPTION
## Summary

Implements [`docs/phase-0/frd.md:649`](docs/phase-0/frd.md) ID6 — the "startup reaper for abandoned jobs" requirement. Closes UAT-6 deployment-shape finding **F-UAT6-8** (stale `library_sync` rows surviving container restarts forever).

## Problem

When the orchestrator container restarts mid-job, the worker process that claimed the job dies with it. The DB row sits in `state='running'` forever — blocks the manual-sync dedup check (`sync.py` filters `state IN ('queued','running')`), confuses operators (`/jobs?state=running` shows ghosts), and would inflate the dashboard's "active jobs" counter.

## Solution

Lifespan startup now executes `reap_running_jobs(pool)` between pool init and the jobs-worker spawn. Single atomic SQL UPDATE marks every `running` row as `failed` with a uniform error message, preserving `started_at` for forensics. Idempotent. Defensive try/except so a database hiccup at boot doesn't abort startup.

## Test plan

- [x] `pytest tests/` — **773 pass** (+10 new):
  - 7 unit in `tests/jobs/test_reaper.py`
  - 3 integration in `tests/api/test_lifespan_reaper.py` driving the real lifespan via `asgi_lifespan.LifespanManager`
- [x] `ruff check` + `ruff format --check`, `mypy --strict src/` (39 source files), `gitleaks`, `semgrep p/owasp-top-ten` — all clean
- [x] Security audit ([`docs/security-audits/id6-startup-job-reaper-security-audit.md`](docs/security-audits/id6-startup-job-reaper-security-audit.md)) — 0 findings. Parameterized SQL; lifespan ordering ensures the new jobs worker can't race the reaper

## Merge considerations

Lifespan integration sits at **step 2b** (after pool init, before steam worker spawn at step 3). Will conflict at merge time with **PR #113 (ID2)** which inserts a lifespan step 5 below the existing flow — resolution is straightforward additive interleave (both add discrete lifespan steps; they don't share variables).

## Test-gate state

After ID2 (#113) AND this PR merge, test-gate counter hits 2/2 → **UAT-N required** before the next feature can start. UAT-7 would naturally combine validation of:
- ID2 (lancache_reachable wiring against the real lancache host)
- ID6 (kill orchestrator mid-job, verify reaper cleans up on restart)
- Post-UAT-6 SEV-2 fixes from PR #112 that haven't been live-validated yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)