### PR TITLE
feat(scheduler): F12 scheduler subsystem — /health.scheduler_running real

### DIFF
--- a/.claude/build-progress.json
+++ b/.claude/build-progress.json
@@ -13,14 +13,15 @@
     "BL10-F1-steam-auth-substrate",
     "BL11-library-sync",
     "ID2-lancache-self-test",
-    "ID6-startup-job-reaper"
+    "ID6-startup-job-reaper",
+    "F12-scheduler-subsystem"
   ],
-  "features_since_last_test": 2,
-  "features_since_last_health_check": 2,
+  "features_since_last_test": 1,
+  "features_since_last_health_check": 3,
   "test_interval": 2,
-  "last_test_session": "2026-05-27",
-  "testing_required": true,
+  "last_test_session": "2026-05-28",
+  "testing_required": false,
   "tester_count": 1,
   "bug_tracker": "github_issues",
-  "sessions_completed": 6
+  "sessions_completed": 7
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,20 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Added — F12 Scheduler subsystem — 2026-05-28
+
+Implements F12 from PROJECT_BIBLE §1.2 MVP cutline and JQ3 (`/health.scheduler_running` is now real). APScheduler 3.11.2 `AsyncIOScheduler` integrated into FastAPI lifespan; periodically enqueues `library_sync` jobs for the BL11 jobs worker to execute.
+
+- New `src/orchestrator/scheduler/` package with `SchedulerManager` (wraps `AsyncIOScheduler`) + `enqueue_library_sync` cron callback. `replace_existing=True` jobs registered at boot; in-memory `MemoryJobStore` (default) means cron config re-renders on every restart.
+- Settings:
+  - `scheduler_enabled: bool = True` — diagnostic / dev escape hatch
+  - `scheduler_library_sync_interval_sec: int = 21600` (6h, range 60..86400)
+- Lifespan ordering: scheduler starts at step 4b (between jobs worker spawn and lancache probe init); shuts down FIRST in teardown so it can't enqueue work during shutdown.
+- `/health.scheduler_running` reads `app.state.scheduler_manager.running`. No-lifespan test fixtures fall back to `False` via `getattr(..., None)` guard.
+- Cron callbacks include dedup against existing queued/running library_sync rows (mirrors the manual sync endpoint) so cron + operator triggers don't race onto duplicate rows.
+- 25 new tests: 7 in `tests/scheduler/test_jobs.py` (enqueue + dedup + error swallow), 7 in `tests/scheduler/test_manager.py` (start/stop/running/jobs), 3 in `tests/api/test_lifespan_scheduler.py` (integration), 5 in `tests/core/test_settings.py` (defaults + bounds), 3 in `tests/api/test_health_endpoint.py` (probe wiring). Full suite: 830 pass.
+- Updated `tests/api/test_lifespan.py::test_lifespan_returns_503_through_handler_when_unhealthy` — `scheduler_running` is now `True` post-F12; `validator_healthy` is the remaining stub-false subsystem keeping /health at 503.
+
 ### Fixed — ID2 lancache probe: real lancache returns 204 with header identifier — 2026-05-28
 
 Surfaced by post-PR-#113 deployment testing against the running `lancachenet/monolithic` image: lancache's `/lancache-heartbeat` endpoint returns **HTTP 204 No Content** (not 200) and identifies itself via the **`X-LanCache-Processed-By`** response header. PR #113's `LancacheProbe._refresh()` strictly checked for 200 → would have reported `lancache_reachable: false` even against a healthy lancache.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -654,4 +654,72 @@ abort startup.
 
 ---
 
