### PR TITLE
fix(lancache): accept 2xx + require X-LanCache-Processed-By header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — ID2 lancache probe: real lancache returns 204 with header identifier — 2026-05-28
+
+Surfaced by post-PR-#113 deployment testing against the running `lancachenet/monolithic` image: lancache's `/lancache-heartbeat` endpoint returns **HTTP 204 No Content** (not 200) and identifies itself via the **`X-LanCache-Processed-By`** response header. PR #113's `LancacheProbe._refresh()` strictly checked for 200 → would have reported `lancache_reachable: false` even against a healthy lancache.
+
+- `LancacheProbe` now accepts any 2xx status code AND requires the `X-LanCache-Processed-By` header. The header check is positive identification — defends against misconfigured DNS bypass / wrong target where some other 2xx-responding service would otherwise pass the probe.
+- Headers checked case-insensitively (httpx normalizes lookup).
+- New structured log event: `lancache.probe.missing_identifier_header` (WARN) fires when a 2xx response arrives without the lancache header — helps operators diagnose "responsive endpoint, wrong target."
+- 5 new tests in `tests/lancache/test_heartbeat.py` (204 with header, 200 with header, all-2xx-with-header, 2xx-without-header-rejected, case-insensitive header match). Renamed `test_non_200_returns_false` → `test_non_2xx_returns_false`.
+
 ### Added — ID6 Startup Job Reaper — 2026-05-27
 
 Implements `docs/phase-0/frd.md:649` ID6 — the "startup reaper for abandoned jobs" requirement. Closes the SEV-3 deployment-shape finding F-UAT6-8 (stale `library_sync` jobs surviving container restarts forever).

--- a/src/orchestrator/lancache/heartbeat.py
+++ b/src/orchestrator/lancache/heartbeat.py
@@ -25,6 +25,16 @@ if TYPE_CHECKING:
 
 _log = structlog.get_logger(__name__)
 
