### PR TITLE
fix(scheduler): dispose stale scheduler in start(), lock the lifecycle (SEV-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — Stability: scheduler `start()` no longer leaks a stale instance (SEV-2) — 2026-06-02
+
+From the 2026-06-02 code review. `SchedulerManager.start()` guarded idempotency with `if self._scheduler is not None and self._scheduler.running: return`. On the **non-running** path — a held-but-stopped scheduler, e.g. after a prior `shutdown()` that raised partway and left `_scheduler` dangling — `start()` fell through and **overwrote** `self._scheduler` with a fresh `AsyncIOScheduler`, silently abandoning the prior object instead of disposing of it. The "idempotent start" contract was false on that path. Currently unreachable via the single-call lifespan, but a latent lifecycle bug.
+
+- `start()` now disposes any held-but-stopped scheduler (warning `scheduler.replacing_stale_instance` + new best-effort `_dispose_stale_scheduler()`, which clears the reference and stops the instance if it is somehow still running) **before** building a fresh one — the manager never abandons a scheduler it owns.
+- Hardened per an adversarial review of the fix: `start()`/`shutdown()` are now serialized behind an `asyncio.Lock`, and `_dispose_stale_scheduler()` is synchronous, so the rebuild is atomic and a future concurrent caller (e.g. a restart endpoint) can never race to construct two schedulers. Uncontended acquire does not suspend, so the single sequential lifespan path is unchanged. (The reviewed TOCTOU/`wakeup`-after-`_eventloop=None` races were shown empirically to be unreachable in the current code; the lock makes the atomicity explicit and durable rather than resting on a subtle no-await invariant.)
+- +3 regression tests (`tests/scheduler/test_manager.py`): replacing a stale non-running instance emits the warning, runs the dispose path, and swaps cleanly (no silent leak); end-to-end recovery after a dangling scheduler yields a fully functional, job-registered scheduler; and two concurrent `start()` calls after a dangling scheduler converge on exactly one running instance. Tests use `structlog.testing.CapturingLogger` patched onto the module logger (the app sets `cache_logger_on_first_use=True`, which defeats `capture_logs` once any earlier test caches the bound logger) and poll for APScheduler's deferred shutdown to keep the precondition deterministic. Full suite: 966 pass. ruff/mypy(strict, `src/`)/gitleaks clean. Security audit: 0 findings (`docs/security-audits/scheduler-start-leak-fix-security-audit.md`).
+
 ### Added — F5 Steam CDN Prefill — 2026-05-29
 
 Implements F5 from PROJECT_BIBLE §1.2 — downloads a Steam game's depot chunks **through** the lancache so they get cached. Together with F7 this closes the orchestrator's core loop (prefill → cache → validate). Steam-only; F6 (Epic) deferred.

--- a/docs/security-audits/scheduler-start-leak-fix-security-audit.md
+++ b/docs/security-audits/scheduler-start-leak-fix-security-audit.md
@@ -1,0 +1,41 @@
+# Security Audit — Scheduler `start()` stale-instance leak fix (SEV-2)
+
+**Date:** 2026-06-02
+**Scope:** `src/orchestrator/scheduler/manager.py` (`SchedulerManager.start`, `shutdown`,
+new `_dispose_stale_scheduler`, new `asyncio.Lock`); `tests/scheduler/test_manager.py`.
+**Origin:** Backlog item from the 2026-06-02 full code review (see
+`project_code_review_2026_06_02`). Persona: Senior Security Engineer — hunt concrete
+exploits, not check boxes.
+
+## Change summary
+
+`start()` previously short-circuited only when the held scheduler was *running*; on the
+non-running path it overwrote `self._scheduler`, abandoning the prior instance. The fix
+disposes of any held-but-stopped scheduler (warning + best-effort `_dispose_stale_scheduler`)
+before rebuilding, and serializes `start()`/`shutdown()` behind an `asyncio.Lock` so the
+lifecycle stays atomic under any future concurrent caller.
+
+## Threat review
+
+| # | Vector | Assessment |
+|---|--------|------------|
+| 1 | **Deadlock / DoS via the new lock** | The lock is acquired only in `start()`/`shutdown()`, never nested, and never held across a blocking await. Inside `start()` the lock-held body is fully synchronous; inside `shutdown()` the only call is `AsyncIOScheduler.shutdown(wait=True)`, which APScheduler defers via `call_soon_threadsafe` and returns immediately (it does not block the loop). No path holds the lock indefinitely → no deadlock. **No reachable trigger** anyway: neither method is exposed to a request; the lifespan calls each once. |
+| 2 | **Exception swallowing hides a security-relevant failure** | `_dispose_stale_scheduler` swallows exceptions from `stale.shutdown(wait=False)` (defensive `stale.running` branch only) and logs `scheduler.stale_dispose_failed` with `str(e)[:200]`. Scheduler-shutdown errors carry no secrets; the message is truncated. Net effect is *more* robust teardown, not less. |
+| 3 | **Information disclosure via new log events** | New events `scheduler.replacing_stale_instance` (no fields) and `scheduler.stale_dispose_failed` (truncated error string). No credentials, tokens, PII, or job payloads are logged. |
+| 4 | **Resource exhaustion** | The fix *removes* a resource leak (abandoned `AsyncIOScheduler` + executor + jobstore + loop timer). Disposal clears the reference (and stops a still-running instance), enabling GC. Net-positive posture. |
+| 5 | **New race introduced** | Verified empirically that `await` of the (now removed) non-suspending dispose coroutine did not yield; the synchronous dispose + lock make the rebuild atomic. The change *closes* a TOCTOU window rather than opening one. |
+| 6 | **New external surface** | None. No new inputs, endpoints, auth changes, SQL, filesystem, or network I/O. |
+
+## Findings
+
+**0 security findings.** The change is a stability/robustness fix with a net-positive
+security posture: it eliminates a resource leak and closes a (currently unreachable)
+concurrency window, adds no attack surface, and discloses no sensitive data.
+
+## Out of scope (noted, not fixed here)
+
+A theoretical APScheduler-internal race — a `wakeup()` callback firing after a deferred
+`_shutdown()` set `_eventloop = None` — was raised during adversarial review. It is an
+APScheduler shutdown-mechanics concern, **not introduced by this fix**, and unreachable
+with this deployment's job intervals (21600s / 60s): `_shutdown()` cancels the timer
+before it can fire. No mitigation added.

--- a/src/orchestrator/scheduler/manager.py
+++ b/src/orchestrator/scheduler/manager.py
@@ -14,6 +14,7 @@ table. The BL11 jobs worker picks them up (F12 D6).
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 import structlog
@@ -56,6 +57,11 @@ class SchedulerManager:
         self._enabled = enabled
         self._library_sync_interval_sec = library_sync_interval_sec
         self._scheduler: AsyncIOScheduler | None = None
+        # Serializes start()/shutdown() so the lifecycle stays atomic even if
+        # they are ever called concurrently (e.g. a future restart endpoint).
+        # Uncontended acquire does not suspend, so the single sequential
+        # lifespan path is unaffected.
+        self._lock = asyncio.Lock()
 
     @property
     def running(self) -> bool:
@@ -65,52 +71,86 @@ class SchedulerManager:
 
     async def start(self) -> None:
         """Construct the AsyncIOScheduler, register jobs, start running.
-        No-op when disabled or already started (F12 D11)."""
+        No-op when disabled or already running (F12 D11).
+
+        If a previous, non-running scheduler is still held (e.g. a prior
+        shutdown that raised partway and left ``_scheduler`` dangling), it is
+        disposed of before a fresh instance is built — the manager never
+        silently abandons a scheduler it owns (SEV-2, code review 2026-06-02).
+        """
         if not self._enabled:
             _log.info("scheduler.disabled_by_settings")
             return
-        if self._scheduler is not None and self._scheduler.running:
-            return
+        async with self._lock:
+            if self._scheduler is not None:
+                if self._scheduler.running:
+                    return
+                # Non-None but stopped: a partial/failed teardown left the
+                # field dangling. Dispose of it so we replace, not leak.
+                _log.warning("scheduler.replacing_stale_instance")
+                self._dispose_stale_scheduler()
 
-        scheduler = AsyncIOScheduler(
-            timezone="UTC",
-            job_defaults={
-                # D4: only one fire at a time per job
-                "max_instances": 1,
-                # D5: always fire on next opportunity, even if late
-                "misfire_grace_time": None,
-                # Don't coalesce missed fires into a burst — single replay
-                "coalesce": True,
-            },
-        )
+            scheduler = AsyncIOScheduler(
+                timezone="UTC",
+                job_defaults={
+                    # D4: only one fire at a time per job
+                    "max_instances": 1,
+                    # D5: always fire on next opportunity, even if late
+                    "misfire_grace_time": None,
+                    # Don't coalesce missed fires into a burst — single replay
+                    "coalesce": True,
+                },
+            )
 
-        scheduler.add_job(
-            enqueue_library_sync,
-            trigger=IntervalTrigger(seconds=self._library_sync_interval_sec),
-            args=(self._pool,),
-            id=LIBRARY_SYNC_JOB_ID,
-            name="Enqueue library_sync for steam",
-            replace_existing=True,
-        )
+            scheduler.add_job(
+                enqueue_library_sync,
+                trigger=IntervalTrigger(seconds=self._library_sync_interval_sec),
+                args=(self._pool,),
+                id=LIBRARY_SYNC_JOB_ID,
+                name="Enqueue library_sync for steam",
+                replace_existing=True,
+            )
 
-        scheduler.start()
-        self._scheduler = scheduler
-        _log.info(
-            "scheduler.started",
-            library_sync_interval_sec=self._library_sync_interval_sec,
-            jobs=len(scheduler.get_jobs()),
-        )
+            scheduler.start()
+            self._scheduler = scheduler
+            _log.info(
+                "scheduler.started",
+                library_sync_interval_sec=self._library_sync_interval_sec,
+                jobs=len(scheduler.get_jobs()),
+            )
 
     async def shutdown(self) -> None:
         """Stop the scheduler. Idempotent — safe to call when not
-        started or already stopped."""
-        if self._scheduler is None:
-            return
-        if self._scheduler.running:
-            # wait=True drains in-flight callbacks; our callbacks are fast.
-            self._scheduler.shutdown(wait=True)
+        started or already stopped. Serialized against start() via the lock."""
+        async with self._lock:
+            if self._scheduler is None:
+                return
+            if self._scheduler.running:
+                # wait=True drains in-flight callbacks; our callbacks are fast.
+                self._scheduler.shutdown(wait=True)
+            self._scheduler = None
+            _log.info("scheduler.stopped")
+
+    def _dispose_stale_scheduler(self) -> None:
+        """Tear down the held-but-stopped scheduler before a fresh one is built.
+        Clears the reference unconditionally so ``start()`` can always proceed;
+        if the instance is somehow still running (defensive — the caller only
+        reaches here on the non-running path), it is stopped first. Best-effort:
+        a half-torn-down instance may raise on shutdown — swallow it rather than
+        block restart.
+
+        Intentionally synchronous: ``start()`` must hold no ``await`` between its
+        guard check and the ``self._scheduler = scheduler`` assignment so that,
+        together with the lock, the rebuild stays atomic and concurrent callers
+        can never race to construct two schedulers.
+        """
+        stale = self._scheduler
         self._scheduler = None
-        _log.info("scheduler.stopped")
+        try:
+            if stale is not None and stale.running:
+                stale.shutdown(wait=False)
+        except Exception as e:  # pragma: no cover - defensive
+            _log.warning("scheduler.stale_dispose_failed", reason=str(e)[:200])
 
     # --- introspection helpers (used by tests + future status page) ---
 

--- a/tests/scheduler/test_manager.py
+++ b/tests/scheduler/test_manager.py
@@ -2,11 +2,40 @@
 
 from __future__ import annotations
 
-import pytest
+import asyncio
 
+import pytest
+from structlog.testing import CapturingLogger
+
+from orchestrator.scheduler import manager as manager_mod
 from orchestrator.scheduler.manager import SchedulerManager
 
 pytestmark = pytest.mark.asyncio
+
+
+def _logged_events(logger: CapturingLogger) -> list[str]:
+    """Event names from a CapturingLogger patched in for the module logger.
+
+    We patch the module's ``_log`` directly rather than use
+    ``structlog.testing.capture_logs`` because the app configures
+    ``cache_logger_on_first_use=True`` — once any earlier test triggers
+    ``configure_logging()`` the bound logger is cached and ``capture_logs``
+    can no longer intercept it (an order-dependent flake we hit live)."""
+    return [call.args[0] for call in logger.calls if call.args]
+
+
+async def _wait_until_stopped(scheduler: object, timeout_sec: float = 2.0) -> None:
+    """AsyncIOScheduler.shutdown() defers the actual stop to a loop callback,
+    so ``running`` does not flip synchronously. Poll until it does (or fail
+    loudly) so the dangling-stopped precondition is deterministic under load.
+
+    Returning with ``running is False`` also guarantees the deferred
+    ``_shutdown`` callback has run, since ``running`` only flips inside it."""
+    deadline = asyncio.get_running_loop().time() + timeout_sec
+    while scheduler.running:  # type: ignore[attr-defined]
+        if asyncio.get_running_loop().time() > deadline:
+            raise AssertionError("scheduler did not reach stopped state in time")
+        await asyncio.sleep(0.01)
 
 
 class TestSchedulerManager:
@@ -94,5 +123,123 @@ class TestSchedulerManager:
             await mgr.start()
             await mgr.start()  # second call should be a no-op
             assert mgr.running is True
+        finally:
+            await mgr.shutdown()
+
+    async def test_start_replaces_stale_nonrunning_scheduler_without_leak(self, pool, monkeypatch):
+        """SEV-2 (code review 2026-06-02): start()'s idempotency guard only
+        short-circuits when the held scheduler is *running*. If `_scheduler`
+        is non-None but stopped (e.g. a prior shutdown that raised partway and
+        left the field dangling), the old guard fell through and silently
+        overwrote `_scheduler` with a fresh instance — abandoning the prior
+        object instead of disposing of it. The contract must be: never leak a
+        held scheduler — dispose of the stale instance (with a warning) before
+        rebuilding."""
+        mgr = SchedulerManager(
+            pool=pool,
+            enabled=True,
+            library_sync_interval_sec=21600,
+        )
+        try:
+            await mgr.start()
+            stale = mgr._scheduler
+            assert stale is not None and stale.running
+
+            # Reproduce the dangling precondition: the underlying scheduler is
+            # stopped out-of-band, but the manager still references it (exactly
+            # what a partial/failed teardown leaves behind).
+            stale.shutdown(wait=False)
+            await _wait_until_stopped(stale)
+            assert mgr._scheduler is stale and not stale.running
+
+            # Spy on the disposal path so the test discriminates "took the
+            # dispose-and-replace path" from "silently overwrote + only logged".
+            disposed: list[bool] = []
+            real_dispose = mgr._dispose_stale_scheduler
+
+            def spy_dispose() -> None:
+                disposed.append(True)
+                real_dispose()
+
+            monkeypatch.setattr(mgr, "_dispose_stale_scheduler", spy_dispose)
+            rec = CapturingLogger()
+            monkeypatch.setattr(manager_mod, "_log", rec)
+            await mgr.start()
+
+            # A fresh, running scheduler replaced the stale one...
+            assert mgr.running is True
+            assert mgr._scheduler is not stale
+            # ...the disposal path actually ran (not just a logged overwrite)...
+            assert disposed == [True]
+            # ...and the replacement was acknowledged, not a silent leak.
+            assert "scheduler.replacing_stale_instance" in _logged_events(rec)
+        finally:
+            await mgr.shutdown()
+
+    async def test_start_recovers_after_dangling_scheduler(self, pool):
+        """End-to-end recovery: after a stale/dangling scheduler is left in
+        place, a subsequent start() yields a healthy manager that registers
+        its jobs and reports running — proving the dispose-and-rebuild path
+        produces a fully functional scheduler, not just a cleared field."""
+        mgr = SchedulerManager(
+            pool=pool,
+            enabled=True,
+            library_sync_interval_sec=60,
+        )
+        try:
+            await mgr.start()
+            stale = mgr._scheduler
+            assert stale is not None
+            stale.shutdown(wait=False)
+            await _wait_until_stopped(stale)
+            assert not mgr.running
+
+            await mgr.start()
+
+            assert mgr.running is True
+            assert "library_sync_steam" in mgr.get_registered_job_ids()
+            job = mgr.get_job("library_sync_steam")
+            assert job is not None
+            assert job.trigger.interval.total_seconds() == 60.0
+        finally:
+            await mgr.shutdown()
+
+    async def test_concurrent_start_after_stale_does_not_leak(self, pool, monkeypatch):
+        """Concurrency guard: two concurrent start() calls after a dangling
+        scheduler must converge on exactly ONE running scheduler — never two
+        started-but-abandoned instances. The lock (serialization) plus the
+        synchronous dispose (no await between guard and assignment) guarantee
+        the rebuild is atomic; this test pins that contract against regressions
+        (e.g. someone later introducing an await without the lock)."""
+        created: list[object] = []
+        real_cls = manager_mod.AsyncIOScheduler
+
+        def tracking_factory(*args: object, **kwargs: object) -> object:
+            inst = real_cls(*args, **kwargs)
+            created.append(inst)
+            return inst
+
+        monkeypatch.setattr(manager_mod, "AsyncIOScheduler", tracking_factory)
+
+        mgr = SchedulerManager(
+            pool=pool,
+            enabled=True,
+            library_sync_interval_sec=21600,
+        )
+        try:
+            await mgr.start()
+            stale = mgr._scheduler
+            assert stale is not None
+            stale.shutdown(wait=False)
+            await _wait_until_stopped(stale)
+            assert not mgr.running
+
+            # Race two rebuilds.
+            await asyncio.gather(mgr.start(), mgr.start())
+
+            assert mgr.running is True
+            running = [s for s in created if s.running]  # type: ignore[attr-defined]
+            assert len(running) == 1, "concurrent start() leaked a running scheduler"
+            assert running[0] is mgr._scheduler
         finally:
             await mgr.shutdown()


### PR DESCRIPTION
## What & why

Second item from the **2026-06-02 full code review** backlog (after the DB-pool SEV-2 in #131). `SchedulerManager.start()` guarded idempotency with `if self._scheduler is not None and self._scheduler.running: return`. On the **non-running** path — a held-but-stopped scheduler (e.g. after a `shutdown()` that raised partway and left `_scheduler` dangling) — `start()` fell through and **overwrote** `self._scheduler` with a fresh `AsyncIOScheduler`, silently abandoning the prior instance. The "idempotent start" contract was false there.

Latent today (the lifespan calls `start()` exactly once), but a real lifecycle leak.

## The fix

- `start()` now disposes any held-but-stopped scheduler — warning `scheduler.replacing_stale_instance` + new best-effort `_dispose_stale_scheduler()` (clears the reference; stops the instance if it is somehow still running) — **before** building a fresh one. The manager never abandons a scheduler it owns.
- **Hardened after a 4-lens adversarial review of the fix:** `start()`/`shutdown()` are serialized behind an `asyncio.Lock`, and `_dispose_stale_scheduler()` is synchronous, so the rebuild is atomic and a future concurrent caller (e.g. a restart endpoint) can never race to construct two schedulers. Uncontended acquire doesn't suspend → the sequential lifespan path is unchanged.
  - The reviewed TOCTOU / `wakeup()`-after-`_eventloop=None` races were shown **empirically unreachable** in the current code (awaiting a non-suspending coroutine doesn't yield); the lock makes the atomicity explicit and durable rather than resting on a subtle no-await invariant.

## Tests (TDD, red→green verified)

+3 regression tests in `tests/scheduler/test_manager.py`:
1. **leak/dispose discriminator** — replacing a stale non-running instance emits the warning, runs the dispose path (spied), and swaps cleanly.
2. **recovery** — end-to-end, a dangling scheduler is rebuilt into a fully functional, job-registered scheduler.
3. **concurrency guard** — two concurrent `start()` calls after a dangling scheduler converge on exactly one running instance.

Tests patch `structlog.testing.CapturingLogger` onto the module logger (the app sets `cache_logger_on_first_use=True`, which defeats `capture_logs` once an earlier test caches the bound logger — an order-dependent flake caught during review) and poll for APScheduler's deferred shutdown for determinism.

## Verification

- **966 tests pass** (3 slow deselected), deterministic.
- `mypy --strict src/` clean · `ruff check` + `ruff format` clean · `gitleaks` clean.
- Security audit: **0 findings** (`docs/security-audits/scheduler-start-leak-fix-security-audit.md`).

Branch is off `main`; independent of #131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)