+## Feature 14: F12 — Scheduler subsystem
+
+**Phase Built:** 2 (Milestone B, Build Loop 14)
+**Status:** Complete (2026-05-28)
+
+**Summary:** Periodically enqueues `library_sync` jobs via APScheduler
+3.11.2 `AsyncIOScheduler` integrated into FastAPI lifespan. Replaces
+the BL5 stub-false `/health.scheduler_running` with a real boolean.
+Decoupled architecture: the scheduler only stamps queued `jobs` rows
+(via thin async callbacks) — the BL11 jobs worker actually executes
+handlers. Means a slow library_sync can never block the scheduler.
+
+**Key Interfaces:**
+  - `src/orchestrator/scheduler/manager.py` — `SchedulerManager` facade
+    with idempotent `.start()` / `.shutdown()` and a `.running` property
+  - `src/orchestrator/scheduler/jobs.py` — `enqueue_library_sync(pool)`
+    cron callback (dedup-aware; never raises)
+  - `src/orchestrator/api/main.py` lifespan step 4b — boots the manager
+    after the jobs worker spawns; shuts it down FIRST so no new work
+    is enqueued during teardown
+  - `src/orchestrator/api/routers/health.py` — `getattr(app.state,
+    "scheduler_manager", None)` + `.running` drives the bool
+  - Settings: `scheduler_enabled`, `scheduler_library_sync_interval_sec`
+
+**Locked design decisions** (see
+[`docs/superpowers/specs/2026-05-28-f12-scheduler-design.md`](superpowers/specs/2026-05-28-f12-scheduler-design.md)):
+  - **D1 AsyncIOScheduler** (v3.11.2 pinned, matches asyncio loop)
+  - **D2 In-memory MemoryJobStore** (cron config re-renders on boot;
+    no persistence contention with the BL4 pool)
+  - **D4 max_instances=1** per scheduled job (no pile-up)
+  - **D5 misfire_grace_time=None** (always fire on next opportunity)
+  - **D6 Scheduler enqueues, jobs worker executes** (decoupled; slow
+    handler can't block scheduler ticks)
+  - **D7 Dedup at enqueue time** (mirrors the manual sync endpoint)
+  - **D11 Scheduler start failure does NOT crash boot** (logged at
+    CRITICAL; `/health` returns 503 via JQ3)
+
+**Test Coverage:** 25 new tests across 5 files:
+  - `tests/scheduler/test_jobs.py` (7): enqueue happy path, queued/
+    running dedup, terminal-states ignored, kind+platform isolation,
+    pool error swallow
+  - `tests/scheduler/test_manager.py` (7): enabled/disabled boot,
+    job registration, interval pass-through, idempotent start/stop
+  - `tests/api/test_lifespan_scheduler.py` (3): integration —
+    scheduler starts in lifespan, disabled-via-settings, /health
+    reflects running=True
+  - `tests/api/test_health_endpoint.py` (+3): probe-absent fallback,
+    running-true, running-false wiring
+  - `tests/core/test_settings.py` (+5): defaults + boundaries for
+    the 2 new fields
+
+**Related ADRs:** None new (APScheduler choice locked in PROJECT_BIBLE §3.1).
+
+**Known Limitations:**
+  - The scheduled library_sync fails with `NotAuthenticated` after a
+    container restart (per documented limitation #108 / `docs/known-
+    limitations.md`) until the operator re-auths. F13 will need its
+    own auth check, or this will be revisited when Steam library
+    evaluation (#111) ships an alternative session-persistence path.
+  - /health still returns 503 because `validator_healthy` remains
+    stub-false until F7 validator ships. F12 alone doesn't flip
+    /health to 200 — but it's one of the three required.
+  - No persistent job store. If the orchestrator is down for >6h,
+    the next library_sync fires at boot+interval, not at boot. F12
+    `coalesce=True` ensures multiple missed fires collapse to one.
+
+---
+
 <!-- Copy the section above for each new feature. Number sequentially. -->

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The bearer token (`orchestrator_token`) is the only required field. Every other 
 | `ORCH_LANCACHE_HEARTBEAT_URL` | URL | `http://lancache/lancache-heartbeat` | ID2 probe target — set to a 127.0.0.1 path if orchestrator is co-resident with lancache |
 | `ORCH_LANCACHE_PROBE_TIMEOUT_SEC` | float (0..60) | `5.0` | Per-probe httpx timeout |
 | `ORCH_LANCACHE_PROBE_CACHE_TTL_SEC` | float (0..600) | `30.0` | TTL for cached probe result; 0 disables cache |
+| `ORCH_SCHEDULER_ENABLED` | bool | `true` | Disable scheduler subsystem (`/health.scheduler_running` reports `false`, 503) |
+| `ORCH_SCHEDULER_LIBRARY_SYNC_INTERVAL_SEC` | int (60..86400) | `21600` | Library_sync schedule cadence (default 6 h) |
 
 **DB pool memory baseline:** `(pool_readers + 1) × db_cache_size_kib + db_mmap_size_bytes`. Default config = `9 × 16 MiB + 256 MiB ≈ 400 MiB` resident. On memory-constrained hardware (e.g. DXP4800 NAS at 4 GB total), halve `ORCH_POOL_READERS` and `ORCH_DB_CACHE_SIZE_KIB` together — yields a `5 × 8 MiB + 256 MiB ≈ 296 MiB` profile. See [`FEATURES.md` — Feature 4](FEATURES.md) and [ADR-0011](docs/ADR%20documentation/0011-db-pool-architecture.md).
 

--- a/docs/security-audits/f12-scheduler-subsystem-security-audit.md
+++ b/docs/security-audits/f12-scheduler-subsystem-security-audit.md
@@ -1,0 +1,89 @@
+# Security Audit — F12 Scheduler Subsystem
+
+**Feature:** F12-scheduler-subsystem
+**Audit date:** 2026-05-28
+**Audited modules:**
+- src/orchestrator/scheduler/__init__.py
+- src/orchestrator/scheduler/manager.py
+- src/orchestrator/scheduler/jobs.py
+- src/orchestrator/api/main.py (lifespan + shutdown wiring)
+- src/orchestrator/api/routers/health.py (running flag)
+- src/orchestrator/core/settings.py (2 new fields)
+
+<!-- Last Updated: 2026-05-28 -->
+
+## Scope
+
+Post-implementation security review of F12 scheduler subsystem and its integration with FastAPI lifespan + `/health`.
+
+## Methodology
+
+1. `ruff check` + `ruff format --check` + `mypy --strict src/` — all clean (44 source files)
+2. `gitleaks detect` full-repo scan — no leaks
+3. `semgrep p/owasp-top-ten` on `src/orchestrator/scheduler/` — 0 findings
+4. Manual review against threat-model entries TM-005 (SQL injection),
+   TM-014 (boot-time / scheduler resource pressure)
+5. Test coverage review — 25 new tests cover the security-relevant
+   edge cases (callback failure swallow, dedup correctness, settings
+   bounds)
+
+## Findings
+
+**SEV-1: 0   SEV-2: 0   SEV-3: 0   SEV-4: 0**
+
+No new vulnerabilities introduced.
+
+## Threat-model walk
+
+- **TM-005 (SQL injection):** MITIGATED. `enqueue_library_sync` uses
+  parameterized SQL exclusively (`?` placeholders or hard-coded
+  literals). The dedup query is hard-coded with no user input. The
+  insert is fully literal — no user-supplied data reaches SQL.
+
+- **TM-014 (boot-time / scheduler resource pressure):** MITIGATED.
+  - `max_instances=1` per scheduled job prevents pile-up if a fire
+    arrives while the previous handler is still running.
+  - `misfire_grace_time=None` + `coalesce=True` means after an outage,
+    only ONE catch-up fire happens (not the missed N fires).
+  - Cron callbacks NEVER raise — exceptions are logged + swallowed
+    (verified by `test_returns_zero_on_pool_error_without_raising`),
+    so a failing tick doesn't put the scheduler in a degraded state.
+  - Default interval 6h × max_instances=1 caps activity at ~4
+    enqueues/day per scheduled job.
+  - Dedup at enqueue time prevents pile-up in the `jobs` table — if
+    a queued/running library_sync exists, no new row is inserted.
+
+## Defensive-programming review
+
+- `SchedulerManager.start()` failures are caught at the lifespan layer
+  (`api.boot.scheduler_start_failed` CRITICAL log) — boot continues
+  with `scheduler_running=False`. JQ3 contract upheld: `/health`
+  returns 503.
+- `SchedulerManager.shutdown()` is idempotent and safe to call when
+  the scheduler never started (the disabled-via-settings path) — no
+  AttributeError on `self._scheduler is None`.
+- Lifespan shuts down scheduler FIRST so it can't enqueue new work
+  during teardown.
+- Scheduler `enabled=False` is a true no-op: registers no jobs,
+  reports `.running=False`, makes `start()` / `shutdown()` no-ops.
+  Validated by `test_disabled_manager_registers_no_jobs`.
+
+## Operator surfaces
+
+- `scheduler.disabled_by_settings` (INFO) — emitted when `ORCH_SCHEDULER_ENABLED=false`
+- `scheduler.started` (INFO) — emitted on successful boot, with interval + job count
+- `scheduler.stopped` (INFO) — emitted on shutdown
+- `scheduler.library_sync.queued` (INFO) — fires every successful enqueue
+- `scheduler.library_sync.dedup_skip` (INFO) — fires when dedup hits
+- `scheduler.library_sync.db_error` (ERROR) — DB failure swallowed
+- `scheduler.library_sync.unexpected_error` (ERROR) — defensive catch
+- `api.boot.scheduler_started` / `api.boot.scheduler_start_failed` —
+  lifespan-level wrappers
+
+No PII, no credentials, no job payloads in any log event.
+
+## Sign-off
+
+No SEV findings. F12 cleared to ship.
+
+— Senior Security Engineer persona, 2026-05-28

--- a/docs/superpowers/specs/2026-05-28-f12-scheduler-design.md
+++ b/docs/superpowers/specs/2026-05-28-f12-scheduler-design.md
@@ -1,0 +1,63 @@
+# F12 — Scheduler subsystem (design)
+
+**Date:** 2026-05-28
+**Spec source:** PROJECT_BIBLE §1.2 (MVP must-have F12), §3.1 (APScheduler in main asyncio loop), §1.5 JQ3 (`/api/v1/health` surfaces `scheduler_running: bool` and returns 503 on scheduler death), FRD §2.
+**Scope:** Periodic scheduled triggers for `library_sync` (default every 6h) via APScheduler 3.11.2 AsyncIOScheduler. Flips the BL5 `/health.scheduler_running` stub-false to real.
+
+## Locked decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | **APScheduler 3.11.2 `AsyncIOScheduler`** | Pinned via requirements.txt; matches our asyncio loop. v4 API exists but adds SQLAlchemy + event broker complexity we don't need. |
+| D2 | **In-memory job store (MemoryJobStore — APScheduler default)** | Scheduled jobs re-register on every boot. No persistence needed; ID6 reaper already handles "stale `running` rows on restart". Avoids a SQLAlchemy/aiosqlite contention layer. |
+| D3 | **`AsyncIOExecutor` (default)** | All scheduled callbacks are `async def`. |
+| D4 | **`max_instances=1`** per scheduled job | If the previous library_sync is still running when the next fire time arrives, skip (don't pile up). |
+| D5 | **`misfire_grace_time=None`** | Always fire on next opportunity even if late — operator may have rebooted mid-interval and we want the next sync to run, not be skipped. |
+| D6 | **Scheduler invokes a thin "enqueue" function**, not the handler directly | The enqueue function inserts a `jobs` row (kind='library_sync', source='scheduler'); the BL11 jobs worker picks it up. Decouples cron firing from handler execution → handler can be slow without blocking the scheduler. |
+| D7 | **Dedup at enqueue time** — skip insert if a queued/running `library_sync` exists | Same query the manual sync endpoint uses (`POST /library/sync`). Prevents pile-up after a long outage. |
+| D8 | **`scheduler_enabled: bool = True`** Settings field | Diagnostic / dev escape hatch; container boots with scheduler disabled when `ORCH_SCHEDULER_ENABLED=false`. |
+| D9 | **`scheduler_library_sync_interval_sec: int = 21600` (6h)** Settings field | Configurable in [60, 86400] range (1 min .. 24h). FRD says "6h default"; tunable for testing. |
+| D10 | **`SchedulerManager.running` property** drives `/health.scheduler_running` | Property delegates to the underlying `AsyncIOScheduler.running` plus a "not None" check. |
+| D11 | **Scheduler errors do NOT crash boot** | If `scheduler.start()` raises, log critical, set running=False, continue. `/health` will reflect 503 via JQ3. |
+| D12 | **Lifespan shutdown calls `scheduler.shutdown(wait=True)`** | Wait for in-flight callbacks (the enqueue function is fast — <1s typically). |
+
+## Files
+
+- `src/orchestrator/scheduler/__init__.py` — package marker
+- `src/orchestrator/scheduler/manager.py` — `SchedulerManager` class wrapping `AsyncIOScheduler`
+- `src/orchestrator/scheduler/jobs.py` — cron callbacks (`enqueue_library_sync(pool)`)
+- `tests/scheduler/test_jobs.py` — enqueue function: empty, dedup-hit, dedup-miss, DB failure
+- `tests/scheduler/test_manager.py` — manager: starts, stops, exposes `.running`, registers configured jobs
+- `tests/api/test_lifespan_scheduler.py` — integration: lifespan starts scheduler, `/health.scheduler_running=True`
+
+## Wire-up
+
+`main.py` lifespan order after this lands:
+
+1. Migrations
+2. Pool init
+2b. Job reaper (ID6, already there)
+3. Steam worker
+4. Jobs worker (BL11)
+4b. **Scheduler (this BL)** — depends on pool, runs cron callbacks that enqueue into the jobs table
+5. Lancache probe (ID2)
+6. Boot metadata, etc.
+
+Shutdown order (LIFO):
+- Scheduler shutdown FIRST (so no new jobs enqueue during teardown)
+- Then jobs worker stops
+- Then steam client
+- Then pool
+
+## Tests strategy
+
+- Unit: pure tests for `enqueue_library_sync` using a real pool fixture (no scheduler)
+- Manager: construct a `SchedulerManager` with `AsyncIOScheduler`, call `.start()`, assert `.running`, verify jobs registered via `get_jobs()`, `.shutdown()` cleanly
+- Integration: lifespan_app fixture boots scheduler, `/health` returns `scheduler_running: True`. Real fire-on-interval is NOT exercised (interval is 6h default; tests would have to wait or use 1s interval + cooperative sleep — leave for live UAT)
+
+## Out of scope (explicit)
+
+- Spike F (perf gate against asyncio-only design) — pre-shipped per Bible §3.1, no scheduler-specific perf test needed
+- Per-platform sync customization (F12 in spec is "library_sync" only; F2 Epic adds its own schedule when it ships)
+- F13 weekly full-library validation sweep — separate scheduled job, separate BL
+- Distributed scheduler coordination — out of scope (single-orchestrator deployment)

--- a/src/orchestrator/api/main.py
+++ b/src/orchestrator/api/main.py
@@ -48,6 +48,7 @@ from orchestrator.jobs.worker import Deps as JobsDeps
 from orchestrator.jobs.worker import worker_loop as jobs_worker_loop
 from orchestrator.lancache.heartbeat import LancacheProbe
 from orchestrator.platform.steam.client import SteamWorkerClient
+from orchestrator.scheduler.manager import SchedulerManager
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -153,6 +154,29 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         poll_interval_sec=settings.jobs_worker_poll_interval_sec,
     )
 
+    # 4b. Scheduler (F12). Registers periodic enqueue callbacks that
+    # insert library_sync rows into the jobs table. The BL11 jobs worker
+    # (started at step 4) actually executes the handlers — the scheduler
+    # only fires cron-style. If start() raises, lifespan catches the
+    # error and continues with scheduler_running=False so /health surfaces
+    # 503 per JQ3.
+    scheduler_manager = SchedulerManager(
+        pool=get_pool(),
+        enabled=settings.scheduler_enabled,
+        library_sync_interval_sec=settings.scheduler_library_sync_interval_sec,
+    )
+    try:
+        await scheduler_manager.start()
+        log.info(
+            "api.boot.scheduler_started",
+            enabled=settings.scheduler_enabled,
+            running=scheduler_manager.running,
+            library_sync_interval_sec=settings.scheduler_library_sync_interval_sec,
+        )
+    except Exception as e:
+        log.critical("api.boot.scheduler_start_failed", reason=str(e)[:200])
+    app.state.scheduler_manager = scheduler_manager
+
     # 5. Lancache self-test probe (ID2). Constructed once; the /health
     # router calls `.probe()` per request, which is cached + concurrency-safe.
     app.state.lancache_probe = LancacheProbe(
@@ -194,7 +218,16 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     finally:
         log.info("api.shutdown.starting")
 
-        # Stop the jobs worker FIRST so it isn't still holding pool /
+        # Stop the scheduler FIRST so it doesn't enqueue new work during
+        # teardown. scheduler_manager.shutdown() is idempotent + safe
+        # when the scheduler never started (e.g., scheduler_enabled=False).
+        log.info("api.shutdown.scheduler_stopping")
+        try:
+            await scheduler_manager.shutdown()
+        except Exception as e:
+            log.error("api.shutdown.scheduler_stop_failed", reason=str(e)[:200])
+
+        # Stop the jobs worker NEXT so it isn't still holding pool /
         # steam-client refs when those resources unwind.
         log.info("api.shutdown.jobs_worker_stopping")
         jobs_shutdown.set()

--- a/src/orchestrator/api/routers/health.py
+++ b/src/orchestrator/api/routers/health.py
@@ -67,12 +67,20 @@ async def get_health(
     if probe is not None:
         lancache_reachable = await probe.probe()
 
+    # F12 scheduler. `app.state.scheduler_manager` is built in lifespan
+    # startup; `.running` reads the underlying AsyncIOScheduler. Tests
+    # without lifespan omit the state — fall back to False (BL5-stub-like).
+    scheduler_manager = getattr(request.app.state, "scheduler_manager", None)
+    scheduler_running = False
+    if scheduler_manager is not None:
+        scheduler_running = scheduler_manager.running
+
     body = HealthResponse(
         status="ok" if pool_ok else "degraded",
         version=__version__,
         uptime_sec=int(time.monotonic() - request.app.state.boot_time),
-        # Remaining BL5 stubs — real when scheduler + validator subsystems ship.
-        scheduler_running=False,
+        # Remaining BL5 stub — real when validator subsystem ships.
+        scheduler_running=scheduler_running,
         lancache_reachable=lancache_reachable,
         cache_volume_mounted=cache_volume_mounted,
         validator_healthy=False,

--- a/src/orchestrator/core/settings.py
+++ b/src/orchestrator/core/settings.py
@@ -87,6 +87,16 @@ class Settings(BaseSettings):
     lancache_probe_timeout_sec: float = Field(default=5.0, gt=0.0, le=60.0)
     lancache_probe_cache_ttl_sec: float = Field(default=30.0, ge=0.0, le=600.0)
 
+    # --- Scheduler (F12) --------------------------------------------
+    # APScheduler AsyncIOScheduler integration. Disable for diagnostic
+    # / dev: /health.scheduler_running surfaces False and the endpoint
+    # returns 503 per JQ3.
+    scheduler_enabled: bool = Field(default=True)
+    # Interval between library_sync schedule fires; FRD says 6h default.
+    # Bounded [60 s, 86400 s] so operators can tune for testing without
+    # accidentally setting a pathological value.
+    scheduler_library_sync_interval_sec: int = Field(default=21600, ge=60, le=86400)
+
     # --- Misc --------------------------------------------------------
     manifest_size_cap_bytes: int = Field(default=134_217_728, gt=0)
     epic_refresh_buffer_sec: int = Field(default=600, ge=0)

--- a/src/orchestrator/scheduler/__init__.py
+++ b/src/orchestrator/scheduler/__init__.py
@@ -1,0 +1,7 @@
+"""Scheduler subsystem (F12).
+
+`SchedulerManager` wraps an APScheduler 3.x `AsyncIOScheduler` and
+registers periodic callbacks that enqueue work into the `jobs` table.
+The BL11 jobs worker is the executor — the scheduler does not run
+handlers itself; it just stamps queued rows.
+"""

--- a/src/orchestrator/scheduler/jobs.py
+++ b/src/orchestrator/scheduler/jobs.py
@@ -1,0 +1,60 @@
+"""Scheduled job callbacks (F12 D6 — scheduler enqueues, jobs worker executes).
+
+These are async functions invoked by APScheduler. They MUST NOT raise
+— a raised exception puts APScheduler into a degraded state and we
+want failed enqueues to be best-effort (next fire will retry).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+
+from orchestrator.db.pool import PoolError
+
+if TYPE_CHECKING:
+    from orchestrator.db.pool import Pool
+
+_log = structlog.get_logger(__name__)
+
+
+async def enqueue_library_sync(pool: Pool) -> int:
+    """Insert a `library_sync` job row if none is queued/running for steam.
+
+    Returns the rowcount affected (0 if dedup-skipped or DB failure, 1
+    if a new row was queued). Never raises — DB errors are logged and
+    swallowed so a failing scheduler tick doesn't crash the scheduler.
+
+    Dedup logic mirrors `sync.trigger_library_sync` so cron + operator
+    triggers don't race onto duplicate rows. F12 D7.
+    """
+    try:
+        existing = await pool.read_one(
+            "SELECT id FROM jobs "
+            "WHERE kind='library_sync' AND platform='steam' "
+            "AND state IN ('queued','running') "
+            "ORDER BY id LIMIT 1"
+        )
+        if existing is not None:
+            _log.info("scheduler.library_sync.dedup_skip", existing_job_id=existing["id"])
+            return 0
+
+        await pool.execute_write(
+            "INSERT INTO jobs (kind, platform, state, source) "
+            "VALUES ('library_sync', 'steam', 'queued', 'scheduler')"
+        )
+        _log.info("scheduler.library_sync.queued")
+        return 1
+    except PoolError as e:
+        _log.error("scheduler.library_sync.db_error", reason=str(e)[:200])
+        return 0
+    except Exception as e:
+        # Defensive: any other exception (callback shouldn't crash the
+        # scheduler) is logged at ERROR and swallowed.
+        _log.error(
+            "scheduler.library_sync.unexpected_error",
+            error=type(e).__name__,
+            reason=str(e)[:200],
+        )
+        return 0

--- a/src/orchestrator/scheduler/manager.py
+++ b/src/orchestrator/scheduler/manager.py
@@ -1,0 +1,125 @@
+"""SchedulerManager — wraps APScheduler 3.x AsyncIOScheduler (F12).
+
+The manager:
+- Constructs an `AsyncIOScheduler` with sensible defaults (in-memory
+  job store, asyncio executor, max_instances=1, no misfire grace)
+- Registers configured periodic jobs at startup
+- Exposes `.running` for `/health.scheduler_running`
+- Provides idempotent `.start()` / `.shutdown()` for lifespan integration
+
+The scheduler itself does not run business logic — it invokes thin
+"enqueue" callbacks in `jobs.py` that insert rows into the `jobs`
+table. The BL11 jobs worker picks them up (F12 D6).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+
+from orchestrator.scheduler.jobs import enqueue_library_sync
+
+if TYPE_CHECKING:
+    from apscheduler.job import Job
+
+    from orchestrator.db.pool import Pool
+
+_log = structlog.get_logger(__name__)
+
+
+# Stable job IDs (F12 D6): manager re-registers on every boot. Using
+# consistent ids means `replace_existing=True` lets us re-deploy without
+# orphan jobs if the in-memory store ever gets persisted in a future BL.
+LIBRARY_SYNC_JOB_ID = "library_sync_steam"
+
+
+class SchedulerManager:
+    """Async scheduler facade. Idempotent start/shutdown for lifespan use.
+
+    Disable via `enabled=False` (Settings.scheduler_enabled). A disabled
+    manager reports `.running=False`, registers no jobs, and `.start()`
+    is a no-op — operator-facing `/health.scheduler_running` correctly
+    surfaces False, returning 503.
+    """
+
+    def __init__(
+        self,
+        *,
+        pool: Pool,
+        enabled: bool,
+        library_sync_interval_sec: int,
+    ) -> None:
+        self._pool = pool
+        self._enabled = enabled
+        self._library_sync_interval_sec = library_sync_interval_sec
+        self._scheduler: AsyncIOScheduler | None = None
+
+    @property
+    def running(self) -> bool:
+        """True iff the underlying APScheduler is running. Drives
+        `/health.scheduler_running`."""
+        return self._scheduler is not None and self._scheduler.running
+
+    async def start(self) -> None:
+        """Construct the AsyncIOScheduler, register jobs, start running.
+        No-op when disabled or already started (F12 D11)."""
+        if not self._enabled:
+            _log.info("scheduler.disabled_by_settings")
+            return
+        if self._scheduler is not None and self._scheduler.running:
+            return
+
+        scheduler = AsyncIOScheduler(
+            timezone="UTC",
+            job_defaults={
+                # D4: only one fire at a time per job
+                "max_instances": 1,
+                # D5: always fire on next opportunity, even if late
+                "misfire_grace_time": None,
+                # Don't coalesce missed fires into a burst — single replay
+                "coalesce": True,
+            },
+        )
+
+        scheduler.add_job(
+            enqueue_library_sync,
+            trigger=IntervalTrigger(seconds=self._library_sync_interval_sec),
+            args=(self._pool,),
+            id=LIBRARY_SYNC_JOB_ID,
+            name="Enqueue library_sync for steam",
+            replace_existing=True,
+        )
+
+        scheduler.start()
+        self._scheduler = scheduler
+        _log.info(
+            "scheduler.started",
+            library_sync_interval_sec=self._library_sync_interval_sec,
+            jobs=len(scheduler.get_jobs()),
+        )
+
+    async def shutdown(self) -> None:
+        """Stop the scheduler. Idempotent — safe to call when not
+        started or already stopped."""
+        if self._scheduler is None:
+            return
+        if self._scheduler.running:
+            # wait=True drains in-flight callbacks; our callbacks are fast.
+            self._scheduler.shutdown(wait=True)
+        self._scheduler = None
+        _log.info("scheduler.stopped")
+
+    # --- introspection helpers (used by tests + future status page) ---
+
+    def get_registered_job_ids(self) -> list[str]:
+        if self._scheduler is None:
+            return []
+        return [j.id for j in self._scheduler.get_jobs()]
+
+    def get_job(self, job_id: str) -> Job | None:
+        if self._scheduler is None:
+            return None
+        return self._scheduler.get_job(job_id)

--- a/tests/api/test_health_endpoint.py
+++ b/tests/api/test_health_endpoint.py
@@ -82,6 +82,37 @@ class TestHealthShipState:
         finally:
             del client._transport.app.state.lancache_probe
 
+    async def test_scheduler_running_false_when_manager_absent(self, client):
+        """No-lifespan unit_app omits app.state.scheduler_manager.
+        /health must fall back to False rather than crashing."""
+        r = await client.get("/api/v1/health")
+        body = r.json()
+        assert body["scheduler_running"] is False
+
+    async def test_scheduler_running_true_when_manager_reports_running(self, client):
+        class _StubManager:
+            running = True
+
+        client._transport.app.state.scheduler_manager = _StubManager()
+        try:
+            r = await client.get("/api/v1/health")
+            body = r.json()
+            assert body["scheduler_running"] is True
+        finally:
+            del client._transport.app.state.scheduler_manager
+
+    async def test_scheduler_running_false_when_manager_reports_stopped(self, client):
+        class _StubManager:
+            running = False
+
+        client._transport.app.state.scheduler_manager = _StubManager()
+        try:
+            r = await client.get("/api/v1/health")
+            body = r.json()
+            assert body["scheduler_running"] is False
+        finally:
+            del client._transport.app.state.scheduler_manager
+
 
 class TestHealthDynamicFields:
     async def test_uptime_sec_increases_monotonically(self, client):

--- a/tests/api/test_lifespan.py
+++ b/tests/api/test_lifespan.py
@@ -54,11 +54,17 @@ class TestLifespanFailures:
 
     async def test_lifespan_returns_503_through_handler_when_unhealthy(self, lifespan_app):
         """Once lifespan is up, a request to /health hits the handler.
-        BL5 ship state: 503 because three subsystems are stub-false."""
+        Post-F12 ship state: 503 still expected because validator_healthy
+        remains stub-false until F7 validator subsystem ships, AND the
+        test app's lancache_heartbeat_url is unreachable in the test
+        environment, AND cache_volume_mounted depends on a path that
+        doesn't exist in test fixtures. scheduler_running is now True
+        (F12 shipped); validator_healthy is the remaining holdout."""
         transport = httpx.ASGITransport(app=lifespan_app)
         async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as c:
             r = await c.get("/api/v1/health")
-        assert r.status_code == 503  # BL5 ship state per spec §6.4
+        assert r.status_code == 503  # validator + lancache + cache_volume still stub-false
         body = r.json()
         assert body["status"] in ("ok", "degraded")
-        assert body["scheduler_running"] is False  # stub
+        assert body["scheduler_running"] is True  # F12 ships the real subsystem
+        assert body["validator_healthy"] is False  # F7 not yet built

--- a/tests/api/test_lifespan_scheduler.py
+++ b/tests/api/test_lifespan_scheduler.py
@@ -1,0 +1,65 @@
+"""Integration test for F12: the scheduler runs in FastAPI lifespan
+startup, exposes `running=True` on `app.state.scheduler_manager`, and
+cleanly shuts down when the lifespan exits."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestLifespanSchedulerIntegration:
+    async def test_scheduler_starts_and_running_on_boot(self, db_path, monkeypatch):
+        from asgi_lifespan import LifespanManager
+
+        from orchestrator.api.main import create_app
+
+        monkeypatch.setenv("ORCH_DATABASE_PATH", str(db_path))
+        # Use a fast cycle so we never accidentally fire during the test.
+        monkeypatch.setenv("ORCH_SCHEDULER_LIBRARY_SYNC_INTERVAL_SEC", "86400")
+
+        app = create_app()
+        async with LifespanManager(app):
+            mgr = app.state.scheduler_manager
+            assert mgr is not None
+            assert mgr.running is True
+            assert "library_sync_steam" in mgr.get_registered_job_ids()
+        # After exiting lifespan, scheduler is stopped.
+        assert app.state.scheduler_manager.running is False
+
+    async def test_scheduler_disabled_via_settings(self, db_path, monkeypatch):
+        from asgi_lifespan import LifespanManager
+
+        from orchestrator.api.main import create_app
+
+        monkeypatch.setenv("ORCH_DATABASE_PATH", str(db_path))
+        monkeypatch.setenv("ORCH_SCHEDULER_ENABLED", "false")
+
+        app = create_app()
+        async with LifespanManager(app):
+            mgr = app.state.scheduler_manager
+            assert mgr is not None
+            assert mgr.running is False
+            assert mgr.get_registered_job_ids() == []
+
+    async def test_health_scheduler_running_true_under_lifespan(self, db_path, monkeypatch):
+        """End-to-end: /health surfaces scheduler_running=True when the
+        scheduler is up in lifespan."""
+        import httpx
+        from asgi_lifespan import LifespanManager
+
+        from orchestrator.api.main import create_app
+
+        monkeypatch.setenv("ORCH_DATABASE_PATH", str(db_path))
+        monkeypatch.setenv("ORCH_SCHEDULER_LIBRARY_SYNC_INTERVAL_SEC", "86400")
+
+        app = create_app()
+        async with LifespanManager(app):
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://testserver"
+            ) as client:
+                r = await client.get("/api/v1/health")
+                body = r.json()
+                assert body["scheduler_running"] is True

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -254,6 +254,26 @@ class TestFieldValidators:
         with pytest.raises(ValidationError):
             Settings(orchestrator_token=VALID_TOKEN, lancache_probe_cache_ttl_sec=-1.0)
 
+    def test_scheduler_enabled_default(self):
+        s = Settings(orchestrator_token=VALID_TOKEN)
+        assert s.scheduler_enabled is True
+
+    def test_scheduler_enabled_can_disable(self):
+        s = Settings(orchestrator_token=VALID_TOKEN, scheduler_enabled=False)
+        assert s.scheduler_enabled is False
+
+    def test_scheduler_library_sync_interval_default_is_6h(self):
+        s = Settings(orchestrator_token=VALID_TOKEN)
+        assert s.scheduler_library_sync_interval_sec == 21600  # 6 * 3600
+
+    def test_scheduler_library_sync_interval_rejects_below_min(self):
+        with pytest.raises(ValidationError):
+            Settings(orchestrator_token=VALID_TOKEN, scheduler_library_sync_interval_sec=30)
+
+    def test_scheduler_library_sync_interval_rejects_above_24h(self):
+        with pytest.raises(ValidationError):
+            Settings(orchestrator_token=VALID_TOKEN, scheduler_library_sync_interval_sec=90000)
+
     def test_pool_readers_zero_rejects(self):
         with pytest.raises(ValidationError):
             Settings(orchestrator_token=VALID_TOKEN, pool_readers=0)

--- a/tests/scheduler/conftest.py
+++ b/tests/scheduler/conftest.py
@@ -1,0 +1,9 @@
+"""Shared fixtures for tests/scheduler/. Re-exports pool fixtures."""
+
+from __future__ import annotations
+
+from tests.db.conftest import (  # noqa: F401
+    _isolated_env,
+    db_path,
+    pool,
+)

--- a/tests/scheduler/test_jobs.py
+++ b/tests/scheduler/test_jobs.py
@@ -1,0 +1,90 @@
+"""Tests for orchestrator.scheduler.jobs (F12)."""
+
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.scheduler.jobs import enqueue_library_sync
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestEnqueueLibrarySync:
+    async def test_inserts_queued_job_when_table_empty(self, pool):
+        n = await enqueue_library_sync(pool)
+        assert n == 1
+        row = await pool.read_one("SELECT kind, platform, state, source FROM jobs LIMIT 1")
+        assert row == {
+            "kind": "library_sync",
+            "platform": "steam",
+            "state": "queued",
+            "source": "scheduler",
+        }
+
+    async def test_dedup_skip_when_queued_already(self, pool):
+        # Seed a queued row from a previous schedule fire / manual trigger.
+        await pool.execute_write(
+            "INSERT INTO jobs (kind, platform, state, source) "
+            "VALUES ('library_sync', 'steam', 'queued', 'api')"
+        )
+        n = await enqueue_library_sync(pool)
+        assert n == 0  # dedup hit; nothing inserted
+        rows = await pool.read_all(
+            "SELECT id FROM jobs WHERE kind='library_sync' AND state='queued'"
+        )
+        assert len(rows) == 1
+
+    async def test_dedup_skip_when_running_already(self, pool):
+        await pool.execute_write(
+            "INSERT INTO jobs (kind, platform, state, source, started_at) "
+            "VALUES ('library_sync', 'steam', 'running', 'scheduler', "
+            "'2026-05-28 12:00:00')"
+        )
+        n = await enqueue_library_sync(pool)
+        assert n == 0
+
+    async def test_enqueues_when_only_terminal_states_exist(self, pool):
+        # Past jobs in terminal states don't block a new schedule fire.
+        for state in ("succeeded", "failed", "cancelled"):
+            await pool.execute_write(
+                "INSERT INTO jobs (kind, platform, state, source, "
+                "started_at, finished_at) VALUES (?, 'steam', ?, "
+                "'scheduler', '2026-05-28 09:00:00', '2026-05-28 09:05:00')",
+                ("library_sync", state),
+            )
+        n = await enqueue_library_sync(pool)
+        assert n == 1
+        # Total rows: 3 terminal + 1 new queued = 4
+        rows = await pool.read_all("SELECT id FROM jobs")
+        assert len(rows) == 4
+
+    async def test_dedup_ignores_other_kinds(self, pool):
+        """A queued `validate` or `sweep` job must not block library_sync."""
+        await pool.execute_write(
+            "INSERT INTO jobs (kind, platform, state, source) "
+            "VALUES ('prefill', 'steam', 'queued', 'scheduler')"
+        )
+        n = await enqueue_library_sync(pool)
+        assert n == 1
+
+    async def test_dedup_ignores_other_platforms(self, pool):
+        """An epic library_sync (when F2 ships) must not block steam."""
+        await pool.execute_write(
+            "INSERT INTO jobs (kind, platform, state, source) "
+            "VALUES ('library_sync', 'epic', 'queued', 'scheduler')"
+        )
+        n = await enqueue_library_sync(pool)
+        assert n == 1
+
+    async def test_returns_zero_on_pool_error_without_raising(self, pool):
+        """Defensive: scheduler callbacks must never raise (would put the
+        scheduler in a degraded state)."""
+        from unittest.mock import AsyncMock
+
+        from orchestrator.db.pool import PoolError
+
+        # Replace pool methods with raising stubs.
+        broken_pool = pool
+        broken_pool.read_one = AsyncMock(side_effect=PoolError("simulated"))
+        n = await enqueue_library_sync(broken_pool)
+        assert n == 0  # logged + returned; did not raise

--- a/tests/scheduler/test_manager.py
+++ b/tests/scheduler/test_manager.py
@@ -1,0 +1,98 @@
+"""Tests for orchestrator.scheduler.manager (F12)."""
+
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.scheduler.manager import SchedulerManager
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestSchedulerManager:
+    async def test_disabled_manager_reports_running_false(self, pool):
+        mgr = SchedulerManager(
+            pool=pool,
+            enabled=False,
+            library_sync_interval_sec=21600,
+        )
+        assert mgr.running is False
+        # start() on a disabled manager is a no-op
+        await mgr.start()
+        assert mgr.running is False
+        await mgr.shutdown()
+
+    async def test_enabled_manager_starts_and_reports_running(self, pool):
+        mgr = SchedulerManager(
+            pool=pool,
+            enabled=True,
+            library_sync_interval_sec=21600,
+        )
+        try:
+            await mgr.start()
+            assert mgr.running is True
+        finally:
+            await mgr.shutdown()
+        assert mgr.running is False
+
+    async def test_enabled_manager_registers_library_sync_job(self, pool):
+        mgr = SchedulerManager(
+            pool=pool,
+            enabled=True,
+            library_sync_interval_sec=21600,
+        )
+        try:
+            await mgr.start()
+            jobs = mgr.get_registered_job_ids()
+            assert "library_sync_steam" in jobs
+        finally:
+            await mgr.shutdown()
+
+    async def test_disabled_manager_registers_no_jobs(self, pool):
+        mgr = SchedulerManager(
+            pool=pool,
+            enabled=False,
+            library_sync_interval_sec=21600,
+        )
+        await mgr.start()
+        assert mgr.get_registered_job_ids() == []
+        await mgr.shutdown()
+
+    async def test_interval_is_passed_through_to_trigger(self, pool):
+        mgr = SchedulerManager(
+            pool=pool,
+            enabled=True,
+            library_sync_interval_sec=60,
+        )
+        try:
+            await mgr.start()
+            job = mgr.get_job("library_sync_steam")
+            assert job is not None
+            # IntervalTrigger.interval is a timedelta(seconds=60)
+            assert job.trigger.interval.total_seconds() == 60.0
+        finally:
+            await mgr.shutdown()
+
+    async def test_shutdown_is_idempotent(self, pool):
+        mgr = SchedulerManager(
+            pool=pool,
+            enabled=True,
+            library_sync_interval_sec=21600,
+        )
+        await mgr.start()
+        await mgr.shutdown()
+        # Second shutdown call must not raise
+        await mgr.shutdown()
+
+    async def test_start_is_idempotent(self, pool):
+        mgr = SchedulerManager(
+            pool=pool,
+            enabled=True,
+            library_sync_interval_sec=21600,
+        )
+        try:
+            await mgr.start()
+            await mgr.start()  # second call should be a no-op
+            assert mgr.running is True
+        finally:
+            await mgr.shutdown()


### PR DESCRIPTION
## Summary

Implements **F12** from PROJECT_BIBLE §1.2 MVP cutline + JQ3. APScheduler 3.11.2 `AsyncIOScheduler` integrated into FastAPI lifespan; periodically enqueues `library_sync` jobs for the BL11 jobs worker to execute. Replaces the BL5 stub-false `/health.scheduler_running` with a real boolean.

## What landed

- New [`src/orchestrator/scheduler/`](src/orchestrator/scheduler/) package:
  - `manager.py` — `SchedulerManager` facade with idempotent `.start()` / `.shutdown()` and `.running` property
  - `jobs.py` — `enqueue_library_sync` cron callback (dedup-aware; swallows all exceptions so a failing tick doesn't degrade the scheduler)
- New Settings:
  - `scheduler_enabled` (default `True`) — diagnostic / dev escape hatch
  - `scheduler_library_sync_interval_sec` (default `21600` = 6 h, range 60..86400)
- FastAPI lifespan step 4b: scheduler boots after jobs worker spawns; shuts down FIRST in teardown
- `/health.scheduler_running` reads `app.state.scheduler_manager.running` via `getattr(..., None)` guard (no-lifespan test fixtures fall back to `False`)

## Design decisions (full spec [in branch](docs/superpowers/specs/2026-05-28-f12-scheduler-design.md))

- **D2 In-memory MemoryJobStore** — cron config re-renders on every boot, no persistence contention with the BL4 pool. Combined with ID6 reaper handling stale `running` rows, this is sufficient for a single-orchestrator deployment.
- **D6 Scheduler enqueues, jobs worker executes** — decoupled. A slow library_sync can never block the scheduler's next tick.
- **D7 Dedup at enqueue time** — mirrors the manual sync endpoint, so cron + operator triggers don't race onto duplicate rows.
- **D11 Scheduler start failure does NOT crash boot** — logged at CRITICAL; `/health` returns 503 per JQ3 contract.

## Test plan

- [x] `pytest tests/` — **830 pass** (+25 new):
  - 7 in `tests/scheduler/test_jobs.py` (enqueue, dedup, error swallow)
  - 7 in `tests/scheduler/test_manager.py` (start/stop/running/jobs)
  - 3 in `tests/api/test_lifespan_scheduler.py` (integration via `asgi_lifespan`)
  - 5 in `tests/core/test_settings.py` (defaults + bounds)
  - 3 in `tests/api/test_health_endpoint.py` (probe-absent fallback + running wiring)
- [x] `ruff check`, `ruff format --check`, `mypy --strict src/` (44 source files), `gitleaks`, `semgrep p/owasp-top-ten` — all clean
- [x] Security audit ([`docs/security-audits/f12-scheduler-subsystem-security-audit.md`](docs/security-audits/f12-scheduler-subsystem-security-audit.md)) — 0 findings

## /health flips to 200 when validator subsystem ships

After this merges, `scheduler_running: true` + `lancache_reachable: true` (ID2) → only `validator_healthy` remains stub-false. F7 validator is the last subsystem needed for `/health` to return 200.

## Test-gate state

Counter ticks to 1/2 (post-UAT-7 was 0/2). One more autonomous feature shippable before UAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)