### PR TITLE
fix(db): bounded reader acquire — fix SEV-2 reader-exhaustion deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — Security/Stability: DB pool reader-exhaustion deadlock (SEV-2) — 2026-06-02
+
+Surfaced by the multi-agent code review. On reader I/O errors (e.g. a failing DB volume), `_replace_connection`'s storm-guard and replacement-open-failure paths returned **without re-queueing** the reader, permanently shrinking the reader pool; with `_checkout_reader` awaiting `self._readers.get()` with **no timeout**, once the queue drained **every read blocked forever** while the pool still reported `state="ready"` and raised no `PoolError`. The existing chaos/slow tests masked it (they asserted only a health symptom, never the loud-failure contract, and never issued the follow-up read that would hang).
+
+- **Bounded reader acquire** (`db/pool.py` `_acquire_reader`): reads now wait at most `pool_reader_acquire_timeout_sec` (default 30 s) for a free reader; on exhaustion they raise `PoolError` (→ 503) instead of hanging — fail loud, not silent.
+- **Lost-slot tracking + heal-on-exhaustion:** a give-up replacement now records the lost slot (`_lost_reader_slots`) instead of silently leaking it; on an acquire timeout with a recorded deficit the pool opens a fresh reader, so capacity **recovers automatically once the fault clears** (rather than requiring a restart).
+- New setting `pool_reader_acquire_timeout_sec` (default 30.0, range 0<t≤300).
+- New regression tests `tests/db/test_pool_reader_exhaustion.py` (exhaustion → `PoolError` within bounded wall-clock, not a hang; recovery after the fault clears). Strengthened the two masking storm tests to assert the lost-slot contract. Full suite: 966 pass + 3 slow.
+
 ### Added — F5 Steam CDN Prefill — 2026-05-29
 
 Implements F5 from PROJECT_BIBLE §1.2 — downloads a Steam game's depot chunks **through** the lancache so they get cached. Together with F7 this closes the orchestrator's core loop (prefill → cache → validate). Steam-only; F6 (Epic) deferred.

--- a/src/orchestrator/core/settings.py
+++ b/src/orchestrator/core/settings.py
@@ -120,6 +120,11 @@ class Settings(BaseSettings):
     # --- DB pool & SQLite tuning (BL4) ---
     pool_readers: int = Field(default=8, ge=1, le=32)
     pool_busy_timeout_ms: int = Field(default=5000, ge=0, le=60000)
+    # SEV-2 fix (code review 2026-06-02): bound how long a read waits for a
+    # free reader connection. If the reader pool is exhausted (e.g. slots lost
+    # to failed replacements after disk I/O errors), reads raise PoolError
+    # rather than blocking forever.
+    pool_reader_acquire_timeout_sec: float = Field(default=30.0, gt=0.0, le=300.0)
     db_cache_size_kib: int = Field(default=16384, ge=1024, le=1048576)
     db_mmap_size_bytes: int = Field(default=268_435_456, ge=0, le=17_179_869_184)
     db_journal_size_limit_bytes: int = Field(default=67_108_864, ge=1_048_576, le=1_073_741_824)

--- a/src/orchestrator/db/pool.py
+++ b/src/orchestrator/db/pool.py
@@ -548,6 +548,7 @@ class Pool:
         cache_size_kib: int,
         mmap_size_bytes: int,
         journal_size_limit_bytes: int,
+        reader_acquire_timeout_sec: float = 30.0,
     ) -> None:
         # V-1: enforce readers_count floor at the Pool layer too. Settings
         # already constrains 1..32 for the singleton path, but Pool.create()
@@ -563,6 +564,7 @@ class Pool:
             )
         self._database_path = database_path
         self._readers_count = readers_count
+        self._reader_acquire_timeout = reader_acquire_timeout_sec
         self._busy_timeout_ms = busy_timeout_ms
         self._cache_size_kib = cache_size_kib
         self._mmap_size_bytes = mmap_size_bytes
@@ -578,6 +580,11 @@ class Pool:
 
         self._writer_healthy = False
         self._reader_healthy: dict[int, bool] = {}
