### PR TITLE
feat(jobs): per-job correlation context + max-runtime self-heal (eval quick-wins)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Added — jobs worker operability (eval quick-wins) — 2026-06-13
+
+Two operability improvements to the jobs worker, from the post-audit codebase eval.
+
+- **Logging:** each job now runs inside its own `correlation_id` (plus `job_id`/`job_kind`) bound into contextvars — the job-side analogue of the HTTP `request_context()`. Every log line a job emits (worker → handler → validator → pool) now carries the same `correlation_id`, so a job's full lifecycle is greppable by one ID. Previously only the HTTP path had correlation IDs; job logs could only be tied together by manually-passed `job_id`.
+- **Self-recovery:** a configurable per-job wall-clock budget (`job_max_runtime_sec`, default 6h, `0` disables) wraps each handler in `asyncio.wait_for`. A wedged handler (e.g. a hung steam-IPC call) is cancelled and the job marked failed with a `jobs.handler.timed_out` log — so it can no longer hold the single worker loop forever, and the system self-heals **without a process restart**. Chosen over a standalone periodic reaper because, in the single-worker topology, timing out the handler also frees the worker (a reaper can't). A false timeout on a genuinely-long prefill is non-catastrophic: the partial cache persists and a retry resumes from it.
+- **Tests:** `test_job_logs_share_a_correlation_id`, `test_hung_handler_times_out_and_marks_failed`. Full suite **1165 pass**; mypy(strict)/ruff/semgrep clean.
+
 ### Fixed — full-codebase audit remediation — 2026-06-09
 
 Remediation of the confirmed (2-skeptic verified) findings from the multi-agent full-codebase audit. The `db/pool.py` concurrency findings shipped separately; the rest are collected here, each fixed test-first.

--- a/src/orchestrator/api/main.py
+++ b/src/orchestrator/api/main.py
@@ -159,6 +159,7 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
             jobs_deps,
             shutdown=jobs_shutdown,
             poll_interval_sec=settings.jobs_worker_poll_interval_sec,
+            job_max_runtime_sec=settings.job_max_runtime_sec,
         ),
         name="jobs_worker",
     )

--- a/src/orchestrator/core/settings.py
+++ b/src/orchestrator/core/settings.py
@@ -201,6 +201,12 @@ class Settings(BaseSettings):
     steam_worker_max_restart_attempts: int = Field(default=3, ge=0, le=10)
     steam_session_dir: Path = Path("/var/lib/orchestrator/steam_session")
     jobs_worker_poll_interval_sec: float = Field(default=1.0, gt=0.0, le=60.0)
+    # Per-job wall-clock budget. A handler that wedges past this is cancelled and
+    # the job marked failed, so it can't hold the single worker loop forever
+    # (self-heals without a process restart). Generous by default — a prefill of
+    # a large game through lancache is long but resumes from cache on retry, so a
+    # rare false timeout is not catastrophic. `0` disables the budget.
+    job_max_runtime_sec: float = Field(default=21600.0, ge=0.0)
 
     @field_validator("cors_origins")
     @classmethod

--- a/src/orchestrator/jobs/worker.py
+++ b/src/orchestrator/jobs/worker.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 
 import structlog
 
+from orchestrator.core.logging import new_correlation_id
 from orchestrator.db.pool import PoolError
 from orchestrator.jobs.handlers import HANDLERS
 
@@ -102,12 +103,25 @@ async def mark_failed(pool: Pool, job_id: int, error: str) -> None:
     )
 
 
-async def worker_loop(deps: Deps, *, shutdown: asyncio.Event, poll_interval_sec: float) -> None:
+async def worker_loop(
+    deps: Deps,
+    *,
+    shutdown: asyncio.Event,
+    poll_interval_sec: float,
+    job_max_runtime_sec: float = 0.0,
+) -> None:
     """Single-loop dispatcher. Runs until `shutdown` is set.
 
     - Unknown `kind` → job marked failed; loop continues.
     - Handler exception → job marked failed; loop continues.
     - `claim_next_job` failure (DB outage) → log + back off + retry.
+    - `job_max_runtime_sec > 0` → each handler is bounded by `asyncio.wait_for`;
+      a wedged handler is cancelled and the job marked failed, so it can't hold
+      the single worker loop forever (self-heals without a process restart).
+
+    Each job runs inside its own `correlation_id` (+ `job_id`/`job_kind`) bound
+    into contextvars, so every log line it emits — worker, handler, validator,
+    pool — is greppable by one ID.
     """
     _log.info("jobs.worker.started", poll_interval=poll_interval_sec)
     while not shutdown.is_set():
