### PR TITLE
fix(uat9): steam-next dict-gid enumeration + jobs kind Literal

### DIFF
--- a/src/orchestrator/api/routers/jobs.py
+++ b/src/orchestrator/api/routers/jobs.py
@@ -81,7 +81,7 @@ class JobResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     id: int
-    kind: Literal["prefill", "validate", "library_sync", "auth_refresh", "sweep"]
+    kind: Literal["prefill", "validate", "library_sync", "auth_refresh", "sweep", "manifest_fetch"]
     game_id: int | None
     platform: Literal["steam", "epic"] | None
     state: Literal["queued", "running", "succeeded", "failed", "cancelled"]

--- a/src/orchestrator/platform/steam/enumerate.py
+++ b/src/orchestrator/platform/steam/enumerate.py
@@ -180,3 +180,49 @@ def enumerate_apps(
         resp = client.get_product_info(apps=batch)
         out.extend(_extract_app_metadata(resp, batch))
     return out
+
+
+def extract_manifest_gid(entry: Any) -> int | None:
+    """Extract a manifest gid from a depot's ``manifests[branch]`` entry.
+
+    Steam-next 1.4.4's ``CDNClient.get_manifests`` assumes this entry is a
+    bare gid string and does ``int(entry)``. Current Steam returns it as a
+    dict — ``{"gid": "...", "size": "...", "download": "..."}`` — so the
+    library raises ``int() argument ... not 'dict'`` (surfaced live in
+    UAT-9). Handle both the legacy string form and the dict form. Returns
+    the gid as int, or ``None`` if absent/unparseable.
+    """
+    if isinstance(entry, dict):
+        entry = entry.get("gid")
+    if entry is None:
+        return None
+    try:
+        return int(entry)
+    except (TypeError, ValueError):
+        return None
+
+
+def manifest_gids_for_app(depots: Any, branch: str = "public") -> list[tuple[int, int]]:
+    """From ``CDNClient.get_app_depot_info()`` output, return
+    ``[(depot_id, manifest_gid)]`` for depots that publish a manifest on
+    ``branch``.
+
+    Skips non-depot keys (``branches``, ``baselanguages``, etc.), depots
+    with no ``manifests`` mapping (e.g. ``depotfromapp`` shared depots), and
+    entries with no/unparseable gid for the branch. Pure — no network — so
+    it is unit-testable without a Steam session.
+    """
+    out: list[tuple[int, int]] = []
+    if not isinstance(depots, dict):
+        return out
+    for key, info in depots.items():
+        if not str(key).isdigit() or not isinstance(info, dict):
+            continue
+        manifests = info.get("manifests")
+        if not isinstance(manifests, dict):
+            continue
+        gid = extract_manifest_gid(manifests.get(branch))
+        if gid is None:
+            continue
+        out.append((int(key), gid))
+    return out

--- a/src/orchestrator/platform/steam/worker.py
+++ b/src/orchestrator/platform/steam/worker.py
@@ -261,11 +261,30 @@ def _handle_manifest_fetch(msg_id: str, params: dict[str, str]) -> None:
         if _cdn_client is None:
             _cdn_client = CDNClient(_client)
 
-        manifests = _cdn_client.get_manifests(app_id, branch="public")
+        # NOTE (UAT-9): we deliberately do NOT call CDNClient.get_manifests().
+        # steam-next 1.4.4 assumes depot_info["manifests"][branch] is a bare
+        # gid string and does int() on it; current Steam returns a dict
+        # ({"gid","size","download"}), so the library raises
+        # "int() argument ... not 'dict'". We replicate the enumeration with
+        # a dict-aware gid extractor (enumerate.manifest_gids_for_app) and
+        # fetch each depot manifest ourselves, skipping depots we can't
+        # access (unowned/shared) rather than failing the whole job.
+        depots = _cdn_client.get_app_depot_info(app_id)
+        depot_gids = enumerate_module.manifest_gids_for_app(depots, "public")
         compressor = _zstd.ZstdCompressor(level=3)
 
         payload: list[dict[str, Any]] = []
-        for mfst in manifests:
+        skipped: list[dict[str, Any]] = []
+        for depot_id, gid in depot_gids:
+            try:
+                code = _cdn_client.get_manifest_request_code(app_id, depot_id, gid)
+                mfst = _cdn_client.get_manifest(
+                    app_id, depot_id, gid, decrypt=True, manifest_request_code=code
+                )
+            except Exception as e:
+                skipped.append({"depot_id": depot_id, "reason": f"{type(e).__name__}: {e}"[:120]})
+                continue
+
             data = mfst.serialize()  # raw protobuf bytes
             compressed = compressor.compress(data)
 
@@ -276,25 +295,22 @@ def _handle_manifest_fetch(msg_id: str, params: dict[str, str]) -> None:
             blob_path = _blob_temp_path("manifest")
             blob_path.write_bytes(compressed)
 
-            # Sum chunk counts across all file mappings.
             chunk_count = 0
             for mapping in mfst.payload.mappings:
                 chunk_count += len(mapping.chunks)
-
-            total_bytes = int(mfst.metadata.cb_disk_original or 0)
 
             payload.append(
                 {
                     "depot_id": int(mfst.depot_id),
                     "manifest_gid": int(mfst.gid),
-                    "name": str(mfst.name or ""),
-                    "total_bytes": total_bytes,
+                    "name": str(getattr(mfst, "name", "") or ""),
+                    "total_bytes": int(mfst.metadata.cb_disk_original or 0),
                     "chunk_count": chunk_count,
                     "raw_path": str(blob_path),
                 }
             )
 
-        _ok(msg_id, {"manifests": payload})
+        _ok(msg_id, {"manifests": payload, "skipped": skipped})
     except Exception as e:
         _err(msg_id, "SteamAPIError", str(e)[:200])
 

--- a/tests/api/test_jobs_router.py
+++ b/tests/api/test_jobs_router.py
@@ -566,3 +566,32 @@ class TestJobsPoolFailure:
         )
         assert r.status_code == 503
         assert r.json() == {"detail": "database unavailable"}