+        # SEV-2 fix: count reader slots lost when a replacement gives up
+        # (storm guard or replacement-open failure). Drives heal-on-acquire
+        # so capacity is restored once the fault clears, and lets the bounded
+        # acquire distinguish "exhausted" from "all readers merely busy".
+        self._lost_reader_slots = 0
         self._replacement_count: dict[str, int] = {"writer": 0, "reader": 0}
         self._replacement_timestamps: dict[str, list[float]] = {
             "writer": [],
@@ -621,6 +628,7 @@ class Pool:
         cache_size_kib: int = 16384,
         mmap_size_bytes: int = 268_435_456,
         journal_size_limit_bytes: int = 67_108_864,
+        reader_acquire_timeout_sec: float = 30.0,
         skip_schema_verify: bool = False,
     ) -> _PoolCreator:
         """Construct a pool. Supports both `await Pool.create(...)` and
@@ -634,6 +642,7 @@ class Pool:
                 "cache_size_kib": cache_size_kib,
                 "mmap_size_bytes": mmap_size_bytes,
                 "journal_size_limit_bytes": journal_size_limit_bytes,
+                "reader_acquire_timeout_sec": reader_acquire_timeout_sec,
                 "skip_schema_verify": skip_schema_verify,
             },
         )
@@ -648,6 +657,7 @@ class Pool:
         cache_size_kib: int,
         mmap_size_bytes: int,
         journal_size_limit_bytes: int,
+        reader_acquire_timeout_sec: float,
         skip_schema_verify: bool,
     ) -> Pool:
         pool = cls(
@@ -657,6 +667,7 @@ class Pool:
             cache_size_kib=cache_size_kib,
             mmap_size_bytes=mmap_size_bytes,
             journal_size_limit_bytes=journal_size_limit_bytes,
+            reader_acquire_timeout_sec=reader_acquire_timeout_sec,
         )
         try:
             pool._writer = await pool._open_connection(role="writer")
@@ -791,11 +802,59 @@ class Pool:
 
     # --- Connection checkout helpers ----------------------------------
 
+    async def _acquire_reader(self) -> aiosqlite.Connection:
+        """Get a reader from the queue, bounded by reader_acquire_timeout.
+
+        SEV-2 fix: a plain `await self._readers.get()` blocks forever once the
+        queue is drained (e.g. slots lost to failed replacements after disk
+        I/O errors), deadlocking all reads while the pool still reports
+        "ready". Instead we time out; if slots were lost we try to heal one
+        (so the pool recovers when the fault clears), otherwise we raise
+        PoolError so callers fail loudly (→ 503) rather than hanging.
+        """
+        try:
+            return await asyncio.wait_for(self._readers.get(), timeout=self._reader_acquire_timeout)
+        except TimeoutError as exc:
+            # Only open a replacement if a slot was genuinely lost — never
+            # exceed readers_count just because all readers are momentarily
+            # busy (that would overflow the bounded queue on release).
+            if self._lost_reader_slots > 0:
+                try:
+                    new_conn = await self._open_connection(role="reader")
+                except Exception as e:
+                    raise PoolError(
+                        "reader pool exhausted: replacement connection could not "
+                        f"be opened ({type(e).__name__})"
+                    ) from e
+                self._adopt_reader(new_conn)
+                self._lost_reader_slots -= 1
+                _log.warning("pool.reader_slot_healed", remaining_deficit=self._lost_reader_slots)
+                return new_conn
+            raise PoolError(
+                f"reader pool exhausted: no reader available within {self._reader_acquire_timeout}s"
+            ) from exc
+
+    def _adopt_reader(self, conn: aiosqlite.Connection) -> None:
+        """Register a freshly-healed reader into a known-dead slot (or append
+        if none), so _reader_pool / _reader_healthy stay consistent and
+        health_check probes the live connection."""
+        for i in range(self._readers_count):
+            if not self._reader_healthy.get(i, False):
+                if i < len(self._reader_pool):
+                    self._reader_pool[i] = conn
+                else:
+                    self._reader_pool.append(conn)
+                self._reader_healthy[i] = True
+                return
+        # No dead slot recorded — append defensively (should not normally hit
+        # since a positive deficit implies a dead slot exists).
+        self._reader_pool.append(conn)
+
     @asynccontextmanager
     async def _checkout_reader(self) -> AsyncIterator[aiosqlite.Connection]:
         if self._state != "ready":
             raise PoolClosedError(state=self._state)
-        reader = await self._readers.get()
+        reader = await self._acquire_reader()
         healthy_after = True
         try:
             yield reader
@@ -859,12 +918,20 @@ class Pool:
                 raise PoolError("reader replacement requires reader_index")
             self._reader_healthy[reader_index] = False
 
-        # Storm guard: > 3 replacements in 60s → degraded; refuse further
+        # Storm guard: > 3 replacements in 60s → refuse further replacement.
+        # SEV-2 fix: the reader was already removed from the queue by
+        # _checkout_reader; giving up here without re-queueing permanently
+        # shrinks capacity, so record the lost slot. The bounded acquire +
+        # heal-on-exhaustion then keep reads loud (PoolError) and let capacity
+        # recover once the fault clears.
         if len(recent) > 3:
+            if role == "reader":
+                self._lost_reader_slots += 1
             _log.critical(
                 "pool.replacement_storm",
                 role=role,
                 count_in_60s=len(recent),
+                lost_reader_slots=self._lost_reader_slots,
             )
             return
 
@@ -875,11 +942,17 @@ class Pool:
         try:
             new_conn = await self._open_connection(role=role)
         except Exception as e:
+            # SEV-2 fix: open failed → the reader slot is gone. Record it so
+            # the bounded acquire surfaces a PoolError (not a hang) and a later
+            # acquire can heal the slot once the fault clears.
+            if role == "reader":
+                self._lost_reader_slots += 1
             _log.critical(
                 "pool.replacement_failed",
                 role=role,
                 reader_index=reader_index,
                 reason=str(e),
+                lost_reader_slots=self._lost_reader_slots,
             )
             return
 
@@ -1260,6 +1333,7 @@ async def init_pool(*, verify_schema: bool = True) -> Pool:
             database_path=settings.database_path,
             readers_count=settings.pool_readers,
             busy_timeout_ms=settings.pool_busy_timeout_ms,
+            reader_acquire_timeout_sec=settings.pool_reader_acquire_timeout_sec,
             cache_size_kib=settings.db_cache_size_kib,
             mmap_size_bytes=settings.db_mmap_size_bytes,
             journal_size_limit_bytes=settings.db_journal_size_limit_bytes,

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -286,6 +286,14 @@ class TestFieldValidators:
         with pytest.raises(ValidationError):
             Settings(orchestrator_token=VALID_TOKEN, pool_busy_timeout_ms=-1)
 
+    def test_pool_reader_acquire_timeout_default_and_bounds(self):
+        """SEV-2 fix: bounded reader acquire timeout."""
+        assert Settings(orchestrator_token=VALID_TOKEN).pool_reader_acquire_timeout_sec == 30.0
+        with pytest.raises(ValidationError):
+            Settings(orchestrator_token=VALID_TOKEN, pool_reader_acquire_timeout_sec=0)
+        with pytest.raises(ValidationError):
+            Settings(orchestrator_token=VALID_TOKEN, pool_reader_acquire_timeout_sec=301)
+
     def test_db_cache_size_below_min_rejects(self):
         with pytest.raises(ValidationError):
             Settings(orchestrator_token=VALID_TOKEN, db_cache_size_kib=1023)

--- a/tests/db/test_pool_chaos.py
+++ b/tests/db/test_pool_chaos.py
@@ -105,8 +105,10 @@ class TestWriterReplacement:
 
 class TestStormGuard:
     async def test_storm_guard_trips_after_3_replacements_in_60s(self, pool: Pool, monkeypatch):
-        """Forcing 4+ replacements within 60s trips the storm guard; pool
-        transitions to degraded."""
+        """Forcing 4+ replacements within 60s trips the storm guard; each
+        give-up records a lost reader slot (SEV-2 fix) and the readers report
+        unhealthy. The full loud-failure (PoolError, not deadlock) + recovery
+        contract is covered by tests/db/test_pool_reader_exhaustion.py."""
 
         async def always_io_error(self, sql, parameters=()):
             raise aiosqlite.OperationalError("disk I/O error")
@@ -115,17 +117,18 @@ class TestStormGuard:
 
         # Trigger replacements rapidly
         for _ in range(4):
-            with contextlib.suppress(ConnectionLostError):
+            with contextlib.suppress(ConnectionLostError, aiosqlite.OperationalError):
                 await pool.read_one("SELECT 1")
             await asyncio.sleep(0.05)
 
         await asyncio.sleep(0.5)
 
-        # After storm guard trips, the pool's degraded
-        # Next op should raise PoolError indicating degraded state
-        # OR all readers may now be marked unhealthy
+        # SEV-2 fix: a give-up replacement no longer silently leaks the reader
+        # slot — it is recorded, so exhaustion is detectable rather than a
+        # silent deadlock.
+        assert pool._lost_reader_slots >= 1
+
         health = await pool.health_check()
-        # Either readers are mostly unhealthy OR the writer is unhealthy
         unhealthy_readers = health["readers"]["total"] - health["readers"]["healthy"]
         assert unhealthy_readers >= 1 or not health["writer"]["healthy"]
 

--- a/tests/db/test_pool_reader_exhaustion.py
+++ b/tests/db/test_pool_reader_exhaustion.py
@@ -1,0 +1,84 @@
+"""Regression tests for the SEV-2 reader-exhaustion deadlock (code review 2026-06-02).
+
+Bug: when reader I/O errors drive connection replacement and the replacement
+gives up (storm guard, or the replacement open itself fails), the reader is
+pulled from the queue but never put back — capacity shrinks permanently. With
+`_checkout_reader` awaiting `_readers.get()` with no timeout, once the queue
+drains EVERY read blocks forever, while the pool still reports state="ready"
+and raises no PoolError.
+
+These tests assert the fixed contract:
+  1. Reader exhaustion raises `PoolError` within a bounded time — never hangs.
+  2. The pool recovers reader capacity once the underlying fault clears.
+
+The outer `asyncio.wait_for(...)` in each test is a HANG DETECTOR: on the
+buggy code the read blocks forever and `wait_for` raises `TimeoutError`
+instead of the expected `PoolError`, failing the test loudly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import TYPE_CHECKING
+
+import aiosqlite
+import pytest
+
+from orchestrator.db.pool import ConnectionLostError, Pool, PoolError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _drain_all_readers(pool: Pool, monkeypatch) -> None:
+    """Force every reader to fail + every replacement-open to fail, so all
+    reader slots leak out of the queue. Leaves `execute` patched to error."""
+
+    async def always_io_error(self, sql, parameters=()):
+        raise aiosqlite.OperationalError("disk I/O error")
+
+    monkeypatch.setattr(aiosqlite.Connection, "execute", always_io_error)
+
+    # One failing read per reader drains that slot (the failed background
+    # replacement gives up and never re-queues). A couple extra for safety.
+    for _ in range(pool._readers_count + 2):
+        with contextlib.suppress(aiosqlite.OperationalError, ConnectionLostError, PoolError):
+            await pool.read_one("SELECT 1")
+    # Let the fire-and-forget replacement tasks finish failing.
+    await asyncio.sleep(0.3)
+
+
+async def test_reader_exhaustion_raises_poolerror_not_deadlock(db_path: Path, monkeypatch):
+    async with Pool.create(
+        database_path=db_path,
+        readers_count=2,
+        reader_acquire_timeout_sec=0.3,
+    ) as pool:
+        await _drain_all_readers(pool, monkeypatch)
+
+        # The queue is now empty and every replacement open still fails, so a
+        # read must surface a PoolError (loud) rather than blocking forever.
+        with pytest.raises(PoolError):
+            await asyncio.wait_for(pool.read_one("SELECT 1"), timeout=5.0)
+
+
+async def test_reader_pool_recovers_after_fault_clears(db_path: Path, monkeypatch):
+    async with Pool.create(
+        database_path=db_path,
+        readers_count=2,
+        reader_acquire_timeout_sec=0.3,
+    ) as pool:
+        await _drain_all_readers(pool, monkeypatch)
+
+        # Fault clears: restore real execute. The next read must heal a reader
+        # slot on the acquire-timeout path and succeed.
+        monkeypatch.undo()
+        row = await asyncio.wait_for(pool.read_one("SELECT 1 AS one"), timeout=5.0)
+        assert row is not None and row["one"] == 1
+
+        # And the pool keeps serving afterwards.
+        row2 = await asyncio.wait_for(pool.read_one("SELECT 2 AS two"), timeout=5.0)
+        assert row2["two"] == 2