@@ -126,52 +140,71 @@ async def worker_loop(deps: Deps, *, shutdown: asyncio.Event, poll_interval_sec:
 
         job_id = int(row["id"])
         kind = str(row["kind"])
-        _log.info("jobs.worker.claimed_job", job_id=job_id, kind=kind)
+        # Bind a correlation_id (+ job_id/kind) for the whole job, so every log
+        # line it emits is greppable by one ID — the job-side analogue of the
+        # HTTP request_context(). bound_contextvars resets all of them on exit,
+        # including on `continue`.
+        with structlog.contextvars.bound_contextvars(
+            correlation_id=new_correlation_id(), job_id=job_id, job_kind=kind
+        ):
+            _log.info("jobs.worker.claimed_job", job_id=job_id, kind=kind)
 
-        handler = HANDLERS.get(kind)
-        if handler is None:
-            await mark_failed(deps.pool, job_id, f"no handler for kind {kind!r}")
-            _log.warning("jobs.handler.no_handler", kind=kind, job_id=job_id)
-            continue
+            handler = HANDLERS.get(kind)
+            if handler is None:
+                await mark_failed(deps.pool, job_id, f"no handler for kind {kind!r}")
+                _log.warning("jobs.handler.no_handler", kind=kind, job_id=job_id)
+                continue
 
-        t0 = time.monotonic()
-        _log.info("jobs.handler.started", kind=kind, job_id=job_id)
-        try:
-            await handler(row, deps)
-        except Exception as e:
-            err = f"{type(e).__name__}: {str(e)[: JOB_ERROR_TRUNCATE - 50]}"
+            t0 = time.monotonic()
+            _log.info("jobs.handler.started", kind=kind, job_id=job_id)
             try:
-                await mark_failed(deps.pool, job_id, err)
-            except Exception as mark_e:
-                _log.error(
-                    "jobs.handler.mark_failed_failed",
+                if job_max_runtime_sec > 0:
+                    await asyncio.wait_for(handler(row, deps), timeout=job_max_runtime_sec)
+                else:
+                    await handler(row, deps)
+            except Exception as e:
+                # A TimeoutError under an active budget means wait_for cancelled a
+                # wedged handler — label it distinctly. (TimeoutError is an
+                # Exception, so it lands here.)
+                timed_out = isinstance(e, TimeoutError) and job_max_runtime_sec > 0
+                if timed_out:
+                    err = f"job exceeded max runtime of {job_max_runtime_sec}s (cancelled)"
+                    event = "jobs.handler.timed_out"
+                else:
+                    err = f"{type(e).__name__}: {str(e)[: JOB_ERROR_TRUNCATE - 50]}"
+                    event = "jobs.handler.failed"
+                try:
+                    await mark_failed(deps.pool, job_id, err)
+                except Exception as mark_e:
+                    _log.error(
+                        "jobs.handler.mark_failed_failed",
+                        job_id=job_id,
+                        original_error=err,
+                        reason=str(mark_e)[:JOB_ERROR_TRUNCATE],
+                    )
+                _log.warning(
+                    event,
+                    kind=kind,
                     job_id=job_id,
-                    original_error=err,
-                    reason=str(mark_e)[:JOB_ERROR_TRUNCATE],
+                    kind_error=type(e).__name__,
+                    elapsed_ms=int((time.monotonic() - t0) * 1000),
                 )
-            _log.warning(
-                "jobs.handler.failed",
+                continue
+
+            try:
+                await mark_succeeded(deps.pool, job_id)
+            except Exception as e:
+                _log.error(
+                    "jobs.handler.mark_succeeded_failed",
+                    job_id=job_id,
+                    reason=str(e)[:JOB_ERROR_TRUNCATE],
+                )
+                continue
+            _log.info(
+                "jobs.handler.completed",
                 kind=kind,
                 job_id=job_id,
-                kind_error=type(e).__name__,
                 elapsed_ms=int((time.monotonic() - t0) * 1000),
             )
-            continue
-
-        try:
-            await mark_succeeded(deps.pool, job_id)
-        except Exception as e:
-            _log.error(
-                "jobs.handler.mark_succeeded_failed",
-                job_id=job_id,
-                reason=str(e)[:JOB_ERROR_TRUNCATE],
-            )
-            continue
-        _log.info(
-            "jobs.handler.completed",
-            kind=kind,
-            job_id=job_id,
-            elapsed_ms=int((time.monotonic() - t0) * 1000),
-        )
 
     _log.info("jobs.worker.stopped")

--- a/tests/jobs/test_worker.py
+++ b/tests/jobs/test_worker.py
@@ -227,6 +227,78 @@ class TestWorkerLoopDispatch:
         assert "RuntimeError" in row1["error"]
         assert row2["state"] == "succeeded"
 
+    async def test_job_logs_share_a_correlation_id(self, pool, capsys):
+        """Every log line emitted during a job (worker + handler) must carry the
+        same correlation_id, so a job's full lifecycle is greppable by one ID."""
+        import json
+
+        import structlog
+
+        from orchestrator.core.logging import configure_logging
+
+        configure_logging()
+        handler_log = structlog.get_logger("test.handler")
+
+        async def my_handler(row, deps):
+            handler_log.info("test.handler.did_work")
+
+        clear()
+        register("library_sync", my_handler)
+        await _queue_job(pool)
+
+        shutdown = asyncio.Event()
+        deps = Deps(pool=pool, steam_client=None)
+
+        async def stopper():
+            for _ in range(300):
+                r = await pool.read_one("SELECT state FROM jobs WHERE id=1")
+                if r and r["state"] == "succeeded":
+                    break
+                await asyncio.sleep(0.01)
+            shutdown.set()
+
+        await asyncio.gather(
+            worker_loop(deps, shutdown=shutdown, poll_interval_sec=0.02),
+            stopper(),
+        )
+
+        lines = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+        claimed = next(line for line in lines if line.get("event") == "jobs.worker.claimed_job")
+        did_work = next(line for line in lines if line.get("event") == "test.handler.did_work")
+        assert "correlation_id" in claimed
+        assert claimed["correlation_id"] == did_work["correlation_id"]
+        assert claimed.get("job_id") == 1
+
+    async def test_hung_handler_times_out_and_marks_failed(self, pool):
+        """A wedged handler must be cancelled at the per-job runtime budget and the
+        job marked failed — self-heals a stuck job without a process restart."""
+
+        async def hung(row, deps):
+            await asyncio.Event().wait()  # never returns
+
+        clear()
+        register("library_sync", hung)
+        await _queue_job(pool)
+
+        shutdown = asyncio.Event()
+        deps = Deps(pool=pool, steam_client=None)
+
+        async def stopper():
+            for _ in range(300):
+                r = await pool.read_one("SELECT state FROM jobs WHERE id=1")
+                if r and r["state"] == "failed":
+                    break
+                await asyncio.sleep(0.01)
+            shutdown.set()
+
+        await asyncio.gather(
+            worker_loop(deps, shutdown=shutdown, poll_interval_sec=0.02, job_max_runtime_sec=0.1),
+            stopper(),
+        )
+        row = await pool.read_one("SELECT state, error FROM jobs WHERE id=1")
+        assert row["state"] == "failed"
+        assert "max runtime" in (row["error"] or "").lower()
+
     async def test_loop_exits_promptly_on_shutdown(self, pool):
         """Empty queue + shutdown.set() should exit within one poll interval."""
         clear()


### PR DESCRIPTION
## Summary

Two jobs-worker operability improvements from the post-audit codebase eval. Both are small, test-first changes to `worker_loop`.

## 1. Per-job correlation context (logging)

Each job now runs inside its own `correlation_id` (+ `job_id`/`job_kind`) bound into contextvars — the job-side analogue of the HTTP `request_context()`. Every log line a job emits across **worker → handler → validator → pool** now carries the same `correlation_id`, so a job's full lifecycle is greppable by one ID. Previously only the HTTP path had correlation IDs; job logs could only be tied together by a manually-passed `job_id`.

## 2. Per-job max-runtime self-heal (self-recovery)

A configurable per-job wall-clock budget (`job_max_runtime_sec`, **default 6h**, `0` disables) wraps each handler in `asyncio.wait_for`. A wedged handler (e.g. a hung steam-IPC call) is cancelled and the job marked failed with a `jobs.handler.timed_out` log — so it can no longer hold the single worker loop forever. The system **self-heals without a process restart**.

**Design note:** chosen over a standalone *periodic reaper* because, in the single-worker topology, timing out the handler also **frees the worker loop** — a reaper would reconcile the DB row but leave the worker still blocked on the wedged handler. Same risk profile, strictly more recovery. A false timeout on a genuinely-long prefill is non-catastrophic: the partial cache persists and a retry resumes from it (hence the generous default).

## Tests

- `test_job_logs_share_a_correlation_id` — the `claimed_job` and handler log lines share one `correlation_id`.
- `test_hung_handler_times_out_and_marks_failed` — a handler that never returns is cancelled at the budget and the job marked failed.

Both verified RED before the change. Full suite **1165 pass**; mypy(strict) / ruff / gitleaks / semgrep clean. New deps: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)