+
+
+def test_job_response_accepts_all_db_job_kinds():
+    """UAT-9 regression: the /jobs response model dropped manifest_fetch rows
+    (its kind Literal was stale), silently hiding them from the API. The
+    model's allowed kinds must match the jobs.kind DB CHECK constraint."""
+    from orchestrator.api.routers.jobs import JobResponse
+
+    for kind in (
+        "prefill",
+        "validate",
+        "library_sync",
+        "auth_refresh",
+        "sweep",
+        "manifest_fetch",
+    ):
+        JobResponse(
+            id=1,
+            kind=kind,
+            game_id=None,
+            platform="steam",
+            state="queued",
+            progress=None,
+            source="api",
+            started_at=None,
+            finished_at=None,
+            error=None,
+            payload=None,
+        )

--- a/tests/platform/steam/test_enumerate.py
+++ b/tests/platform/steam/test_enumerate.py
@@ -359,3 +359,47 @@ class TestEnumerateApps:
     def test_default_batch_size_constant(self):
         # Sanity: 50 packages per call balances Steam's 15s job timeout vs round-trip count
         assert DEFAULT_BATCH_SIZE == 50
+
+
+class TestManifestGidExtraction:
+    """UAT-9: steam-next 1.4.4 chokes on the dict-form manifests[branch]
+    entry. Our dict-aware extractor must handle both forms."""
+
+    def test_legacy_string_gid(self):
+        from orchestrator.platform.steam.enumerate import extract_manifest_gid
+
+        assert extract_manifest_gid("7611933945298954112") == 7611933945298954112
+
+    def test_dict_form_gid(self):
+        from orchestrator.platform.steam.enumerate import extract_manifest_gid
+
+        entry = {"gid": "7611933945298954112", "size": "123", "download": "45"}
+        assert extract_manifest_gid(entry) == 7611933945298954112
+
+    def test_none_and_unparseable(self):
+        from orchestrator.platform.steam.enumerate import extract_manifest_gid
+
+        assert extract_manifest_gid(None) is None
+        assert extract_manifest_gid({}) is None
+        assert extract_manifest_gid({"gid": None}) is None
+        assert extract_manifest_gid("not-a-number") is None
+
+    def test_manifest_gids_for_app_filters_and_extracts(self):
+        from orchestrator.platform.steam.enumerate import manifest_gids_for_app
+
+        depots = {
+            "branches": {"public": {"buildid": "1"}},  # non-depot key, skipped
+            "baselanguages": "english",  # non-depot, skipped
+            "529341": {"manifests": {"public": {"gid": "100", "size": "1"}}},
+            "529345": {"manifests": {"public": "200"}},  # legacy string form
+            "529346": {"manifests": {"beta": {"gid": "300"}}},  # no public, skipped
+            "529347": {"depotfromapp": "228980"},  # shared depot, no manifests
+        }
+        result = manifest_gids_for_app(depots, "public")
+        assert sorted(result) == [(529341, 100), (529345, 200)]
+
+    def test_manifest_gids_for_app_non_dict(self):
+        from orchestrator.platform.steam.enumerate import manifest_gids_for_app
+
+        assert manifest_gids_for_app(None) == []
+        assert manifest_gids_for_app([]) == []


### PR DESCRIPTION
## Summary

Two bugs surfaced by the **UAT-9 live test** — both invisible to the unit tests, which stubbed steam-next entirely. This is the payoff of validating against real Steam + the real cache.

### 1. steam-next 1.4.4 incompatible with current Steam manifest format (manifest fetch failed)

`CDNClient.get_manifests()` does `int(manifest_gid)` where `manifest_gid = depot_info["manifests"][branch]`. Current Steam returns that as a **dict** (`{"gid","size","download"}`), not a bare gid string, so the library raises `int() argument ... not 'dict'` and **every manifest fetch fails**. steam-next 1.4.4 is pinned and unmaintained.

Fix: the worker no longer calls `get_manifests()`. It enumerates depots via `get_app_depot_info()` + a dict-aware gid extractor (`enumerate.manifest_gids_for_app`, pure/unit-tested for both the legacy string and new dict forms) and fetches each depot manifest directly, **skipping depots it can't access** (unowned/shared) rather than failing the whole job.

### 2. `/jobs` endpoint silently dropped `manifest_fetch` rows

The `JobResponse.kind` Literal was missing `manifest_fetch`, so the endpoint hit `response_model_validation_failed` and dropped those rows — manifest-fetch jobs were invisible via the API. Added the value to match the `jobs.kind` DB CHECK.

## Testing

- New unit tests: `extract_manifest_gid` (string + dict + None/unparseable), `manifest_gids_for_app` (skips `branches`/`baselanguages`/shared depots, extracts both gid forms), `JobResponse` accepts all six DB job kinds.
- Full suite **938 pass**; ruff/mypy clean.
- **Live-confirmed in UAT-9:** fix #2 verified (the `/jobs` endpoint now shows the `manifest_fetch` job); fix #1 confirmed against real Steam during the UAT-9 fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)