--- a/tests/db/test_pool_slow.py
+++ b/tests/db/test_pool_slow.py
@@ -97,9 +97,14 @@ async def test_sustained_concurrent_workload(populated_pool: Pool):
 
 
 @pytest.mark.slow
-async def test_replacement_storm_guard_under_load(pool: Pool, monkeypatch):
-    """Pathologically broken connection forces many replacements in 60s; storm
-    guard trips and pool transitions to degraded state."""
+async def test_replacement_storm_guard_under_load(db_path, monkeypatch):
+    """Pathologically broken reads force many replacements in 60s; the storm
+    guard trips and records lost reader slots (SEV-2 fix) instead of silently
+    leaking them. Loud-failure + recovery contract: see
+    tests/db/test_pool_reader_exhaustion.py.
+
+    Uses a short reader_acquire_timeout so the post-exhaustion reads fail fast
+    instead of blocking on the production default."""
     original_execute = aiosqlite.Connection.execute
 
     async def io_error_for_reads(self, sql, parameters=()):
@@ -107,20 +112,22 @@ async def test_replacement_storm_guard_under_load(pool: Pool, monkeypatch):
             raise aiosqlite.OperationalError("disk I/O error")
         return await original_execute(self, sql, parameters)
 
-    monkeypatch.setattr(aiosqlite.Connection, "execute", io_error_for_reads)
+    async with Pool.create(
+        database_path=db_path, readers_count=4, reader_acquire_timeout_sec=0.3
+    ) as pool:
+        monkeypatch.setattr(aiosqlite.Connection, "execute", io_error_for_reads)
 
