### PR TITLE
docs(uat10): live UAT results — F5 + F6 prefill PASS, session closed

### DIFF
--- a/.claude/build-progress.json
+++ b/.claude/build-progress.json
@@ -21,12 +21,12 @@
     "F5-steam-prefill",
     "f6-epic-prefill"
   ],
-  "features_since_last_test": 2,
+  "features_since_last_test": 0,
   "features_since_last_health_check": 3,
   "test_interval": 2,
-  "last_test_session": "2026-05-29",
-  "testing_required": true,
+  "last_test_session": "2026-06-05",
+  "testing_required": false,
   "tester_count": 1,
   "bug_tracker": "github_issues",
-  "sessions_completed": 9
+  "sessions_completed": 10
 }

--- a/.claude/process-state.json
+++ b/.claude/process-state.json
@@ -13,11 +13,17 @@
   },
   "uat_session": {
     "session_id": 10,
-    "step": 3,
+    "step": 9,
     "steps_completed": [
       "agents_dispatched",
       "template_generated",
-      "orchestrator_notified"
+      "orchestrator_notified",
+      "results_received",
+      "completeness_verified",
+      "bugs_consolidated",
+      "triage_complete",
+      "remediation_complete",
+      "gate_passed"
     ],
     "started_at": "2026-06-04T19:27:54Z"
   },

--- a/tests/uat/sessions/2026-06-04-session-10/submissions/uat-10-live-results-2026-06-05.md
+++ b/tests/uat/sessions/2026-06-04-session-10/submissions/uat-10-live-results-2026-06-05.md
@@ -1,0 +1,39 @@
+# UAT-10 — Live Results (F5 Steam prefill + F6 Epic prefill)
+
+**Date:** 2026-06-05
+**Tester:** Karl (auth) + agent-driven (deploy, prefill, verify over SSH)
+**Build:** `git_sha=474380a` (main, post-#139 remediation) — dockerized on the lancache host (`orchestrator-uat10`, `--network host`, bound `127.0.0.1:8765`, cache mounted read-only).
+**Outcome:** **PASS** — both prefill pipelines proven end-to-end against real Steam + Epic accounts and the real lancache. The remediated code (PR #139) ran live with no regressions; the F5 MISS path and F6 full stack — neither previously live-tested — both work.
+
+## Deploy / health
+`/health` → `200`, `git_sha=474380a`, `scheduler_running`, `lancache_reachable`, `cache_volume_mounted`, `validator_healthy` all true. ✅
+
+## F6 — Epic (full PASS)
+- OAuth: real `legendary.gl/epiclogin` code → `202`, account **Kraulerson**, `auth_status=ok`; **no token echoed** in response or logs (`epic_auth.authenticated` carries only `account_id`). Refresh token persisted.
+- Library: `enumerate.returned app_count=694` → **663 games** upserted (`platform=epic`).
+- **Manifest probe (16 titles):** 14 real binary manifests fetched + parsed (chunk counts 158–65 292, sizes 127 MB–62 GB); 2 unowned/DLC → clean `EpicManifestError` (HTTP 403, no crash). Real CDN hosts `egs-cloudfront-chunks.epicgamescdn.com` / `egdownload.fastly-edge.com` **both pass the FQDN/SSRF guard** (UAT-10 #4). No real manifest false-tripped the decompression cap (#1).
+- **Prefill via the real endpoint (#5):** `POST /games/8/prefill` → `202`, `platform=epic` (was 400 pre-fix). Game 8 = **Turaco**, v17, 158 chunks, `depot_id=NULL`, `raw=13398B`.
+- Download + verify: 158/158 chunks through the lancache, **`hit_ratio=1.0`** → `status=up_to_date`, `size_bytes=133,764,890`.
+
+## F5 — Steam (full PASS)
+- Auth: username/password → `202` (`challenge_type=mobile_authenticator`) → Steam Guard code → `200`, `auth_status=ok`. (Earlier failures were a placeholder/typo in the manual curl, not a product issue.)
+- Library: `enumerate.returned app_count=2461` → **2461 games** upserted (readable titles).
+- Manifest fetch probe (6 small candidates): dedicated-server/editor tools return 0 chunks (no owned depots); Source SDK = smallest real game.
+- **Prefill (#5 sibling / F5 MISS path, first live test):** `POST /games/703/prefill` (Source SDK, ~2 GB) → `prefill.completed ok=2430/2430 failed=0` in ~42 s → chained validate enqueued.
+- **F7 validate (on-disk):** `outcome=cached`, **chunks_cached=2430 / missing=0** → `status=up_to_date`, `size_bytes=2,173,258,931`. 100% of prefilled chunks confirmed on disk in the lancache (re-confirms the cache-key formula).
+
+## Remediation re-confirmed live (PR #139)
+- **#5** Epic prefill trigger works via the real API endpoint (202, not 400).
+- **#4** SSRF FQDN guard accepts real Epic CDN hosts (no false rejection) and the manifest fetch validates before the GET.
+- **#1** real (compressed) Epic manifests parse fine under the bounded decompressor.
+- **#7** real unowned-title 403s surface as clean `EpicManifestError`, no raw traceback.
+
+## New observations (minor, non-blocking — filed as follow-ups)
+1. **Epic `title` not resolved to a store title** — the library enumerate stores `app_name` as the title (sometimes a readable slug like `Turaco`, often a hex GUID). Cosmetic; resolving display titles needs a separate Epic catalog lookup.
+2. **No `GET /api/v1/games/{id}` detail route** — `games.py` is list-only; a by-id fetch 404s. Minor API-completeness gap (the sub-resource triggers `/games/{id}/prefill` etc. do exist).
+
+Neither is SEV-1/2. No must-fix bugs surfaced live → no further remediation required for UAT-10.
+
+## Notes
+- The Steam password was inadvertently pasted in plaintext during auth → recommended Karl rotate it post-UAT.
+- `orchestrator-uat10` container left running on the host (holds Karl's Steam session + Epic refresh token in its named volume) pending teardown decision.


### PR DESCRIPTION
Closes out **UAT-10**. Both prefill pipelines pass live against the fixed code (PR #139), on the dockerized build `git_sha=474380a` running on the lancache host with real Steam + Epic accounts.

## Results
- **F6 Epic:** OAuth (no token logged) → 663 games → prefill `Turaco` via the real `/games/{id}/prefill` endpoint (#5; was 400 pre-fix) → 158/158 chunks, **`hit_ratio=1.0`**, `up_to_date`. Real CDN hosts pass the #4 FQDN guard; 14/16 probed manifests parsed (2 unowned → clean `EpicManifestError`).
- **F5 Steam:** auth (2FA) → 2461 games → prefill `Source SDK` (~2 GB) → 2430/2430 chunks in 42 s → chained F7 validate **`cached=2430 / missing=0`** → `up_to_date`. First live exercise of the F5 MISS path.

## Contents
- `tests/uat/sessions/2026-06-04-session-10/submissions/uat-10-live-results-2026-06-05.md` — full live record.
- UAT-10 checklist closed (9/9) + test-gate counter reset (state files).

## Follow-ups filed (minor, non-blocking)
- #140 — resolve Epic display titles (currently stores `app_name`).
- #141 — add `GET /api/v1/games/{id}` detail route (list-only today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)