### PR TITLE
fix(uat10): remediate 11 findings + 1 observation from the F5/F6 sweep

### DIFF
--- a/.claude/build-progress.json
+++ b/.claude/build-progress.json
@@ -18,13 +18,14 @@
     "F10-status-page",
     "BL12-manifest-fetcher",
     "F7-cache-validator",
-    "F5-steam-prefill"
+    "F5-steam-prefill",
+    "f6-epic-prefill"
   ],
-  "features_since_last_test": 1,
-  "features_since_last_health_check": 2,
+  "features_since_last_test": 2,
+  "features_since_last_health_check": 3,
   "test_interval": 2,
   "last_test_session": "2026-05-29",
-  "testing_required": false,
+  "testing_required": true,
   "tester_count": 1,
   "bug_tracker": "github_issues",
   "sessions_completed": 9

--- a/.claude/process-state.json
+++ b/.claude/process-state.json
@@ -1,25 +1,25 @@
 {
   "build_loop": {
-    "feature": null,
-    "step": 0,
-    "steps_completed": [],
-    "started_at": null
+    "feature": "uat10-remediation",
+    "step": 5,
+    "steps_completed": [
+      "tests_written",
+      "tests_verified_failing",
+      "implemented",
+      "security_audit",
+      "documentation_updated"
+    ],
+    "started_at": "2026-06-04T20:25:33Z"
   },
   "uat_session": {
-    "session_id": 9,
-    "step": 9,
+    "session_id": 10,
+    "step": 3,
     "steps_completed": [
       "agents_dispatched",
       "template_generated",
-      "orchestrator_notified",
-      "results_received",
-      "completeness_verified",
-      "bugs_consolidated",
-      "triage_complete",
-      "remediation_complete",
-      "gate_passed"
+      "orchestrator_notified"
     ],
-    "started_at": "2026-05-29T00:19:52Z"
+    "started_at": "2026-06-04T19:27:54Z"
   },
   "phase3_validation": {
     "steps_completed": [],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,22 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — UAT-10 remediation (F5/F6 automated sweep) — 2026-06-04
+
+Remediates the 11 confirmed findings (+ 1 observation) from the UAT-10 automated
+adversarial sweep over F5 (Steam prefill) and F6 (Epic prefill). Each fix landed
+test-first; full suite **1051 pass**, mypy(strict)/ruff/gitleaks/semgrep clean.
+Security audit: `docs/security-audits/uat10-remediation-security-audit.md`.
+
+- **Security — Epic manifest decompression bomb (SEV-2):** `platform/epic/manifest.py` inflated the zlib body with unbounded `zlib.decompress`; a tiny compressed manifest (under the 128 MiB *compressed* cap) could expand to GBs and OOM the process. It now uses a bounded `zlib.decompressobj().decompress(body, max_decompressed)` (256 MiB default) and raises `EpicManifestError` before allocating beyond the cap.
+- **Security — Epic manifest fetch SSRF (SEV-3):** `fetch_manifest` GET-ed the response-supplied CDN `uri` *before* validating it; the FQDN + `..` guards ran only afterward. The host (FQDN) and path-traversal checks now run **before** the GET, so a hostile/MITM'd Epic response can no longer drive the manifest fetch at an internal host/IP.
+- **Changed — Epic prefill is now triggerable (SEV-3):** `POST /api/v1/games/{id}/prefill` was hardcoded to `steam` (400 for non-steam), leaving the Epic prefill handler reachable only by a manual DB insert. The trigger now accepts `steam`/`epic` and enqueues a job carrying the game's own platform; an unsupported platform still returns 400.
+- **Fixed — Steam prefill stuck `downloading` (SEV-3):** an IPC/worker/auth failure during manifest expand/fetch left the game in `downloading` forever (only the *jobs* row was marked failed). `_steam_prefill` now wraps its work and marks the game `failed` (`WHERE status='downloading'`), mirroring the Epic path.
+- **Fixed — post-prefill validate error leaves game stuck (SEV-3):** a successful prefill followed by a `validate` returning `outcome='error'` (e.g. cache unmounted) never resolved the transient `downloading` status. The validate handler now resolves only that transient state to `failed` (scoped `WHERE status='downloading'`) without clobbering an already-classified status.
+- **Fixed — Epic OAuth success-path error contract (SEV-4):** a malformed/non-JSON HTTP 200 from the token endpoint raised a raw `KeyError`/`JSONDecodeError` (→ a 500 instead of the documented 401). It now raises `EpicAuthError`, logging only `what`+`status` (never the body/token).
+- **Changed — Steam auth auto-enqueue:** switched `_queue_library_sync_job_best_effort` to atomic `INSERT ... ON CONFLICT DO NOTHING` (was a SELECT-then-INSERT straddling an `await`), consistent with the other four call sites.
+- **Tests:** added regression tests for every fix above, plus the previously-missing coverage the sweep flagged — Epic downloader retry (503→200 recovery, transport-error retry-then-fail), `verify_cached` MISS-ratio + non-gating low-ratio warning, the CDN `..` traversal guard, and the `O_NOFOLLOW` symlink/TOCTOU guard. Removed a redundant `pytest.mark.asyncio` that warned on two sync tests.
+
 ### Added — F6 Epic CDN Prefill (full Epic stack) — 2026-06-03
 
 Implements F6 from PROJECT_BIBLE §1.2 — brings Epic Games to parity with the Steam pipeline: OAuth → library enumeration → manifest fetch + parse → chunk prefill through the lancache → cache-HIT verification. All **pure-Python / async-httpx in the orchestrator process** — no `legendary` runtime dependency, no gevent, no worker subprocess (unlike Steam's ADR-0013 isolation). De-risked end-to-end by `spikes/spike_b_epic_prefill.py` (PASS). **No DB migration** — the schema was already Epic-ready. **ADR-0014** records pure-Python-over-`legendary` (a deliberate deviation from the Phase-0 Manifesto wording).

--- a/docs/security-audits/uat10-remediation-security-audit.md
+++ b/docs/security-audits/uat10-remediation-security-audit.md
@@ -1,0 +1,72 @@
+# Security Audit — UAT-10 Remediation
+
+**Date:** 2026-06-04
+**Branch:** `fix/uat10-remediation`
+**Scope:** the 11 confirmed findings + 1 observation from the UAT-10 automated
+adversarial sweep (`tests/uat/sessions/2026-06-04-session-10/agent-results/uat-10-agent-sweep-2026-06-04.md`),
+covering F5 (Steam prefill) and F6 (Epic prefill).
+**Persona:** Senior Security Engineer. Each finding was confirmed by an
+independent skeptic agent against the actual code before remediation; every fix
+landed test-first (failing test → fix → green).
+
+## Security-relevant fixes
+
+| Finding | Vector | Fix | Regression test |
+|---------|--------|-----|-----------------|
+| **#1 (SEV-2)** | **Decompression bomb / DoS.** `manifest.py:_parse` used unbounded `zlib.decompress`; a tiny compressed manifest (well under the 128 MiB *compressed* cap) could inflate to GBs and OOM the process (reproduced: 510 KB → ~500 MB RSS). | `_decompress_capped()` uses `zlib.decompressobj().decompress(body_raw, max_bytes)` and raises `EpicManifestError` when `unconsumed_tail`/`not eof` (cap hit or truncated). `parse_manifest(raw, *, max_decompressed=_MAX_DECOMPRESSED_BYTES=256 MiB)`; the bomb is rejected **before** allocation. | `test_decompression_bomb_is_capped` (tiny compressed body, `max_decompressed=1024` → `EpicManifestError`); `test_compressed_body_within_cap_still_parses` (normal compressed manifest still parses). |
+| **#4 (SEV-3)** | **SSRF on the manifest fetch.** `fetch_manifest` issued `client.get(uri)` to the response-supplied (attacker-influenceable under MITM/CDN-compromise) `uri` **before** validating it; the FQDN + `..` checks ran only after the GET, so they protected the chunk path but not the manifest GET itself (an internal host / `169.254.169.254` could be fetched). | The `urlparse` + `_HOSTNAME_RE` FQDN guard + `..`-rejection now run **before** the GET. The FQDN regex requires a dotted public host with an alpha TLD, so bare internal hosts, IP literals, and `file://`/`gopher://` (empty `hostname`) are all rejected pre-fetch. | `test_fetch_manifest_rejects_non_fqdn_host_before_get` and `test_fetch_manifest_rejects_path_traversal_before_get` both assert `EpicManifestError` **and** that the unvalidated host was never fetched (`downloaded["hit"] is False`). |
+| **#9 (SEV-4)** | Traversal-guard regression risk — the `..`-in-`cdn_base` mitigation had no dedicated test. | Covered by `test_fetch_manifest_rejects_path_traversal_before_get` (above). | — |
+| **#10 (SEV-4)** | Symlink/TOCTOU regression risk — the `O_NOFOLLOW` token-file guard had no test, so a refactor to `Path.write_text`/`open()` could silently re-open arbitrary-file-truncation. | Pinned by `test_save_refresh_token_refuses_symlink` (plants a symlink at the token path, asserts `OSError` + the link target is untouched). | — |
+
+## Correctness / stability fixes (security-adjacent)
+
+- **#2 (SEV-3)** — Steam prefill no longer leaves a game stuck `downloading` on an
+  IPC/worker/auth failure; `_steam_prefill` now wraps the work and marks `failed`
+  (`WHERE status='downloading'`), mirroring the Epic guard. Accurate status is a
+  precondition for trustworthy cache-coverage reporting.
+- **#3 (SEV-3)** — A post-prefill `validate` with `outcome='error'` (e.g. cache
+  unmounted) now resolves the *transient* `downloading` state to `failed`
+  (scoped `WHERE status='downloading'`) without clobbering an
+  already-classified status.
+- **#5 (SEV-3)** — The prefill trigger is now platform-parameterized
+  (`steam`/`epic`); the Epic prefill handler is no longer dead code reachable
+  only by manual DB insert. Inputs remain parameterized SQL; the platform is
+  validated against an allow-list (`{steam, epic}`) with a 400 otherwise.
+- **#7 (SEV-4)** — Epic OAuth's 200-success path now raises `EpicAuthError` on a
+  malformed/non-JSON body instead of a raw `KeyError`/`JSONDecodeError`, so a
+  hostile/proxy 200 maps to the documented 401/NotAuthenticated rather than a
+  500. The new log event carries only `what`+`status` — **never** the body/token.
+- **Observation** — the Steam auth auto-enqueue now uses atomic
+  `INSERT ... ON CONFLICT DO NOTHING` (was a SELECT-then-INSERT straddling an
+  `await`, which could raise a benign `IntegrityViolationError` against the
+  0004 UNIQUE index), consistent with the four other call sites.
+
+## Non-security test-quality fixes
+
+- **#6 (SEV-3)** — Epic downloader retry loop now has tests for transient-5xx
+  recovery (503→200) and transport-error retry-then-fail.
+- **#8 (SEV-4)** — `verify_cached` MISS arithmetic (ratio 0.5) and the
+  `hit_ratio<0.5` non-gating warning branch are now exercised.
+- **#11 (nit)** — removed a redundant module-level `pytest.mark.asyncio`
+  (`asyncio_mode=auto` already collects the coroutines) that warned on two sync
+  tests.
+
+## Findings status
+
+**0 open security findings.** The two security-material findings (#1 DoS, #4
+SSRF) are fixed and regression-tested; the two security-relevant test gaps (#9,
+#10) now pin their guards. No token/credential material is logged by any changed
+path. No new dependencies, no new SQL interpolation. Full suite **1051 pass**;
+`mypy --strict`, `ruff`, `gitleaks`, and the custom `semgrep` rules are clean.
+
+## Residual / accepted (unchanged from F6)
+
+- The app-wide `RequestValidationError` handler can still echo a malformed
+  `/epic/auth` body (the single-use, short-lived OAuth code) back to the
+  **submitter** — out of scope for this remediation (a global-handler change);
+  remains flagged for a follow-up to strip `input` for sensitive models.
+- The #4 FQDN guard still permits an attacker-controlled *public* FQDN that
+  resolves to an internal IP (DNS rebinding / `metadata.google.internal`).
+  Reordering the check before the GET is a strict improvement; resolve-and-reject
+  RFC1918/link-local (or domain pinning) is noted as defense-in-depth for a
+  future pass.

--- a/src/orchestrator/api/routers/auth.py
+++ b/src/orchestrator/api/routers/auth.py
@@ -145,23 +145,23 @@ async def _queue_library_sync_job_best_effort(pool: Pool) -> None:
     (BL11). Plan P9: failures are logged but do NOT cause the auth response
     to fail — auth succeeded; the operator can manually re-sync.
 
-    Skips if a queued/running `library_sync` job already exists to avoid
-    duplicate work. (Concurrent auth + manual POST can still race; the
-    second handler call is idempotent via UPSERT.)
+    Dedup is DB-enforced by the partial UNIQUE index
+    ``idx_jobs_library_sync_inflight`` (migration 0004): an atomic
+    ``INSERT ... ON CONFLICT DO NOTHING`` permits at most one queued/running
+    library_sync per platform, so a concurrent auth + manual POST can no longer
+    race a SELECT-then-INSERT into a constraint violation (UAT-10 observation;
+    matches the four other call sites).
     """
     try:
-        existing = await pool.read_one(
-            "SELECT id FROM jobs WHERE kind='library_sync' AND platform='steam' "
-            "AND state IN ('queued','running') ORDER BY id LIMIT 1"
-        )
-        if existing is not None:
-            _log.info("auth.auto_sync.dedup_skip", existing_job_id=existing["id"])
-            return
-        await pool.execute_write(
-            "INSERT INTO jobs (kind, platform, state, source) VALUES (?, ?, 'queued', 'api')",
+        inserted = await pool.execute_write(
+            "INSERT INTO jobs (kind, platform, state, source) "
+            "VALUES (?, ?, 'queued', 'api') ON CONFLICT DO NOTHING",
             ("library_sync", "steam"),
         )
-        _log.info("auth.auto_sync.queued")
+        if inserted:
+            _log.info("auth.auto_sync.queued")
+        else:
+            _log.info("auth.auto_sync.dedup_skip")
     except PoolError as e:
         _log.warning("auth.auto_sync.queue_failed", reason=str(e)[:200])
 

--- a/src/orchestrator/api/routers/prefill_trigger.py
+++ b/src/orchestrator/api/routers/prefill_trigger.py
@@ -1,4 +1,7 @@
-"""POST /api/v1/games/{game_id}/prefill — prefill trigger (F5).
+"""POST /api/v1/games/{game_id}/prefill — prefill trigger (F5 steam, F6 epic).
+
+Supports both steam and epic games; the enqueued job carries the game's own
+platform so the worker dispatches to the right prefill handler.
 
 Handler-side dedup: if a `prefill` job for this game is already queued/running,
 return the existing job_id rather than creating a duplicate. The race window
@@ -29,7 +32,7 @@ router = APIRouter(prefix="/api/v1/games", tags=["prefill"])
     "/{game_id}/prefill",
     responses={
         202: {"description": "Prefill job queued or existing in-flight job returned"},
-        400: {"description": "Game is on a non-steam platform"},
+        400: {"description": "Game is on an unsupported platform (not steam/epic)"},
         401: {"description": "Missing/invalid bearer"},
         404: {"description": "Game not found"},
         503: {"description": "Database unavailable"},
@@ -43,10 +46,11 @@ async def trigger_prefill(
         game = await pool.read_one("SELECT id, platform FROM games WHERE id=?", (game_id,))
         if game is None:
             raise HTTPException(status_code=404, detail=f"game {game_id} not found")
-        if game["platform"] != "steam":
+        platform = game["platform"]
+        if platform not in ("steam", "epic"):
             raise HTTPException(
                 status_code=400,
-                detail=f"prefill only supports steam (got {game['platform']!r})",
+                detail=f"prefill only supports steam/epic (got {platform!r})",
             )
 
         existing = await pool.read_one(
@@ -66,8 +70,8 @@ async def trigger_prefill(
 
         await pool.execute_write(
             "INSERT INTO jobs (kind, game_id, platform, state, source) "
-            "VALUES ('prefill', ?, 'steam', 'queued', 'api')",
-            (game_id,),
+            "VALUES ('prefill', ?, ?, 'queued', 'api')",
+            (game_id, platform),
         )
         new_row = await pool.read_one(
             "SELECT id FROM jobs WHERE kind='prefill' AND game_id=? "

--- a/src/orchestrator/jobs/handlers/prefill.py
+++ b/src/orchestrator/jobs/handlers/prefill.py
@@ -25,6 +25,7 @@ from orchestrator.validator.disk_stat import _LATEST_PER_DEPOT_SQL
 if TYPE_CHECKING:
     from orchestrator.jobs.worker import Deps
     from orchestrator.platform.epic.client import EpicClient
+    from orchestrator.platform.steam.client import SteamWorkerClient
 
 _log = structlog.get_logger(__name__)
 
@@ -184,12 +185,18 @@ async def _epic_prefill_inner(
 async def _steam_prefill(job: dict[str, Any], deps: Deps) -> None:
     """Prefill one Steam game's chunks through the lancache (F5).
 
+    Sets the game to 'downloading', then delegates to ``_steam_prefill_inner``
+    inside a guard so any failure (IPC/worker death, expired session, network)
+    marks the game 'failed' rather than leaving it stuck 'downloading' forever
+    (UAT-10 #2; mirrors the Epic path).
+
     Raises:
         ValueError — unknown game or non-steam platform.
         RuntimeError — steam_client is None, or chunks failed to download.
     """
     if deps.steam_client is None:
         raise RuntimeError("steam_client is required for prefill handler")
+    steam_client = deps.steam_client
     game_id = job.get("game_id")
     if game_id is None:
         raise ValueError("prefill job has no game_id")
@@ -203,7 +210,28 @@ async def _steam_prefill(job: dict[str, Any], deps: Deps) -> None:
     job_id = job.get("id")
     await deps.pool.execute_write("UPDATE games SET status='downloading' WHERE id=?", (game_id,))
     _log.info("prefill.started", job_id=job_id, game_id=game_id)
+    try:
+        await _steam_prefill_inner(job_id, game_id, game, deps, steam_client)
+    except Exception as e:
+        # Never leave the game stuck in 'downloading'. The chunk-failure path
+        # already set 'failed' (this then no-ops via the status guard); any other
+        # failure (IPC/worker/network) is marked here before the re-raise.
+        with contextlib.suppress(Exception):
+            await deps.pool.execute_write(
+                "UPDATE games SET status='failed', last_error=? "
+                "WHERE id=? AND status='downloading'",
+                (f"prefill: {type(e).__name__}: {e}"[:200], game_id),
+            )
+        raise
 
+
+async def _steam_prefill_inner(
+    job_id: Any,
+    game_id: int,
+    game: dict[str, Any],
+    deps: Deps,
+    steam_client: SteamWorkerClient,
+) -> None:
     # Ensure manifests exist (fetch once if the game has none).
     uris = await _load_chunk_uris(deps, game_id)
     if not uris:
@@ -217,7 +245,7 @@ async def _steam_prefill(job: dict[str, Any], deps: Deps) -> None:
             except (TypeError, ValueError) as e:
                 raise ValueError(f"game {game_id} app_id not numeric") from e
             _log.info("prefill.fetching_manifests", job_id=job_id, game_id=game_id)
-            await deps.steam_client.manifest_fetch(app_id_int)
+            await steam_client.manifest_fetch(app_id_int)
             uris = await _load_chunk_uris(deps, game_id)
 
     settings = get_settings()

--- a/src/orchestrator/jobs/handlers/validate.py
+++ b/src/orchestrator/jobs/handlers/validate.py
@@ -85,6 +85,16 @@ async def validate_handler(job: dict[str, Any], deps: Deps) -> None:
             "UPDATE games SET status=?, last_validated_at=CURRENT_TIMESTAMP WHERE id=?",
             (new_status, game_id),
         )
+    else:
+        # outcome='error' (infra failure, e.g. cache unmounted). Never clobber an
+        # already-classified status — but a freshly-prefilled game's only prior
+        # state is the transient 'downloading', which would otherwise stay stuck
+        # forever. Resolve only that, scoped by WHERE status='downloading'
+        # (UAT-10 #3).
+        await deps.pool.execute_write(
+            "UPDATE games SET status='failed', last_error=? WHERE id=? AND status='downloading'",
+            ((f"validate: {result.error}"[:200] if result.error else "validate: error"), game_id),
+        )
 
     _log.info(
         "validate.recorded",

--- a/src/orchestrator/platform/epic/manifest.py
+++ b/src/orchestrator/platform/epic/manifest.py
@@ -28,6 +28,12 @@ _log = structlog.get_logger(__name__)
 _MANIFEST_MAGIC = 0x44BEC00C
 _MAX_CHUNKS = 5_000_000  # DoS guard on a corrupt/hostile chunk_count
 _MAX_PREREQ = 100_000  # DoS guard on a corrupt/hostile prereq_count loop
+# Hard cap on the DECOMPRESSED manifest body. zlib.decompress is otherwise
+# unbounded — a tiny compressed body can inflate to gigabytes (decompression
+# bomb / DoS), and the compressed-size cap in fetch_manifest does NOT bound the
+# decompressed output. 256 MiB is far above any real manifest (which is further
+# bounded by _MAX_CHUNKS) yet stops a bomb before it is allocated.
+_MAX_DECOMPRESSED_BYTES = 256 * 1024 * 1024
 # A plausible public FQDN (at least one dot). The CDN host comes from Epic's
 # signed manifest response and is used as the lancache Host header (which routes
 # the upstream fetch) — validate it so a hostile/MITM'd response can't point the
@@ -58,17 +64,35 @@ def _read_array(bio: BytesIO, count: int, fmt: str) -> list[int]:
     return [struct.unpack(fmt, bio.read(size))[0] for _ in range(count)]
 
 
-def parse_manifest(raw: bytes) -> EpicManifest:
-    """Parse an Epic binary manifest into version + chunk list."""
+def parse_manifest(raw: bytes, *, max_decompressed: int = _MAX_DECOMPRESSED_BYTES) -> EpicManifest:
+    """Parse an Epic binary manifest into version + chunk list.
+
+    ``max_decompressed`` caps the inflated body to defuse a decompression bomb.
+    """
     try:
-        return _parse(raw)
+        return _parse(raw, max_decompressed)
     except EpicManifestError:
         raise
     except (struct.error, zlib.error, ValueError, IndexError) as e:
         raise EpicManifestError(f"malformed Epic manifest: {type(e).__name__}: {e}") from e
 
 
-def _parse(raw: bytes) -> EpicManifest:
+def _decompress_capped(body_raw: bytes, max_bytes: int) -> bytes:
+    """zlib-inflate ``body_raw`` with a hard output cap (anti-bomb).
+
+    ``decompressobj().decompress(data, max_length)`` stops after ``max_length``
+    output bytes, leaving the remainder in ``unconsumed_tail``; a non-empty tail
+    (or ``not eof``) means the stream exceeds the cap (or is truncated), so we
+    raise instead of allocating an unbounded buffer.
+    """
+    dobj = zlib.decompressobj()
+    body = dobj.decompress(body_raw, max_bytes)
+    if dobj.unconsumed_tail or not dobj.eof:
+        raise EpicManifestError(f"epic manifest decompresses beyond size cap ({max_bytes} bytes)")
+    return body
+
+
+def _parse(raw: bytes, max_decompressed: int) -> EpicManifest:
     bio = BytesIO(raw)
     (magic,) = struct.unpack("<I", bio.read(4))
     if magic != _MANIFEST_MAGIC:
@@ -82,7 +106,7 @@ def _parse(raw: bytes) -> EpicManifest:
 
     bio.seek(header_size)
     body_raw = bio.read()
-    body = zlib.decompress(body_raw) if (stored_as & 0x01) else body_raw
+    body = _decompress_capped(body_raw, max_decompressed) if (stored_as & 0x01) else body_raw
     bb = BytesIO(body)
 
     # ManifestMeta — read meta_size, then skip to its end.
@@ -175,6 +199,18 @@ async def fetch_manifest(
             raise EpicManifestError("no manifest URI in response")
         entry = manifests[0]
         uri = str(entry["uri"])
+        # Validate the signed CDN URI BEFORE fetching it. ``uri`` comes from
+        # Epic's response and is BOTH this GET's target AND the lancache Host
+        # header + URL path. Validating after the GET (the prior bug) left the
+        # manifest fetch itself open to SSRF — a hostile/MITM'd response could
+        # point this GET at an internal host/IP (UAT-10 #4 / adversarial review).
+        parsed = urlparse(uri)
+        cdn_host = parsed.hostname or ""
+        cdn_base = parsed.path.rsplit("/", 1)[0]
+        if not _HOSTNAME_RE.match(cdn_host):
+            raise EpicManifestError(f"implausible CDN host: {cdn_host!r}")
+        if ".." in cdn_base:
+            raise EpicManifestError(f"path traversal in CDN base: {cdn_base!r}")
         params: dict[str, str] | None = None
         if "queryParams" in entry:
             params = {str(p["name"]): str(p["value"]) for p in entry["queryParams"]}
@@ -188,17 +224,7 @@ async def fetch_manifest(
             )
         manifest = parse_manifest(mresp.content)
         manifest.raw = mresp.content
-
-    parsed = urlparse(uri)
-    cdn_host = parsed.hostname or ""
-    cdn_base = parsed.path.rsplit("/", 1)[0]
-    # The CDN host/base come from Epic's signed response — validate before they
-    # become the lancache Host header + URL path (adversarial review).
-    if not _HOSTNAME_RE.match(cdn_host):
-        raise EpicManifestError(f"implausible CDN host: {cdn_host!r}")
-    if ".." in cdn_base:
-        raise EpicManifestError(f"path traversal in CDN base: {cdn_base!r}")
-    manifest.cdn_base = cdn_base
+        manifest.cdn_base = cdn_base
     return manifest, cdn_host, cdn_base
 
 

--- a/src/orchestrator/platform/epic/oauth.py
+++ b/src/orchestrator/platform/epic/oauth.py
@@ -69,7 +69,15 @@ async def _grant(data: dict[str, str], settings: Settings, *, what: str) -> Auth
             code = str(resp.json().get("errorCode", ""))
         _log.warning("epic.oauth.failed", what=what, status=resp.status_code, error_code=code)
         raise EpicAuthError(f"epic {what} failed: HTTP {resp.status_code} {code}")
-    return _to_tokens(resp.json())
+    # A 200 can still be malformed (proxy/CDN error page, truncated body, schema
+    # change). Surface it as EpicAuthError — the documented contract — so callers
+    # map it to 401/NotAuthenticated rather than leaking a raw KeyError /
+    # JSONDecodeError (UAT-10 #7). Log only what/status — never the body/token.
+    try:
+        return _to_tokens(resp.json())
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
+        _log.warning("epic.oauth.bad_response", what=what, status=resp.status_code)
+        raise EpicAuthError(f"epic {what} returned a malformed token response") from e
 
 
 async def exchange_code(code: str, settings: Settings) -> AuthTokens:

--- a/tests/api/test_prefill_trigger_router.py
+++ b/tests/api/test_prefill_trigger_router.py
@@ -85,15 +85,49 @@ class TestErrors:
         assert r.status_code == 404
         assert "not found" in r.json()["detail"]
 
-    async def test_non_steam_game_returns_400(self, client, populated_pool):
+    async def test_epic_game_queues_epic_prefill_job(self, client, populated_pool):
         row = await populated_pool.read_one("SELECT id FROM games WHERE platform='epic' LIMIT 1")
         assert row is not None
         r = await client.post(
             f"/api/v1/games/{row['id']}/prefill",
             headers={"Authorization": f"Bearer {VALID_TOKEN}"},
         )
+        assert r.status_code == 202
+        jrow = await populated_pool.read_one(
+            "SELECT kind, game_id, platform, state, source FROM jobs WHERE id=?",
+            (r.json()["job_id"],),
+        )
+        assert jrow == {
+            "kind": "prefill",
+            "game_id": row["id"],
+            "platform": "epic",
+            "state": "queued",
+            "source": "api",
+        }
+
+    async def test_unsupported_platform_returns_400(self, unit_app):
+        import httpx
+
+        from orchestrator.api.dependencies import get_pool_dep
+
+        class _GogPool:
+            async def read_one(self, query, *_a, **_kw):
+                if "FROM games" in query:
+                    return {"id": 7, "platform": "gog"}
+                return None
+
+            async def execute_write(self, *_a, **_kw):
+                return 1
+
+        unit_app.dependency_overrides[get_pool_dep] = lambda: _GogPool()
+        transport = httpx.ASGITransport(app=unit_app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as c:
+            r = await c.post(
+                "/api/v1/games/7/prefill",
+                headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+            )
         assert r.status_code == 400
-        assert "steam" in r.json()["detail"]
+        assert "gog" in r.json()["detail"]
 
 
 class TestAuthBoundary:

--- a/tests/jobs/test_epic_handlers.py
+++ b/tests/jobs/test_epic_handlers.py
@@ -100,6 +100,29 @@ async def test_epic_prefill_downloads_stores_manifest_marks_up_to_date(pool, mon
     assert m["total_bytes"] == 500
 
 
+async def test_epic_prefill_low_hit_ratio_is_non_gating(pool, monkeypatch):
+    """A low post-prefill HIT ratio logs a warning but does NOT fail the job —
+    lancache caches asynchronously, so an immediate re-request can legitimately
+    MISS; download success is the success signal (UAT-10 #8)."""
+    gid = await _seed_epic_game(pool, app_id="AppE")
+    stub = _StubEpic(manifest=_manifest())
+
+    async def fake_prefill(paths, host, base, settings, **kw):
+        return EpicPrefillResult(len(paths), len(paths), 0)
+
+    async def fake_verify(paths, host, base, settings, **kw):
+        return 0.2  # below the 0.5 warning threshold
+
+    monkeypatch.setattr(ph, "epic_prefill_chunks", fake_prefill)
+    monkeypatch.setattr(ph, "epic_verify_cached", fake_verify)
+
+    await prefill_handler(
+        _job("prefill", gid), Deps(pool=pool, steam_client=None, epic_client=stub)
+    )
+    g = await pool.read_one("SELECT status FROM games WHERE id=?", (gid,))
+    assert g["status"] == "up_to_date"  # informational, not a failure
+
+
 async def test_epic_prefill_failed_chunks_marks_failed(pool, monkeypatch):
     gid = await _seed_epic_game(pool, app_id="AppB")
     stub = _StubEpic(manifest=_manifest())

--- a/tests/jobs/test_prefill_handler.py
+++ b/tests/jobs/test_prefill_handler.py
@@ -85,6 +85,22 @@ async def test_chunk_failure_marks_game_failed(pool, monkeypatch):
     assert vj is None
 
 
+async def test_manifest_error_marks_failed_not_stuck_downloading(pool):
+    """An IPC/worker failure during manifest expand must not leave the game
+    stuck in 'downloading' forever — it must resolve to 'failed' (UAT-10 #2)."""
+    game_id = await _seed_game(pool)
+    await _seed_manifest(pool, game_id)
+
+    class _BoomSteam(_StubSteam):
+        async def manifest_expand(self, raw):
+            raise RuntimeError("worker died: IPC timeout")
+
+    with pytest.raises(RuntimeError):
+        await prefill_handler(_job(game_id), Deps(pool=pool, steam_client=_BoomSteam()))
+    g = await pool.read_one("SELECT status FROM games WHERE id=?", (game_id,))
+    assert g["status"] == "failed"
+
+
 async def test_no_manifests_triggers_fetch(pool, monkeypatch):
     game_id = await _seed_game(pool)  # no manifest rows
 

--- a/tests/jobs/test_validate_handler.py
+++ b/tests/jobs/test_validate_handler.py
@@ -112,7 +112,7 @@ async def test_partial_marks_validation_failed(pool, cache_root):
     assert g["status"] == "validation_failed"
 
 
-async def test_error_leaves_status_unchanged(pool, tmp_path, monkeypatch):
+async def test_error_does_not_clobber_classified_status(pool, tmp_path, monkeypatch):
     # Point at a non-existent cache root → outcome error.
     monkeypatch.setenv("ORCH_LANCACHE_NGINX_CACHE_PATH", str(tmp_path / "nope"))
     from orchestrator.core.settings import get_settings
@@ -120,14 +120,32 @@ async def test_error_leaves_status_unchanged(pool, tmp_path, monkeypatch):
     get_settings.cache_clear()
     game_id = await _seed_game(pool)
     await _seed_manifest(pool, game_id)
-    # Pre-set a known status to confirm it is NOT clobbered.
+    # A real, already-classified status must NOT be clobbered by an error outcome.
+    await pool.execute_write("UPDATE games SET status='up_to_date' WHERE id=?", (game_id,))
+    deps = Deps(pool=pool, steam_client=_StubSteam({"depot_id": 731, "chunk_shas": [SHA_A]}))
+    await validate_handler(_job(game_id), deps)
+    g = await pool.read_one("SELECT status FROM games WHERE id=?", (game_id,))
+    assert g["status"] == "up_to_date"  # unchanged
+    vh = await pool.read_one("SELECT outcome FROM validation_history WHERE game_id=?", (game_id,))
+    assert vh["outcome"] == "error"
+    get_settings.cache_clear()
+
+
+async def test_error_unsticks_transient_downloading(pool, tmp_path, monkeypatch):
+    """A post-prefill validate that hits an infra error (cache unmounted) must
+    resolve the transient 'downloading' state to 'failed', not leave it stuck
+    (UAT-10 #3). It still must not clobber a real classified status (above)."""
+    monkeypatch.setenv("ORCH_LANCACHE_NGINX_CACHE_PATH", str(tmp_path / "nope"))
+    from orchestrator.core.settings import get_settings
+
+    get_settings.cache_clear()
+    game_id = await _seed_game(pool)
+    await _seed_manifest(pool, game_id)
     await pool.execute_write("UPDATE games SET status='downloading' WHERE id=?", (game_id,))
     deps = Deps(pool=pool, steam_client=_StubSteam({"depot_id": 731, "chunk_shas": [SHA_A]}))
     await validate_handler(_job(game_id), deps)
     g = await pool.read_one("SELECT status FROM games WHERE id=?", (game_id,))
-    assert g["status"] == "downloading"  # unchanged
-    vh = await pool.read_one("SELECT outcome FROM validation_history WHERE game_id=?", (game_id,))
-    assert vh["outcome"] == "error"
+    assert g["status"] == "failed"  # transient 'downloading' resolved, not stuck
     get_settings.cache_clear()
 
 

--- a/tests/platform/epic/test_manifest_fetch.py
+++ b/tests/platform/epic/test_manifest_fetch.py
@@ -74,8 +74,9 @@ async def test_fetch_manifest_size_cap(monkeypatch):
         await ep_man.fetch_manifest("TOK", item, s)
 
 
-async def test_fetch_manifest_rejects_non_fqdn_host(monkeypatch):
+async def test_fetch_manifest_rejects_non_fqdn_host_before_get(monkeypatch):
     raw = build_manifest(22, make_chunks(1))
+    downloaded = {"hit": False}
 
     def handler(req: httpx.Request) -> httpx.Response:
         if "/assets/v2/" in req.url.path:
@@ -84,12 +85,39 @@ async def test_fetch_manifest_rejects_non_fqdn_host(monkeypatch):
                 200,
                 json={"elements": [{"manifests": [{"uri": "http://internal-host/a/d.manifest"}]}]},
             )
+        downloaded["hit"] = True  # SSRF: the unvalidated host must NEVER be fetched
         return httpx.Response(200, content=raw)
 
     monkeypatch.setattr(ep_man, "_build_transport", lambda: httpx.MockTransport(handler))
     item = EpicLibraryItem(app_name="A", namespace="ns", catalog_item_id="c", title="A")
     with pytest.raises(ep_man.EpicManifestError, match="CDN host"):
         await ep_man.fetch_manifest("TOK", item, _settings())
+    assert downloaded["hit"] is False  # validation must precede the manifest GET
+
+
+async def test_fetch_manifest_rejects_path_traversal_before_get(monkeypatch):
+    raw = build_manifest(22, make_chunks(1))
+    downloaded = {"hit": False}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if "/assets/v2/" in req.url.path:
+            # Dotted host passes the FQDN guard, but the path carries traversal.
+            return httpx.Response(
+                200,
+                json={
+                    "elements": [
+                        {"manifests": [{"uri": "https://epiccdn.test/a/../../x/d.manifest"}]}
+                    ]
+                },
+            )
+        downloaded["hit"] = True
+        return httpx.Response(200, content=raw)
+
+    monkeypatch.setattr(ep_man, "_build_transport", lambda: httpx.MockTransport(handler))
+    item = EpicLibraryItem(app_name="A", namespace="ns", catalog_item_id="c", title="A")
+    with pytest.raises(ep_man.EpicManifestError, match="path traversal"):
+        await ep_man.fetch_manifest("TOK", item, _settings())
+    assert downloaded["hit"] is False  # traversal rejected before the manifest GET
 
 
 async def test_fetch_manifest_no_elements_raises(monkeypatch):

--- a/tests/platform/epic/test_manifest_parse.py
+++ b/tests/platform/epic/test_manifest_parse.py
@@ -37,6 +37,38 @@ def test_parse_zlib_compressed_body():
     assert m.chunks[1].hash == 101
 
 
+def test_decompression_bomb_is_capped():
+    """A zlib body that inflates beyond the cap must raise EpicManifestError,
+    NOT allocate the full decompressed buffer (DoS guard). The compressed
+    manifest stays tiny — well under any compressed-size cap."""
+    import struct
+    import zlib
+
+    big = b"\x00" * (256 * 1024)  # inflates from a few hundred bytes
+    payload = zlib.compress(big)
+    header = bytearray()
+    header += struct.pack("<I", 0x44BEC00C)  # magic
+    header += struct.pack("<I", 0)  # header_size placeholder
+    header += struct.pack("<I", len(payload))  # data_size_compressed
+    header += struct.pack("<I", len(big))  # data_size_uncompressed
+    header += b"\x00" * 20  # sha
+    header += struct.pack("<B", 0x01)  # stored_as = zlib body
+    header += struct.pack("<I", 22)  # version
+    header[4:8] = struct.pack("<I", len(header))  # real header_size
+    raw = bytes(header) + payload
+
+    with pytest.raises(EpicManifestError, match="cap"):
+        parse_manifest(raw, max_decompressed=1024)
+
+
+def test_compressed_body_within_cap_still_parses():
+    """A normal compressed manifest decompresses fully under the cap."""
+    raw = build_manifest(22, make_chunks(2), compress=True)
+    m = parse_manifest(raw, max_decompressed=4 * 1024 * 1024)
+    assert m.version == 22
+    assert len(m.chunks) == 2
+
+
 def test_parse_legacy_hex_path():
     raw = build_manifest(18, make_chunks(1))
     m = parse_manifest(raw)

--- a/tests/platform/epic/test_oauth.py
+++ b/tests/platform/epic/test_oauth.py
@@ -11,7 +11,9 @@ from orchestrator.core.settings import Settings
 from orchestrator.platform.epic import oauth as ep_oauth
 from orchestrator.platform.epic.models import AuthTokens
 
-pytestmark = pytest.mark.asyncio
+# No module-level asyncio marker: asyncio_mode=auto already collects the async
+# tests as coroutines, and the marker spuriously warned on the sync tests below
+# (UAT-10 #11).
 
 VALID_TOKEN = "a" * 32
 
@@ -69,6 +71,30 @@ async def test_refresh_failure_raises_epicauth(monkeypatch):
         await ep_oauth.refresh("BAD", _settings())
 
 
+async def test_malformed_200_missing_access_token_raises_epicauth(monkeypatch):
+    """A 200 whose JSON omits access_token must surface as EpicAuthError, not a
+    raw KeyError (so callers map it to 401/NotAuthenticated) — UAT-10 #7."""
+    monkeypatch.setattr(
+        ep_oauth,
+        "_build_transport",
+        lambda: httpx.MockTransport(lambda r: httpx.Response(200, json={"refresh_token": "x"})),
+    )
+    with pytest.raises(ep_oauth.EpicAuthError):
+        await ep_oauth.exchange_code("CODE", _settings())
+
+
+async def test_malformed_200_non_json_raises_epicauth(monkeypatch):
+    """A 200 with a non-JSON body (proxy/CDN error page) must raise EpicAuthError,
+    not a raw JSONDecodeError — UAT-10 #7."""
+    monkeypatch.setattr(
+        ep_oauth,
+        "_build_transport",
+        lambda: httpx.MockTransport(lambda r: httpx.Response(200, content=b"<html>err</html>")),
+    )
+    with pytest.raises(ep_oauth.EpicAuthError):
+        await ep_oauth.exchange_code("CODE", _settings())
+
+
 def test_persist_and_load_refresh_token(tmp_path):
     path = str(tmp_path / "epic_session.json")
     ep_oauth.save_refresh_token(path, "RT-123")
@@ -78,3 +104,15 @@ def test_persist_and_load_refresh_token(tmp_path):
 
 def test_load_missing_returns_none(tmp_path):
     assert ep_oauth.load_refresh_token(str(tmp_path / "nope.json")) is None
+
+
+def test_save_refresh_token_refuses_symlink(tmp_path):
+    """O_NOFOLLOW must refuse to write through a symlink planted at the token
+    path (TOCTOU / arbitrary-file-truncation guard) — UAT-10 #10 regression."""
+    victim = tmp_path / "victim.txt"
+    victim.write_text("DO-NOT-TRUNCATE")
+    link = tmp_path / "epic_session.json"
+    link.symlink_to(victim)
+    with pytest.raises(OSError):  # ELOOP from O_NOFOLLOW
+        ep_oauth.save_refresh_token(str(link), "RT-123")
+    assert victim.read_text() == "DO-NOT-TRUNCATE"  # target untouched

--- a/tests/prefill/test_epic_downloader.py
+++ b/tests/prefill/test_epic_downloader.py
@@ -69,6 +69,55 @@ async def test_empty_is_noop():
     assert r.chunks_total == 0 and r.chunks_ok == 0
 
 
+async def test_5xx_retried_then_success(monkeypatch):
+    """A transient 503 is retried; a following 200 succeeds (UAT-10 #6)."""
+    calls = {"n": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(503) if calls["n"] == 1 else httpx.Response(200)
+
+    async def _noop_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(
+        "orchestrator.prefill.epic_downloader._build_transport",
+        lambda: httpx.MockTransport(handler),
+    )
+    monkeypatch.setattr("orchestrator.prefill.epic_downloader.asyncio.sleep", _noop_sleep)
+    r = await prefill_chunks(
+        ["ChunksV5/00/x.chunk"], "h", "/b", _settings(), lancache_base_url="http://127.0.0.1"
+    )
+    assert (r.chunks_ok, r.chunks_failed) == (1, 0)
+    assert calls["n"] == 2  # one retry, then success
+
+
+async def test_transport_error_retried_then_failed(monkeypatch):
+    """A transport error is retried up to max_attempts, then recorded failed with
+    the exception type as the reason (UAT-10 #6)."""
+    calls = {"n": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        raise httpx.ConnectError("boom")
+
+    async def _noop_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(
+        "orchestrator.prefill.epic_downloader._build_transport",
+        lambda: httpx.MockTransport(handler),
+    )
+    monkeypatch.setattr("orchestrator.prefill.epic_downloader.asyncio.sleep", _noop_sleep)
+    s = Settings(orchestrator_token=VALID_TOKEN, prefill_chunk_max_attempts=2)
+    r = await prefill_chunks(
+        ["ChunksV5/00/x.chunk"], "h", "/b", s, lancache_base_url="http://127.0.0.1"
+    )
+    assert r.chunks_failed == 1
+    assert calls["n"] == 2  # retried up to max_attempts
+    assert r.failures and r.failures[0][1] == "ConnectError"
+
+
 async def test_verify_cached_counts_hits(monkeypatch):
     def handler(req: httpx.Request) -> httpx.Response:
         return httpx.Response(200, headers={"X-Upstream-Cache-Status": "HIT"})
@@ -85,6 +134,29 @@ async def test_verify_cached_counts_hits(monkeypatch):
         lancache_base_url="http://127.0.0.1",
     )
     assert ratio == 1.0
+
+
+async def test_verify_cached_mixed_hit_miss(monkeypatch):
+    """A mix of HIT and non-HIT responses yields the real fraction, exercising
+    the MISS branch and the hits/total arithmetic off the 1.0 boundary
+    (UAT-10 #8)."""
+    statuses = iter(["HIT", "MISS"])
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, headers={"X-Upstream-Cache-Status": next(statuses)})
+
+    monkeypatch.setattr(
+        "orchestrator.prefill.epic_downloader._build_transport",
+        lambda: httpx.MockTransport(handler),
+    )
+    ratio = await verify_cached(
+        ["ChunksV5/00/a.chunk", "ChunksV5/00/b.chunk"],
+        "h",
+        "/b",
+        _settings(),
+        lancache_base_url="http://127.0.0.1",
+    )
+    assert ratio == 0.5
 
 
 async def test_verify_cached_empty_is_zero():

--- a/tests/uat/sessions/2026-06-04-session-10/agent-results/uat-10-agent-sweep-2026-06-04.md
+++ b/tests/uat/sessions/2026-06-04-session-10/agent-results/uat-10-agent-sweep-2026-06-04.md
@@ -1,0 +1,75 @@
+# UAT-10 — Automated Adversarial Sweep (agent results)
+
+**Date:** 2026-06-04
+**Features under test:** F5 (Steam prefill), F6 (Epic prefill) — the two features since UAT-9.
+**Baseline (merged `main` @ aa25597):** 1037 tests pass · `mypy --strict` clean · `ruff check`/`format` clean · `gitleaks` no leaks · `semgrep` custom rules clean. (The lone `pip-licenses` "failure" is a PATH artifact; passes with the venv on PATH, as CI runs it.)
+
+**Method:** A multi-agent Workflow ran 5 independent finder lenses over F5+F6 — (L1) F5 Steam-prefill exploratory, (L2) F6 OAuth + binary-manifest parser, (L3) F6 downloader + CDN routing + handler, (L4) cross-platform integration & regression, (L5) test-quality + coverage + live-scope. **Every candidate finding was then handed to an independent skeptic agent** prompted to refute it by reading the actual code; only code-confirmed findings are kept. 17 agents total.
+
+**Result: 11 confirmed · 1 refuted · 1 low-sev observation (not filed).**
+
+---
+
+## Confirmed findings
+
+| # | Sev | Cat | File | Title |
+|---|-----|-----|------|-------|
+| 1 | **SEV-2** | security | `platform/epic/manifest.py:85` | Manifest zlib body decompressed with no `max_length` — decompression bomb (DoS) bypasses the size cap |
+| 2 | **SEV-3** | stability | `jobs/handlers/prefill.py` `_steam_prefill` | Steam prefill leaves game stuck `downloading` forever on manifest/IPC error (no guard; Epic path has one) |
+| 3 | **SEV-3** | correctness | `jobs/handlers/prefill.py` + `validator/...` | Steam prefill never resolves status when post-prefill `validate` returns `outcome='error'` (cache unmounted) → stuck `downloading` |
+| 4 | **SEV-3** | security | `platform/epic/manifest.py:177-202` | SSRF: Epic manifest GET fires **before** the host/`..` validation (validation runs too late to protect the manifest fetch) |
+| 5 | **SEV-3** | correctness | `jobs/handlers/prefill.py` dispatch | **Epic prefill handler is unreachable** — no production path enqueues `prefill`+`epic` (trigger is steam-hardcoded, 400s non-steam). Blocks the F6 live UAT. |
+| 6 | **SEV-3** | test-quality | `tests/prefill/test_epic_downloader.py` | Epic downloader retry loop untested: no timeout/transport path, no 5xx-retry-then-success |
+| 7 | **SEV-4** | stability | `platform/epic/oauth.py:72` | OAuth 200-success path raises raw `KeyError`/`JSONDecodeError` instead of `EpicAuthError` (becomes a 500, not the documented 401) |
+| 8 | **SEV-4** | test-quality | `tests/prefill/test_epic_downloader.py` | `verify_cached` MISS path + the `hit_ratio<0.5` warning branch never exercised (every test returns ratio 1.0) |
+| 9 | **SEV-4** | test-quality | `tests/platform/epic/test_manifest_fetch.py` | CDN-base `..` path-traversal guard has no dedicated test (its sibling host guard does) |
+| 10 | **SEV-4** | test-quality | `tests/platform/epic/test_oauth.py` | `save_refresh_token` `O_NOFOLLOW` symlink/TOCTOU guard never exercised by a test |
+| 11 | **nit** | test-quality | `tests/platform/epic/test_oauth.py:14` | Two sync OAuth tests carry the module `pytest.mark.asyncio` → `PytestWarning` (delete the marker; `asyncio_mode=auto`) |
+
+### Detail & fixes
+
+**#1 — SEV-2 zlib decompression bomb (security).** `_parse` (`manifest.py:85`): `body = zlib.decompress(body_raw) ...` — single-shot, **no `max_length`**. The only size guard (`fetch_manifest:184`) caps the *compressed* download at 128 MiB; the decompressed `body` is unbounded. `data_size_uncompressed` is read (`:78`) and discarded. The `meta_size <= len(body)` check (`:90`) runs *after* the bomb is already allocated. **Reproduced offline:** a 510 KB raw manifest (well under the 128 MiB compressed cap) inflated to ~500 MB body, peak RSS 1538 MB; a few-MB download → multi-GB → OOM-kills the orchestrator. Attacker surface: a MITM'd/compromised Epic response, or any caller of the public `parse_manifest`. Matches the project's own unenforced threat-model item TM-018. **Fix:** bounded streaming decompress capped at `manifest_size_cap_bytes` — `d=zlib.decompressobj(); body=d.decompress(body_raw, cap); if d.unconsumed_tail or not d.eof: raise EpicManifestError(...)`. Thread the cap into `parse_manifest`/`_parse`. Regression test: feed a small zlib bomb, assert `EpicManifestError` (not a multi-GB allocation).
+
+**#2 — SEV-3 Steam prefill stuck `downloading` on IPC/auth error (stability).** `_steam_prefill` sets `status='downloading'` unconditionally (`:204`) then runs `_load_chunk_uris`→`manifest_expand` and `manifest_fetch` (`:208`,`:220`) with **no enclosing try/except**. Those IPC calls raise (`IPCTimeoutError`, `WorkerDiedError`, `SteamWorkerError(NotAuthenticated)`) — exactly the failures the orchestrator exists to surface. The exception → `worker_loop` → `mark_failed` touches only the **jobs** row; nothing resets `games.status`. The ID6 reaper also only touches jobs. The Epic path wraps the identical logic in a guard ("Never leave the game stuck in 'downloading'", `:96-108`); Steam has no equivalent. **Fix:** extract `_steam_prefill_inner`, wrap in the same `except Exception` → `UPDATE games SET status='failed', last_error=? WHERE id=? AND status='downloading'`; re-raise. Add a test injecting an IPC error and asserting status ends `failed`.
+
+**#3 — SEV-3 post-prefill validate `error` outcome leaves game stuck (correctness).** On full prefill success, `_steam_prefill` enqueues a `validate` job and deliberately leaves `status='downloading'` ("validate sets the final status"). But `validate_handler` only writes status when `_STATUS_FOR.get(outcome)` is non-None, and `_STATUS_FOR` has **no `error` key** (by design, to avoid clobbering real state on re-validate). `validate_game` returns `outcome='error'` **without raising** when `cache_root` isn't a directory / `steam_client` is None / no manifests. So a successful prefill + a validate that hits an infra error (lancache cache unmounted — precisely what the validator should flag) → game permanently `downloading`. **Fix:** when the validate outcome is `error`, clear only the transient state — `UPDATE games SET status='failed', last_error=? WHERE id=? AND status='downloading'` (still never clobbers a real prior classification). Regression test: prefill→validate(error)→assert status ≠ `downloading`.
+
+**#4 — SEV-3 SSRF on Epic manifest fetch (security).** In `fetch_manifest`, `uri` comes from Epic's `/assets/v2` JSON, and `client.get(uri)` (`:181`) fires **before** the `_HOSTNAME_RE` FQDN check and `..` check (`:197-199`), which only run after the GET completes. So the guard hardening the chunk-download path does **not** protect the manifest GET. An adversary who can influence the Epic API response (TLS MITM / compromised CDN edge / DNS poisoning) can point the GET at `http://169.254.169.254/...` or an internal host; the orchestrator fetches up to 128 MiB of it. Bounded (one GET, `follow_redirects=False`, response consumed as opaque bytes) → blind/semi-blind SSRF. **Fix:** validate `parsed.scheme in {http,https}` + `_HOSTNAME_RE.match(host)` + reject `..` **before** the GET; drop the now-redundant post-fetch checks. Defense-in-depth: reject hosts resolving to RFC1918/loopback/link-local, or pin allowed CDN domains.
+
+**#5 — SEV-3 Epic prefill handler unreachable (correctness) — blocks F6 live UAT.** `prefill_handler` dispatches `platform=='epic' → _epic_prefill`, but **no production path ever creates a `prefill` job with `platform='epic'`.** The only prefill INSERT is `prefill_trigger.py:69` (`platform` hardcoded `'steam'`), and that router 400s non-steam first. Epic auth/sync enqueue only `library_sync`; the scheduler enqueues only steam `library_sync`; steam prefill enqueues only steam `validate`. So F6's headline capability can't be driven through any operator interface — `POST /games/{epic_id}/prefill` → 400. **Fix:** generalize `trigger_prefill` to allow `platform in {steam,epic}` and parameterize the INSERT's platform from `game['platform']` (the dedup SELECT/read-back already filter on kind+game_id only, so they work for either platform); or add a dedicated Epic prefill router. Replace `test_non_steam_game_returns_400` with a 202+epic-row assertion and an end-to-end test that the enqueued epic job reaches `_epic_prefill`. **Live-UAT workaround until fixed:** manual `INSERT INTO jobs (kind, game_id, platform, state, source) VALUES ('prefill', <id>, 'epic', 'queued', 'cli')`.
+
+**#6 — SEV-3 Epic downloader retry logic untested (test-quality).** `epic_downloader.py:116-119` (timeout/transport retry) and the 5xx-retry-then-200 branch are never exercised (coverage: `Missing 110, 105->120, 116-119`). The only failure test is `test_4xx_not_retried`. The sibling Steam suite tests 5xx-retry-then-success; Epic doesn't, and neither simulates `TimeoutException`/`TransportError`. A regression that broke transient-error recovery would pass green. **Fix:** add (a) 503-then-200 → `chunks_ok==1`, 2 calls; (b) raise `ConnectError` → retried to `max_attempts` then `chunks_failed==1` (monkeypatch `asyncio.sleep`).
+
+**#7 — SEV-4 OAuth success path raises raw exception (stability).** `oauth.py:72` `return _to_tokens(resp.json())` is unguarded: a 200 with non-JSON body raises `JSONDecodeError`; a 200 missing `access_token` raises `KeyError` (`_to_tokens` uses bracket access). Callers catch only `EpicAuthError` → in the router this becomes a generic 500 instead of the documented 401. **Fix:** wrap the success path, raise `EpicAuthError` on parse/shape errors (log only `what`+status, never the body). Unit-test a 200 with missing `access_token` and a 200 non-JSON body.
+
+**#8 — SEV-4 `verify_cached` MISS path untested (test-quality).** Every test returns `X-Upstream-Cache-Status: HIT` (ratio 1.0) or empty (0.0); no partial ratio. So `epic_downloader.py:159->153` (non-HIT branch) and `prefill.py:165` (`low_hit_ratio` warning) are uncovered, and `verify_cached` — the **only** Epic validation gate (F7-Epic disk-stat deferred) — is only tested at the 100% boundary. **Fix:** mixed HIT/MISS test asserting `ratio==0.5`; handler test where `fake_verify` returns 0.2 asserts status still `up_to_date` (non-gating) **and** the warning fires.
+
+**#9 — SEV-4 CDN-base traversal guard untested (test-quality).** `manifest.py:199-200` (`'..' in cdn_base` → raise) has no test; its sibling host guard does (`test_fetch_manifest_rejects_non_fqdn_host`). Coverage: `manifest.py:200` missing. A refactor of `cdn_base` derivation could silently re-open traversal. **Fix:** feed a manifest `uri` with `..` in the path (dotted host so it passes the host guard), assert `EpicManifestError(match='path traversal')`.
+
+**#10 — SEV-4 `O_NOFOLLOW` symlink guard untested (test-quality).** `oauth.py:96-104` opens the token file with `O_NOFOLLOW` (TOCTOU/arbitrary-truncation guard); the only persistence test checks 0600 + round-trip, never plants a symlink. A refactor back to `Path.write_text`/`open()` would pass every test while re-introducing the vuln. **Fix:** symlink the token path to a victim file, assert `save_refresh_token` raises `OSError` and the target is untouched.
+
+**#11 — nit asyncio marker on sync tests (test-quality).** `test_oauth.py:14` `pytestmark = pytest.mark.asyncio` applies to two sync tests → `PytestWarning` ×2 (confirmed live). Tests still run/assert correctly (verified). `asyncio_mode=auto`, so the marker is redundant even for the async tests. **Fix:** delete the module-level `pytestmark`.
+
+---
+
+## Refuted (1) — kept off the bug list
+
+**Chunk `file_size` parsed as signed `<q>` → negative `total_bytes` (claimed nit).** Code facts accurate, **impact refuted:** both target columns are STRICT-table `CHECK(... >= 0)` (`manifests.total_bytes`, `games.size_bytes`), and the manifest UPSERT runs before the games UPDATE, so a negative total is rejected at the first write → classified `IntegrityViolationError` → caught by `_epic_prefill`'s guard → game `failed`, nothing corrupted. `file_size` is used only to sum `total_bytes` (never for sizing/progress). The DB already enforces the invariant; a hostile manifest fails the job cleanly. *Optional* defense-in-depth nit only: raise `EpicManifestError` on negative sizes at parse time for a domain-specific error.
+
+## Low-sev observation (not filed as SEV)
+
+**Steam auth auto-enqueue not migrated to `ON CONFLICT DO NOTHING`.** `_queue_library_sync_job_best_effort` (`auth.py:143-166`) still does SELECT-then-INSERT straddling an `await` (the pre-0004 pattern). Against the new `idx_jobs_library_sync_inflight` UNIQUE index, a concurrent insert in the gap makes the plain INSERT raise `IntegrityViolationError` — but it subclasses `PoolError`, is caught at `auth.py:165`, logged `auth.auto_sync.queue_failed`, and auth still returns success. Net: rare benign log-noise + a skipped auto-sync (operator can re-sync), not a 500. The Epic auth path already uses the correct pattern. **One-line follow-up:** switch to `ON CONFLICT DO NOTHING` for consistency with the other four call sites.
+
+---
+
+## Live-only scenarios (require real Steam/Epic accounts + a real lancache)
+
+The automated suite mocks every network boundary (`httpx.MockTransport`), stubs the platform clients, and uses synthetic binary manifests — it proves internal logic but **nothing** about real wire formats, signed-URL expiry, chunk-key/Host routing, or on-disk cache population. The following must be verified by hand (see the interactive template `test-session-10-v1.html`):
+
+**F5 Steam prefill:** real 2FA auth + session persist → library_sync upserts real games → `POST /games/{id}/prefill` fetches a real depot manifest, `manifest_expand` yields real SHAs → chunks 200 **through** the lancache (`Host: lancache.steamcontent.com`, Valve UA), exercising the real retry loop → on-disk cache populated at the F7 cache-key path → chained `validate` runs → game `up_to_date` → re-request HITs.
+
+**F6 Epic prefill:** real OAuth code from `legendary.gl/epiclogin` → `POST /platforms/epic/auth` (202, no tokens echoed, refresh token 0600, auto library_sync) → real token refresh on a later call → library enumerate populates `platform='epic'` games (real cursor pagination) → **trigger an Epic prefill** (currently needs the #5 SQL workaround) → FRESH signed manifest fetched + real binary manifest parses (real feature-levels/compression/UTF-16 the fixtures don't cover) → chunks 200 through the lancache with **Host-header routing** to the real Epic CDN host (passes the FQDN + `..` guards) → on-disk cache populated → `verify_cached` re-requests yield real `X-Upstream-Cache-Status: HIT` → game `up_to_date` with real `size_bytes`; a real partial CDN failure yields `failed`+`last_error` (stuck-`downloading` guard holds on a real exception).
+
+## Recommended remediation (after the live pass)
+
+Fix **all 11 confirmed** test-first (most are unit-testable offline), plus the one-line auth.py follow-up. Suggested order: **#1 (SEV-2 bomb) → #4 (SSRF ordering) → #5 (Epic trigger; unblocks F6 live) → #2, #3 (stuck-downloading) → #7 (OAuth contract) → #6, #8, #9, #10 (test-quality) → #11 (nit)**. Then re-green the suite + static gates and close the gate.

--- a/tests/uat/sessions/2026-06-04-session-10/templates/test-session-10-v1.html
+++ b/tests/uat/sessions/2026-06-04-session-10/templates/test-session-10-v1.html
@@ -1,0 +1,335 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>UAT Session 10</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif; background: #0f0f17; color: #cdd6f4; line-height: 1.5; padding: 24px; max-width: 960px; margin: 0 auto; }
+  h1 { font-size: 1.6rem; margin-bottom: 4px; }
+  .meta { color: #a6adc8; font-size: 0.9rem; margin-bottom: 24px; }
+  .progress-bar { background: #1e1e2e; border-radius: 8px; height: 8px; margin-bottom: 24px; overflow: hidden; }
+  .progress-fill { background: #a6e3a1; height: 100%; width: 0%; transition: width 0.3s; }
+  .progress-text { text-align: center; color: #a6adc8; font-size: 0.85rem; margin-bottom: 24px; }
+  h2 { font-size: 1.2rem; color: #89b4fa; margin: 32px 0 16px; padding-bottom: 8px; border-bottom: 1px solid #313244; }
+  .fixture-ref { background: #11111b; border: 1px solid #313244; border-radius: 8px; padding: 12px 16px; margin-bottom: 16px; font-size: 0.85rem; color: #a6adc8; }
+  .fixture-ref strong { color: #cdd6f4; }
+  .fixture-ref code { background: #313244; padding: 2px 6px; border-radius: 3px; color: #f9e2af; }
+  .banner { background: #2a1e2e; border: 1px solid #f38ba8; border-radius: 8px; padding: 12px 16px; margin-bottom: 16px; font-size: 0.85rem; color: #f5c2e7; }
+  .banner strong { color: #f38ba8; }
+  .banner code { background: #313244; padding: 2px 6px; border-radius: 3px; color: #f9e2af; }
+  .scenario { background: #1e1e2e; border-radius: 8px; margin-bottom: 12px; overflow: hidden; border-left: 4px solid #45475a; transition: border-color 0.2s; }
+  .scenario.pass { border-left-color: #a6e3a1; }
+  .scenario.fail { border-left-color: #f38ba8; }
+  .scenario-header { padding: 12px 16px; display: flex; align-items: center; gap: 12px; }
+  .scenario-num { background: #313244; color: #a6adc8; font-size: 0.8rem; font-weight: 600; padding: 2px 8px; border-radius: 4px; min-width: 28px; text-align: center; }
+  .scenario-title { flex: 1; font-weight: 500; }
+  .btn-group { display: flex; gap: 4px; }
+  .btn { padding: 6px 14px; border: 1px solid #45475a; border-radius: 4px; background: transparent; color: #cdd6f4; cursor: pointer; font-size: 0.85rem; transition: all 0.15s; }
+  .btn:hover { background: #313244; }
+  .btn.pass-btn.active { background: #a6e3a1; color: #1e1e2e; border-color: #a6e3a1; font-weight: 600; }
+  .btn.fail-btn.active { background: #f38ba8; color: #1e1e2e; border-color: #f38ba8; font-weight: 600; }
+  .btn.skip-btn.active { background: #f9e2af; color: #1e1e2e; border-color: #f9e2af; font-weight: 600; }
+  .scenario-details { padding: 0 16px 8px 16px; display: none; }
+  .scenario-details.open { display: block; }
+  .steps { background: #11111b; padding: 10px 14px; border-radius: 4px; font-size: 0.85rem; color: #a6adc8; margin-bottom: 8px; }
+  .steps strong { color: #cdd6f4; }
+  .scenario-notes { padding: 4px 16px 12px 16px; }
+  .notes-input { width: 100%; background: #11111b; border: 1px solid #45475a; color: #cdd6f4; padding: 8px 12px; border-radius: 4px; font-size: 0.85rem; font-family: inherit; resize: vertical; min-height: 36px; }
+  .notes-input:focus { outline: none; border-color: #89b4fa; }
+  .toggle-details { background: none; border: none; color: #6c7086; cursor: pointer; font-size: 0.75rem; padding: 4px 8px; }
+  .toggle-details:hover { color: #89b4fa; }
+  .bugs-section { margin-top: 40px; }
+  .bug-entry { background: #1e1e2e; border-radius: 8px; padding: 16px; margin-bottom: 12px; border-left: 4px solid #f38ba8; }
+  .bug-row { display: flex; gap: 12px; margin-bottom: 8px; flex-wrap: wrap; }
+  .bug-field { flex: 1; min-width: 200px; }
+  .bug-field label { display: block; color: #a6adc8; font-size: 0.8rem; margin-bottom: 4px; }
+  .bug-field input, .bug-field select, .bug-field textarea { width: 100%; background: #11111b; border: 1px solid #45475a; color: #cdd6f4; padding: 8px 12px; border-radius: 4px; font-size: 0.85rem; font-family: inherit; }
+  .bug-field textarea { resize: vertical; min-height: 60px; }
+  .bug-field input:focus, .bug-field select:focus, .bug-field textarea:focus { outline: none; border-color: #89b4fa; }
+  .bug-field select { appearance: auto; }
+  .add-bug-btn { background: #313244; border: 1px dashed #45475a; color: #a6adc8; padding: 10px; border-radius: 8px; width: 100%; cursor: pointer; font-size: 0.85rem; margin-bottom: 12px; }
+  .add-bug-btn:hover { border-color: #f38ba8; color: #f38ba8; }
+  .remove-bug { background: none; border: none; color: #f38ba8; cursor: pointer; font-size: 0.8rem; float: right; }
+  .overall-notes { margin-top: 32px; }
+  .overall-notes textarea { width: 100%; background: #11111b; border: 1px solid #45475a; color: #cdd6f4; padding: 12px; border-radius: 8px; font-size: 0.9rem; font-family: inherit; resize: vertical; min-height: 100px; }
+  .overall-notes textarea:focus { outline: none; border-color: #89b4fa; }
+  .export-section { margin-top: 32px; text-align: center; padding: 24px; }
+  .export-btn { background: #89b4fa; color: #1e1e2e; border: none; padding: 12px 32px; border-radius: 8px; font-size: 1rem; font-weight: 600; cursor: pointer; }
+  .export-btn:hover { background: #74c7ec; }
+  .export-btn:active { transform: scale(0.98); }
+  .copy-msg { color: #a6e3a1; margin-top: 8px; font-size: 0.85rem; display: none; }
+</style>
+</head>
+<body>
+
+<h1>UAT Session 10</h1>
+<div class="meta">Date: 2026-06-04 | Features: F5 Steam Prefill, F6 Epic Prefill | Tester: <input id="tester-name" type="text" placeholder="Your name" style="background:#1e1e2e;border:1px solid #45475a;color:#cdd6f4;padding:4px 8px;border-radius:4px;font-size:0.85rem;width:140px;"></div>
+
+<div class="fixture-ref">
+  <strong>Setup.</strong> Deploy current <code>main</code> (commit <code>aa25597</code>) on the lancache host using the UAT-9 recipe (dual-venv image, <code>--network host</code>, cache mounted read-only). Set <code>ORCH=http://127.0.0.1:8765</code> and <code>TOKEN=&lt;your 32-hex orchestrator token&gt;</code>. <code>/platforms/*/auth</code> is loopback-only — run auth from the host. Watch logs with <code>docker logs -f &lt;container&gt;</code>.<br>
+  <strong>This session tests the PREFILL features (F5/F6) live</strong> — the automated agent sweep already passed 1037 unit tests + static gates; what only a live run can prove is real chunk download through the lancache and real on-disk cache population.
+</div>
+
+<div class="banner">
+  <strong>Heads-up — 11 bugs already found by the automated sweep</strong> (see <code>agent-results/uat-10-agent-sweep-2026-06-04.md</code>). They will be fixed test-first after this live pass. Two you may hit during testing:<br>
+  • <strong>#5 (SEV-3):</strong> Epic prefill has <em>no trigger endpoint</em> yet. To run F6 scenarios 11–14, enqueue manually on the host: <code>sqlite3 /var/lib/orchestrator/orchestrator.db "INSERT INTO jobs (kind, game_id, platform, state, source) VALUES ('prefill', &lt;epic_game_id&gt;, 'epic', 'queued', 'cli');"</code> (the worker picks it up on its next poll).<br>
+  • <strong>#2/#3 (SEV-3):</strong> a Steam prefill that fails mid-manifest, or whose post-prefill validate hits an unmounted cache, may leave the game showing <code>downloading</code> forever. If you see a stuck <code>downloading</code>, note it on the matching scenario — it's expected and already filed.
+</div>
+
+<div class="progress-bar"><div class="progress-fill" id="progress-fill"></div></div>
+<div class="progress-text" id="progress-text">0 / 0 completed</div>
+
+<h2>Feature 5: Steam Prefill (F5)</h2>
+<div class="fixture-ref">
+  <strong>Endpoints:</strong> <code>POST $ORCH/api/v1/platforms/steam/library/sync</code> · <code>POST $ORCH/api/v1/games/{id}/prefill</code> · <code>GET $ORCH/api/v1/games?platform=steam</code><br>
+  Steam session does NOT persist across container restart (steam-next #108) — a fresh deploy needs a fresh 2FA.
+</div>
+<div id="feature5"></div>
+
+<h2>Feature 6: Epic Prefill (F6)</h2>
+<div class="fixture-ref">
+  <strong>Endpoints:</strong> <code>POST $ORCH/api/v1/platforms/epic/auth</code> (body <code>{"code":"&lt;authorizationCode&gt;"}</code> from <code>legendary.gl/epiclogin</code>) · <code>POST $ORCH/api/v1/platforms/epic/library/sync</code> · <code>GET $ORCH/api/v1/games?platform=epic</code><br>
+  No prefill endpoint yet (agent finding #5) — use the manual SQL insert from the banner above for scenarios 11–14.
+</div>
+<div id="feature6"></div>
+
+<div class="bugs-section">
+  <h2>Bugs Found (new — beyond the 11 already filed)</h2>
+  <div id="bugs-list"></div>
+  <button class="add-bug-btn" onclick="addBug()">+ Add Bug</button>
+</div>
+
+<div class="overall-notes">
+  <h2>Overall Notes</h2>
+  <textarea id="overall-notes" placeholder="Free-form observations, UX concerns, real wire-format surprises, anything that felt wrong even if it technically worked..."></textarea>
+</div>
+
+<div class="export-section">
+  <button class="export-btn" onclick="exportResults()">Copy Results to Clipboard</button>
+  <div class="copy-msg" id="copy-msg">Copied! Paste into terminal or save to the submissions folder.</div>
+</div>
+
+<script>
+const scenarios = [
+  {
+    "id": 1, "feature": 5,
+    "title": "Steam auth with 2FA; session established",
+    "steps": "1. Deploy current main on the lancache host (UAT-9 recipe).\n2. From the host, run the Steam auth flow (helper script / POST .../platforms/steam/auth) and enter the Steam Guard 2FA code when prompted.\n3. GET $ORCH/api/v1/platforms -H \"Authorization: Bearer $TOKEN\".",
+    "expected": "Auth succeeds; platforms shows steam auth_status='ok'. The password and any session token NEVER appear in docker logs."
+  },
+  {
+    "id": 2, "feature": 5,
+    "title": "Library sync upserts real owned games",
+    "steps": "1. curl -sX POST $ORCH/api/v1/platforms/steam/library/sync -H \"Authorization: Bearer $TOKEN\"  (returns a job_id; a second call within the window returns the SAME job_id — dedup).\n2. Wait for the job to finish (GET $ORCH/api/v1/jobs?kind=library_sync).\n3. GET $ORCH/api/v1/games?platform=steam&per_page=5.",
+    "expected": "Real owned games (real app_ids/titles, not fixtures) are upserted into games with platform='steam'. Exactly one in-flight library_sync at a time."
+  },
+  {
+    "id": 3, "feature": 5,
+    "title": "Trigger prefill; real manifest fetched + expanded",
+    "steps": "1. Pick a SMALL owned game id from scenario 2.\n2. curl -sX POST $ORCH/api/v1/games/{id}/prefill -H \"Authorization: Bearer $TOKEN\"  -> 202 + job_id.\n3. Watch logs: prefill.started -> (prefill.fetching_manifests if needed) -> chunk activity.",
+    "expected": "A real depot manifest is fetched from Steam and manifest_expand yields real chunk SHAs. Game status moves to 'downloading'. No crash."
+  },
+  {
+    "id": 4, "feature": 5,
+    "title": "Chunks download THROUGH the lancache (retry loop under real load)",
+    "steps": "1. While the prefill job runs, tail the lancache access log AND the orchestrator log.\n2. Confirm requests hit http://<lancache>/depot/{depot}/chunk/{sha} with Host: lancache.steamcontent.com and the Valve User-Agent.\n3. Note any real timeouts/503s and whether they recover.",
+    "expected": "Chunks are requested through the lancache (not direct to Steam). Transient 5xx/timeouts retry and recover; the prefill completes. chunks_failed=0 on a healthy run."
+  },
+  {
+    "id": 5, "feature": 5,
+    "title": "On-disk lancache cache is actually POPULATED",
+    "steps": "1. After prefill completes, on the lancache host inspect the cache dir for the game's chunks at the F7 cache-key path (md5 formula).\n2. Compare cached chunk count to the manifest chunk_count (du / find under the cache).",
+    "expected": "The bytes really landed on the cache SSD — a meaningful fraction of the game's chunks are present on disk (this is the core value-prop)."
+  },
+  {
+    "id": 6, "feature": 5,
+    "title": "Chained validate runs; game reaches a terminal status",
+    "steps": "1. After prefill success, confirm a 'validate' job was enqueued (GET $ORCH/api/v1/jobs?kind=validate).\n2. Wait for it; GET $ORCH/api/v1/games/{id}.",
+    "expected": "Game transitions to 'up_to_date' (fully cached) or 'validation_failed'/'failed' with a real last_error (partial/again). It must NOT remain 'downloading' (see bug #2/#3 — flag if it does)."
+  },
+  {
+    "id": 7, "feature": 5,
+    "title": "Re-request a sample → real cache HIT",
+    "steps": "1. Pick one chunk URL from scenario 4.\n2. Re-request it through the lancache and inspect the cache-status response header.",
+    "expected": "The second request is served from cache (HIT) — proves caching, not just a one-time transfer."
+  },
+  {
+    "id": 8, "feature": 6,
+    "title": "Epic OAuth: submit code, tokens persisted, auto-sync enqueued",
+    "steps": "1. In a browser logged into a real Epic account that owns games, open legendary.gl/epiclogin and copy the authorizationCode JSON value.\n2. From the host: curl -sX POST $ORCH/api/v1/platforms/epic/auth -H \"Authorization: Bearer $TOKEN\" -H 'Content-Type: application/json' -d '{\"code\":\"<CODE>\"}'\n3. GET $ORCH/api/v1/platforms/epic/auth ; on the host, stat the epic_session file.",
+    "expected": "202 with account_id/display_name; NO access/refresh token or code echoed in the response or logs. Refresh token file is mode 0600. epic auth_status='ok'. A library_sync job is auto-enqueued."
+  },
+  {
+    "id": 9, "feature": 6,
+    "title": "Epic library enumerate populates games (with pagination)",
+    "steps": "1. Wait for the auto library_sync (or POST $ORCH/api/v1/platforms/epic/library/sync).\n2. GET $ORCH/api/v1/games?platform=epic&per_page=10.\n3. If the library is large, confirm >1 cursor page was fetched (logs).",
+    "expected": "Real Epic titles populate games with platform='epic' and metadata JSON (namespace, catalog_item_id). Cursor pagination works across multiple pages."
+  },
+  {
+    "id": 10, "feature": 6,
+    "title": "Token refresh works on a later call",
+    "steps": "1. Some time after auth (or after restarting the worker so the cached access token is gone), trigger any Epic operation that needs a token (e.g. a second library sync).\n2. Watch logs for a refresh grant.",
+    "expected": "The refresh grant succeeds, a rotated refresh token is persisted (0600), and the operation proceeds. No token material in logs."
+  },
+  {
+    "id": 11, "feature": 6,
+    "title": "Trigger Epic prefill (manual insert); FRESH manifest fetched + parses",
+    "steps": "1. Pick a SMALL owned Epic game id.\n2. On the host: sqlite3 /var/lib/orchestrator/orchestrator.db \"INSERT INTO jobs (kind, game_id, platform, state, source) VALUES ('prefill', <id>, 'epic', 'queued', 'cli');\"\n3. Watch logs: prefill.epic.started -> manifest fetch -> chunk activity.",
+    "expected": "A FRESH signed manifest is fetched at prefill time and the REAL binary manifest parses without error (real feature-levels/compression/UTF-16 paths the synthetic fixtures don't cover). The size cap does NOT falsely trip on a real manifest. Game status 'downloading'."
+  },
+  {
+    "id": 12, "feature": 6,
+    "title": "Epic chunks download THROUGH the lancache with Host-header routing",
+    "steps": "1. While the epic prefill runs, tail the lancache access log + orchestrator log.\n2. Confirm requests hit http://<lancache>/<cdn_base>/ChunksV5/NN/<b64hash>_<b64guid>.chunk with Host: <real epic cdn host>.",
+    "expected": "Chunks route through the lancache via the Host header. The real CDN host passes the FQDN guard and the real cdn_base passes the '..' guard (a legitimate signed path is NOT falsely rejected)."
+  },
+  {
+    "id": 13, "feature": 6,
+    "title": "On-disk cache populated + verify_cached HIT → up_to_date",
+    "steps": "1. After the epic prefill completes, confirm the cache dir for the Epic CDN host is populated on disk.\n2. GET $ORCH/api/v1/games/{id} ; check logs for prefill.epic.completed and any prefill.epic.low_hit_ratio warning.",
+    "expected": "On-disk cache is populated for the Epic CDN host; verify_cached re-requests yield real X-Upstream-Cache-Status: HIT. Game reaches 'up_to_date' with size_bytes = real sum of chunk file_sizes. (Confirm the real lancache emits the HIT header for the Epic CDN host — it's the only Epic validation gate.)"
+  },
+  {
+    "id": 14, "feature": 6,
+    "title": "Partial CDN failure → failed + last_error (stuck-downloading guard holds)",
+    "steps": "1. (Opportunistic) If any real Epic chunk 404s/500s from the CDN during a prefill, observe the outcome.\n2. Otherwise note N/A.",
+    "expected": "A real partial failure yields status='failed' + a real last_error — the game does NOT remain 'downloading'. (The guard must hold on a real exception, not just the synthetic test case.)"
+  }
+];
+
+function renderScenarios() {
+  scenarios.forEach(s => {
+    const container = document.getElementById('feature' + s.feature);
+    if (!container) return;
+    container.innerHTML += '<div class="scenario" id="scenario-' + s.id + '">' +
+      '<div class="scenario-header">' +
+        '<span class="scenario-num">' + s.id + '</span>' +
+        '<span class="scenario-title">' + s.title + '</span>' +
+        '<button class="toggle-details" onclick="toggleDetails(' + s.id + ')">details</button>' +
+        '<div class="btn-group">' +
+          '<button class="btn pass-btn" onclick="setResult(' + s.id + ',\'pass\',this)">Pass</button>' +
+          '<button class="btn fail-btn" onclick="setResult(' + s.id + ',\'fail\',this)">Fail</button>' +
+          '<button class="btn skip-btn" onclick="setResult(' + s.id + ',\'skip\',this)">Skip</button>' +
+        '</div>' +
+      '</div>' +
+      '<div class="scenario-details" id="details-' + s.id + '">' +
+        '<div class="steps"><strong>Steps:</strong><br>' + s.steps.replace(/\n/g,'<br>') + '</div>' +
+        '<div class="steps"><strong>Expected:</strong><br>' + s.expected + '</div>' +
+      '</div>' +
+      '<div class="scenario-notes">' +
+        '<textarea class="notes-input" id="notes-' + s.id + '" placeholder="Notes — observations, issues, anything worth recording"></textarea>' +
+      '</div>' +
+    '</div>';
+  });
+}
+
+const results = {};
+
+function setResult(id, result, btn) {
+  results[id] = result;
+  const sc = document.getElementById('scenario-' + id);
+  sc.className = 'scenario ' + (result === 'skip' ? '' : result);
+  sc.querySelectorAll('.btn').forEach(b => b.classList.remove('active'));
+  btn.classList.add('active');
+  updateProgress();
+}
+
+function toggleDetails(id) {
+  document.getElementById('details-' + id).classList.toggle('open');
+}
+
+function updateProgress() {
+  const done = Object.keys(results).length;
+  const pct = (done / scenarios.length * 100).toFixed(0);
+  document.getElementById('progress-fill').style.width = pct + '%';
+  document.getElementById('progress-text').textContent = done + ' / ' + scenarios.length + ' completed';
+}
+
+var bugCount = 0;
+function addBug() {
+  bugCount++;
+  var n = bugCount;
+  document.getElementById('bugs-list').innerHTML +=
+    '<div class="bug-entry" id="bug-' + n + '">' +
+      '<button class="remove-bug" onclick="document.getElementById(\'bug-' + n + '\').remove()">remove</button>' +
+      '<div class="bug-row">' +
+        '<div class="bug-field"><label>Severity</label><select id="bug-sev-' + n + '">' +
+          '<option>SEV-1 (crash/data loss)</option><option>SEV-2 (broken, workaround exists)</option>' +
+          '<option selected>SEV-3 (minor UX)</option><option>SEV-4 (polish/enhancement)</option>' +
+        '</select></div>' +
+        '<div class="bug-field"><label>Feature</label><select id="bug-feat-' + n + '">' +
+          '<option>5 - Steam Prefill (F5)</option><option>6 - Epic Prefill (F6)</option>' +
+        '</select></div>' +
+      '</div>' +
+      '<div class="bug-field"><label>Description</label><input id="bug-desc-' + n + '" placeholder="What went wrong?"></div>' +
+      '<div class="bug-field" style="margin-top:8px"><label>Steps to Reproduce</label><textarea id="bug-steps-' + n + '" placeholder="1. ...\n2. ...\n3. ..."></textarea></div>' +
+      '<div class="bug-field" style="margin-top:8px"><label>Expected vs Actual</label><textarea id="bug-exp-' + n + '" placeholder="Expected: ...\nActual: ..."></textarea></div>' +
+    '</div>';
+}
+
+function exportResults() {
+  var tester = document.getElementById('tester-name').value || 'Unknown';
+  var md = '# ' + document.querySelector('h1').textContent + ' Results\n\n';
+  md += '**Date:** 2026-06-04\n';
+  md += '**Tester:** ' + tester + '\n';
+  md += '**Features:** F5 Steam Prefill, F6 Epic Prefill\n\n';
+
+  var pass = 0, fail = 0, skip = 0;
+  for (var k in results) {
+    if (results[k] === 'pass') pass++;
+    else if (results[k] === 'fail') fail++;
+    else if (results[k] === 'skip') skip++;
+  }
+  var untested = scenarios.length - Object.keys(results).length;
+  md += '**Summary:** ' + pass + ' passed, ' + fail + ' failed, ' + skip + ' skipped, ' + untested + ' not tested\n\n---\n\n';
+
+  md += '## Scenarios\n\n';
+  md += '| # | Scenario | Result | Notes |\n';
+  md += '|---|---|---|---|\n';
+  scenarios.forEach(function(s) {
+    var r = results[s.id] || 'not tested';
+    var icon = r === 'pass' ? 'PASS' : r === 'fail' ? 'FAIL' : r === 'skip' ? 'SKIP' : '-';
+    var el = document.getElementById('notes-' + s.id);
+    var notes = el ? el.value.replace(/\|/g, '/').replace(/\n/g, ' ').replace(/`/g, "'").replace(/\[/g, '(').replace(/\]/g, ')').replace(/\*/g, '-') : '';
+    md += '| ' + s.id + ' | ' + s.title + ' | ' + icon + ' | ' + notes + ' |\n';
+  });
+
+  var bugEntries = document.querySelectorAll('.bug-entry');
+  if (bugEntries.length > 0) {
+    md += '\n---\n\n## Bugs Found (new)\n\n';
+    var i = 0;
+    bugEntries.forEach(function(el) {
+      i++;
+      var id = el.id.split('-')[1];
+      var sev = document.getElementById('bug-sev-' + id);
+      var feat = document.getElementById('bug-feat-' + id);
+      var desc = document.getElementById('bug-desc-' + id);
+      var steps = document.getElementById('bug-steps-' + id);
+      var exp = document.getElementById('bug-exp-' + id);
+      md += '### Bug ' + i + '\n';
+      md += '- **Severity:** ' + (sev ? sev.value : '') + '\n';
+      md += '- **Feature:** ' + (feat ? feat.value : '') + '\n';
+      md += '- **Description:** ' + (desc ? desc.value : '') + '\n';
+      md += '- **Steps:** ' + (steps ? steps.value.replace(/\n/g, '; ') : '') + '\n';
+      md += '- **Expected vs Actual:** ' + (exp ? exp.value.replace(/\n/g, '; ') : '') + '\n\n';
+    });
+  }
+
+  var overall = document.getElementById('overall-notes').value;
+  if (overall) {
+    md += '\n---\n\n## Overall Notes\n\n' + overall + '\n';
+  }
+
+  navigator.clipboard.writeText(md).then(function() {
+    var msg = document.getElementById('copy-msg');
+    msg.style.display = 'block';
+    setTimeout(function() { msg.style.display = 'none'; }, 3000);
+  });
+}
+
+renderScenarios();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## UAT-10 remediation — F5 (Steam prefill) + F6 (Epic prefill)

Remediates all **11 confirmed findings + 1 observation** from the UAT-10 automated adversarial sweep (5 finder lenses → independent skeptic-verify each). Every fix landed **test-first** (RED→GREEN). Full report: `tests/uat/sessions/2026-06-04-session-10/agent-results/uat-10-agent-sweep-2026-06-04.md`.

### Security
- **#1 (SEV-2) Epic manifest decompression bomb** — `manifest.py` inflated the zlib body with unbounded `zlib.decompress`; a tiny compressed manifest (under the 128 MiB *compressed* cap) could expand to GBs and OOM the process (reproduced offline: 510 KB → ~500 MB RSS). Now a bounded `zlib.decompressobj().decompress(body, max_decompressed)` (256 MiB default) that raises `EpicManifestError` before allocating beyond the cap.
- **#4 (SEV-3) Epic manifest fetch SSRF** — `fetch_manifest` GET-ed the response-supplied CDN `uri` *before* validating it; the FQDN + `..` guards ran only afterward. Host (FQDN) + traversal checks now run **before** the GET, so a hostile/MITM'd Epic response can't drive the manifest fetch at an internal host/IP. Both regression tests assert the unvalidated host is never fetched.

### Correctness / stability
- **#5 (SEV-3)** Epic prefill is now triggerable — `POST /games/{id}/prefill` accepts `steam`/`epic` and enqueues the game's own platform (was steam-hardcoded → 400 for Epic, leaving `_epic_prefill` reachable only by manual DB insert).
- **#2 (SEV-3)** Steam prefill no longer stuck `downloading` on an IPC/worker/auth failure — `_steam_prefill` wraps its work and marks `failed` (`WHERE status='downloading'`), mirroring the Epic guard.
- **#3 (SEV-3)** A post-prefill `validate` with `outcome='error'` (cache unmounted) now resolves the transient `downloading` to `failed` without clobbering an already-classified status.
- **#7 (SEV-4)** Epic OAuth's malformed-200 path raises `EpicAuthError` (not a raw `KeyError`/`JSONDecodeError`) → documented 401; logs only `what`+`status`.
- **Observation** — Steam auth auto-enqueue switched to atomic `INSERT ... ON CONFLICT DO NOTHING`.

### Test-quality (#6/#8/#9/#10/#11)
Epic downloader retry (503→200 recovery, transport-error retry-then-fail); `verify_cached` MISS ratio + non-gating low-ratio warning; CDN `..` traversal guard; `O_NOFOLLOW` symlink/TOCTOU guard; removed a redundant `pytest.mark.asyncio` that warned on two sync tests.

### Verification
- **1051 tests pass** (+14 vs. baseline); `mypy --strict`, `ruff`, `gitleaks`, custom `semgrep` rules all clean.
- Security audit: `docs/security-audits/uat10-remediation-security-audit.md` (0 open findings).
- 1 finding correctly **refuted** by the sweep (negative `file_size` → DB CHECK already rejects) — not changed.

### Still required after merge
The **F5/F6 live UAT** (real Steam/Epic accounts) remains the manual step — the `test-session-10-v1.html` template is included and now runs against fixed code (Epic prefill via the real endpoint, no SQL workaround needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)