+# Lancache nginx identifies itself with this header on EVERY response,
+# including the /lancache-heartbeat 204. Verified against lancache.net's
+# `lancachenet/monolithic` image at v3.x. We require the header (not
+# just any 2xx) so a misconfigured DNS bypass pointing at a different
+# server can't accidentally look "reachable". Surfaced by post-PR-#113
+# deployment testing where the bare-2xx check passed against a real
+# lancache returning 204 but would have also passed against any other
+# 2xx-responding service.
+LANCACHE_IDENTIFIER_HEADER = "X-LanCache-Processed-By"
+
 
 class LancacheProbe:
     """Cached async HTTP probe of `GET <url>` for lancache reachability.
@@ -102,7 +112,22 @@ class LancacheProbe:
         try:
             async with httpx.AsyncClient(timeout=self._timeout_sec) as client:
                 response = await client.get(self._url)
-                ok = response.status_code == 200
+                # Lancache nginx returns 204 No Content on the heartbeat
+                # endpoint (verified against the running lancachenet/
+                # monolithic image). Accept any 2xx and require the
+                # `X-LanCache-Processed-By` header so the probe doesn't
+                # call a non-lancache service "reachable" by accident.
+                ok = (
+                    200 <= response.status_code < 300
+                    and LANCACHE_IDENTIFIER_HEADER in response.headers
+                )
+                if not ok and 200 <= response.status_code < 300:
+                    _log.warning(
+                        "lancache.probe.missing_identifier_header",
+                        url=self._url,
+                        status_code=response.status_code,
+                        header=LANCACHE_IDENTIFIER_HEADER,
+                    )
         except (
             httpx.ConnectTimeout,
             httpx.ReadTimeout,

--- a/tests/lancache/test_heartbeat.py
+++ b/tests/lancache/test_heartbeat.py
@@ -15,21 +15,34 @@ pytestmark = pytest.mark.asyncio
 
 URL = "http://lancache:80/lancache-heartbeat"
 
+# Lancache nginx stamps this header on every response, including the
+# 204 returned by /lancache-heartbeat. Verified against the running
+# `lancachenet/monolithic` image. The probe requires it as positive
+# identification.
+LANCACHE_HEADERS = {"X-LanCache-Processed-By": "test-lancache-host"}
 
-def _ok_response(text: str = "lancache-heartbeat") -> httpx.Response:
-    """Mock a 200 OK heartbeat response."""
+
+def _ok_response(
+    text: str = "",
+    status: int = 204,
+    headers: dict[str, str] | None = None,
+) -> httpx.Response:
+    """Mock a healthy lancache heartbeat response — 204 No Content with
+    the identifier header (default), matching real lancache behavior."""
     return httpx.Response(
-        status_code=200,
+        status_code=status,
         text=text,
         request=httpx.Request("GET", URL),
+        headers=headers if headers is not None else LANCACHE_HEADERS,
     )
 
 
-def _status_response(status: int) -> httpx.Response:
+def _status_response(status: int, headers: dict[str, str] | None = None) -> httpx.Response:
     return httpx.Response(
         status_code=status,
         text="",
         request=httpx.Request("GET", URL),
+        headers=headers or {},
     )
 
 
@@ -51,15 +64,59 @@ class TestProbeBasics:
         assert probe.last_checked_at_mono() is not None
         assert mock.call_count == 1
 
-    async def test_non_200_returns_false(self):
+    async def test_non_2xx_returns_false(self):
         probe = LancacheProbe(url=URL)
         for status in (301, 302, 400, 401, 403, 404, 500, 502, 503):
-            mock = AsyncMock(return_value=_status_response(status))
+            mock = AsyncMock(return_value=_status_response(status, LANCACHE_HEADERS))
             with patch.object(httpx.AsyncClient, "get", new=mock, create=True):
                 # Fresh probe each iteration so caching doesn't suppress the call.
                 probe = LancacheProbe(url=URL, cache_ttl_sec=0.0)
                 result = await probe.probe()
             assert result is False, f"status={status} should report unreachable"
+
+    async def test_accepts_204_with_identifier_header(self):
+        """Real lancache returns 204 No Content + X-LanCache-Processed-By
+        header — verified against a running lancachenet/monolithic image."""
+        probe = LancacheProbe(url=URL)
+        mock = AsyncMock(return_value=_ok_response(status=204))
+        with patch.object(httpx.AsyncClient, "get", new=mock, create=True):
+            assert await probe.probe() is True
+
+    async def test_accepts_200_with_identifier_header(self):
+        """Some lancache variants return 200; still healthy as long as the
+        identifier header is present."""
+        probe = LancacheProbe(url=URL)
+        mock = AsyncMock(return_value=_ok_response(status=200))
+        with patch.object(httpx.AsyncClient, "get", new=mock, create=True):
+            assert await probe.probe() is True
+
+    async def test_accepts_all_2xx_with_identifier_header(self):
+        probe = LancacheProbe(url=URL, cache_ttl_sec=0.0)
+        for status in (200, 201, 202, 204, 206):
+            mock = AsyncMock(return_value=_ok_response(status=status))
+            with patch.object(httpx.AsyncClient, "get", new=mock, create=True):
+                assert await probe.probe() is True, f"status={status} should be reachable"
+
+    async def test_2xx_without_identifier_header_returns_false(self):
+        """Defends against a misconfigured DNS bypass / wrong target —
+        a generic 2xx-responding service is not lancache."""
+        probe = LancacheProbe(url=URL)
+        mock = AsyncMock(return_value=_status_response(204, headers={}))
+        with patch.object(httpx.AsyncClient, "get", new=mock, create=True):
+            assert await probe.probe() is False
+
+    async def test_header_match_is_case_insensitive(self):
+        """httpx normalizes header lookup; verify the probe handles
+        lower-case + mixed-case header names."""
+        probe = LancacheProbe(url=URL, cache_ttl_sec=0.0)
+        for header_name in (
+            "X-LanCache-Processed-By",
+            "x-lancache-processed-by",
+            "X-LANCACHE-PROCESSED-BY",
+        ):
+            mock = AsyncMock(return_value=_status_response(204, headers={header_name: "host"}))
+            with patch.object(httpx.AsyncClient, "get", new=mock, create=True):
+                assert await probe.probe() is True, f"header={header_name!r}"
 
 
 class TestErrorHandling:


### PR DESCRIPTION
## Summary

Surfaced by deployment testing of PR #113 (ID2) against the running `lancachenet/monolithic` image on the lancache host: **lancache returns HTTP 204 with `X-LanCache-Processed-By` header**, not HTTP 200. PR #113's strict 200 check would have reported `lancache_reachable: false` even against a fully-healthy lancache — bug that only deployment testing could catch.

## Fix

- `LancacheProbe._refresh()` now accepts any 2xx status code AND requires the `X-LanCache-Processed-By` header
- Header lookup is case-insensitive (httpx normalizes)
- New `lancache.probe.missing_identifier_header` WARN event fires when a 2xx response arrives without the lancache header — diagnostic for "responsive endpoint, wrong target"

## Why the header check (not just any 2xx)

Defends against misconfigured DNS bypass / wrong target. Without it, the probe would call any 2xx-responding service "lancache" — e.g., a misconfigured reverse proxy returning 200 on every URL.

## Test plan

- [x] 21 lancache tests pass (16 original + 5 new)
- [x] Full suite: 805 pass; ruff/format/mypy --strict/gitleaks clean
- [x] Will be live-validated post-merge against the running lancache on 192.168.1.40

🤖 Generated with [Claude Code](https://claude.com/claude-code)