-    # Hammer reads in parallel to trigger replacements
-    async def trigger():
-        with contextlib.suppress(Exception):
-            await pool.read_one("SELECT 1")
+        async def trigger():
+            with contextlib.suppress(Exception):
+                await pool.read_one("SELECT 1")
 
-    await asyncio.gather(*(trigger() for _ in range(10)))
-    await asyncio.sleep(2)
+        await asyncio.gather(*(trigger() for _ in range(10)))
+        await asyncio.sleep(2)
 
-    # After storm guard, pool is degraded
-    health = await pool.health_check()
-    # All readers should be unhealthy now (storm guard refused further replacements)
-    assert health["readers"]["healthy"] < health["readers"]["total"]
+        # Storm guard tripped → at least one reader slot recorded as lost.
+        assert pool._lost_reader_slots >= 1
+        health = await pool.health_check()
+        assert health["readers"]["healthy"] < health["readers"]["total"]
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary

Fixes the **SEV-2** deadlock surfaced by the code review: under reader I/O errors (e.g. a failing DB volume), the connection pool could **deadlock all reads** while still reporting healthy.

### The bug

On a reader I/O error, `_checkout_reader` pulls the dead reader from the queue and spawns `_replace_connection` to restore it. But `_replace_connection` has two early-return paths — the **storm guard** (>3 replacements/60 s) and **replacement-open failure** — that return *before* re-queueing, so reader capacity drops by one **permanently** each time. Because `_checkout_reader` awaited `self._readers.get()` with **no timeout**, once the queue drained **every read blocked forever**, while the pool stayed `state="ready"` and raised no `PoolError`. The trigger is exactly a failing disk. The existing chaos/slow tests **masked** it (asserting only a health symptom, never the loud-failure contract, never the follow-up read that would hang).

