### PR TITLE
fix(docker): repair console-script shebangs + python -m uvicorn entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — Docker image entrypoint + console-script shebangs — 2026-06-13
+
+Caught during the UAT-11 live deploy: the runtime container failed to start (`sh: exec: uvicorn: not found`).
+
+- The venv is built at `/build/.venv` and `COPY`'d to `/app/.venv`, so every pip console script hardcodes a `#!/build/.venv/bin/python` shebang that doesn't exist in the runtime image — breaking both the `uvicorn` entrypoint and the **bundled `orchestrator-cli` console script** (it would `ENOENT` inside the container). The Dockerfile now rewrites those shebangs to `/app/.venv/bin/python` after the copy.
+- The entrypoint now runs `python -m uvicorn` (shebang-independent) rather than the `uvicorn` console script, while keeping the `ORCH_API_HOST` loopback default from F-INT-3.
+
 ### Fixed — UAT-11 remediation — 2026-06-13
 
 Remediation of the UAT-11 findings (automated PASS; exploratory + integration legs). All fixed test-first.

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,13 @@ RUN groupadd -r -g 1000 orchestrator \
     && chown orchestrator:orchestrator /var/lib/orchestrator
 
 COPY --from=builder /build/.venv /app/.venv
+# pip console scripts hardcode the build-stage shebang
+# (#!/build/.venv/bin/python), which doesn't exist in the runtime image — so
+# uvicorn AND the bundled `orchestrator-cli` console script fail with ENOENT.
+# Rewrite the shebang of every text script to the final venv path. (Restricting
+# to grep-matched files avoids touching the `python` symlinks / binaries.)
+RUN grep -rlI '^#!/build/\.venv/bin/python' /app/.venv/bin/ \
+    | xargs -r sed -i '1s|/build/\.venv/bin/python|/app/.venv/bin/python|'
 COPY --from=builder /build/src /app/src
 # Steam worker venv at the path Settings.steam_worker_python_path expects.
 COPY --from=builder /build/.venv-steam-worker /opt/orchestrator/venv-steam-worker
@@ -67,4 +74,7 @@ EXPOSE 8765
 # trigger endpoints are NOT exposed to the LAN by default and the non-loopback
 # boot warning only fires when an operator deliberately opts in (UAT-11 F-INT-3).
 # For LAN access, run with host networking or set ORCH_API_HOST=0.0.0.0.
-ENTRYPOINT ["sh", "-c", "exec uvicorn orchestrator.api.main:app --host \"${ORCH_API_HOST:-127.0.0.1}\" --port \"${ORCH_API_PORT:-8765}\""]
+# `python -m uvicorn` (not the `uvicorn` console script) so the entrypoint is
+# independent of the console-script shebang; binds ORCH_API_HOST, default
+# loopback (UAT-11 F-INT-3).
+ENTRYPOINT ["sh", "-c", "exec python -m uvicorn orchestrator.api.main:app --host \"${ORCH_API_HOST:-127.0.0.1}\" --port \"${ORCH_API_PORT:-8765}\""]

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -70,3 +70,23 @@ def test_entrypoint_defaults_to_loopback_not_hardcoded_0_0_0_0():
     assert '"--host", "0.0.0.0"' not in entry
     assert "ORCH_API_HOST" in entry
     assert "127.0.0.1" in entry  # the secure default
+
+
+def test_entrypoint_uses_python_m_uvicorn_not_console_script():
+    """The venv is copied build->runtime, so the `uvicorn` console-script shebang
+    is broken; the entrypoint must invoke `python -m uvicorn` (shebang-independent)
+    so the container actually starts (caught live, UAT-11)."""
+    text = _dockerfile_text()
+    entry = next(line for line in text.splitlines() if "uvicorn" in line and "ENTRYPOINT" in line)
+    assert "python -m uvicorn" in entry
+
+
+def test_venv_console_script_shebangs_rewritten_to_runtime_path():
+    """The copied venv's console scripts (incl. the bundled `orchestrator-cli`)
+    hardcode the build-stage `#!/build/.venv/bin/python` shebang, which doesn't
+    exist in the runtime image. The Dockerfile must rewrite them to /app/.venv so
+    `orchestrator-cli` works inside the container (caught live, UAT-11)."""
+    text = _dockerfile_text()
+    assert "/build/.venv/bin/python" in text  # the broken shebang it rewrites
+    # rewritten to the runtime path via sed over the matching scripts
+    assert "sed" in text and "/app/.venv/bin/python" in text


### PR DESCRIPTION
## Summary

**Caught during the UAT-11 live deploy** — the runtime container failed to start: `sh: exec: uvicorn: not found`.

**Root cause:** the venv is built at `/build/.venv` and `COPY`'d to `/app/.venv`, so every pip console script hardcodes a `#!/build/.venv/bin/python` shebang that doesn't exist in the runtime image. This breaks the `uvicorn` entrypoint **and the bundled `orchestrator-cli` console script** (it `ENOENT`s inside the container — the F11 CLI deliverable would not run in the deployed image). The F-INT-3 `sh -c "exec uvicorn"` form surfaced what the original exec-form happened to mask.

## Fix

- Rewrite the build-path shebangs to `/app/.venv/bin/python` after the `COPY` (so `orchestrator-cli` works in the container too).
- Entrypoint runs `python -m uvicorn` (shebang-independent), keeping the `ORCH_API_HOST` loopback default from F-INT-3.

## Verification

`tests/test_dockerfile.py` — asserts the entrypoint uses `python -m uvicorn` and the shebang rewrite is present. **Rebuilt + ran live on the lancache host** as part of finishing the UAT-11 live leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)