### The fix

- **Bounded acquire** (`_acquire_reader`): reads wait at most `pool_reader_acquire_timeout_sec` (default 30 s); on exhaustion they raise `PoolError` (→ 503) instead of hanging — **fail loud, not silent**.
- **Lost-slot tracking** (`_lost_reader_slots`): a give-up replacement records the lost slot instead of silently leaking it.
- **Heal-on-exhaustion:** on an acquire timeout with a recorded deficit, open a fresh reader → capacity **recovers automatically once the fault clears** (no restart). The deficit gate prevents opening beyond `readers_count` when readers are merely busy.
- New setting `pool_reader_acquire_timeout_sec` (default 30.0, 0<t≤300).

### Testing (TDD)

- New `tests/db/test_pool_reader_exhaustion.py`: exhaustion → `PoolError` within bounded wall-clock (the outer `wait_for` is a hang-detector — it fails loudly if the read still blocks); and recovery after the fault clears.
- **Strengthened the two masking storm tests** to assert the lost-slot contract (and gave the slow one a short timeout so it no longer waits 30 s).
- Full suite **966 pass** + 3 slow; ruff/mypy/gitleaks clean.

Found by the multi-agent code review (the headline finding). Other review items (the scheduler SEV-2, heartbeat/logging/order-by SEV-3s) are separate and not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)