### PR TITLE
fix(steam): survive slow-CDN gevent.Timeout + drain worker stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — Steam worker stderr is now drained + captured — 2026-06-14
+
+Caught during the UAT-11 live leg: the Steam worker subprocess crashed ~25s into an `app_id=211` manifest fetch with `steam_worker.died reason=stdout_closed` and **zero diagnostics** — the worker's `stderr` was a `PIPE` that nothing ever consumed, so its traceback (the only window into the opaque gevent/steam-next subprocess) was discarded.
+
+- The orchestrator now runs a dedicated task that drains the worker's `stderr` line-by-line for the worker's lifetime, logging each as `steam_worker.stderr` and retaining the last 50 lines in a ring buffer. The `steam_worker.died` (and restart-storm-guard) breadcrumb now carries the last 10 stderr lines, so a crash is self-explaining (Python traceback, or a native `Segmentation fault` line).
+- Also closes a latent stall: an undrained `stderr` PIPE fills its ~64 KiB OS buffer under a chatty worker and blocks the next write — freezing the whole gevent hub mid-fetch. Draining removes that failure mode.
+- **Tests:** `TestWorkerStderrDrain` (ring capture, death-log breadcrumb, drain task wired in `start()`). Full suite **1188 pass**; mypy(strict)/ruff/semgrep clean.
+
 ### Fixed — Docker image entrypoint + console-script shebangs — 2026-06-13
 
 Caught during the UAT-11 live deploy: the runtime container failed to start (`sh: exec: uvicorn: not found`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — Steam worker crash on slow-CDN `gevent.Timeout` — 2026-06-14
+
+Root-caused via the new stderr drain (below) during the UAT-11 live leg: a manifest fetch for a Steam app with a slow CDN depot crashed the worker process (`steam_worker.died reason=stdout_closed`), failing that job **and every subsequent job until restart**. The captured stderr showed `gevent.timeout.Timeout: 15 seconds`.
+
+- **Root cause:** `gevent.Timeout` subclasses `BaseException` (by gevent's design, so a stack-unwinding timeout can't be swallowed by a bare `except Exception`). steam-next's CDN/CM calls raise it when a depot is slow, so it escaped every `except Exception` in the worker handlers **and** the dispatch loop, terminating the process. This is intermittent and CDN-timing-dependent — which is why the same app (211) succeeded in 4s on one attempt and a different app (340) crashed at 15s on another, and why it was never the `#15` manifest-cleanup change (a `BaseException` bypasses try/except regardless of wrapping).
+- **Fix (defense in depth):** `worker.py` now imports `gevent.Timeout` and (1) the `manifest.fetch` handler catches it → clean **retryable** `SteamCDNTimeout` error (it fails the job rather than recording a partial manifest set as success — the `#109` false-empty lesson — and cleans its temp BLOBs), and (2) the worker's `main()` dispatch loop wraps every handler so **no** op's `gevent.Timeout` (or any unexpected exception) can take the worker down.
+- **Tests:** `test_manifest_fetch_gevent_timeout_does_not_crash_worker`, `test_dispatch_loop_survives_handler_gevent_timeout` (the `gevent` stub's `Timeout` subclasses `BaseException` to faithfully reproduce the escape). Full suite **1190 pass**; mypy(strict)/ruff/semgrep clean.
+
 ### Fixed — Steam worker stderr is now drained + captured — 2026-06-14
 
 Caught during the UAT-11 live leg: the Steam worker subprocess crashed ~25s into an `app_id=211` manifest fetch with `steam_worker.died reason=stdout_closed` and **zero diagnostics** — the worker's `stderr` was a `PIPE` that nothing ever consumed, so its traceback (the only window into the opaque gevent/steam-next subprocess) was discarded.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,10 @@ warn_unused_configs = true
 plugins = ["pydantic.mypy"]
 
 [[tool.mypy.overrides]]
-module = ["apscheduler.*", "aiosqlite.*"]
+# gevent: installed in the worker venv (stub-less) but not in CI's mypy env, so
+# the missing-import error code differs by environment (import-untyped vs
+# import-not-found). ignore_missing_imports covers both deterministically.
+module = ["apscheduler.*", "aiosqlite.*", "gevent.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/src/orchestrator/platform/steam/client.py
+++ b/src/orchestrator/platform/steam/client.py
@@ -12,6 +12,7 @@ orchestrator's asyncio process.
 from __future__ import annotations
 
 import asyncio
+import collections
 import contextlib
 import os
 import tempfile
@@ -35,6 +36,13 @@ from orchestrator.platform.steam.protocol import (
 # 10 MiB protocol-level cap (protocol.py) is what enforces, not asyncio's
 # arbitrary internal default. F-UAT6-1.
 _STDOUT_READ_LIMIT = MAX_IPC_LINE_BYTES + 1024
+
+# How many of the worker's most-recent stderr lines to retain for the
+# steam_worker.died breadcrumb. The worker subprocess is opaque (separate
+# gevent venv); its stderr — Python tracebacks, native "Segmentation fault"
+# messages — is the only diagnostic when it dies. Bounded so a chatty worker
+# can't grow this without limit.
+_STDERR_RING_SIZE = 50
 
 _log = structlog.get_logger(__name__)
 
@@ -103,6 +111,10 @@ class SteamWorkerClient:
 
         self._process: asyncio.subprocess.Process | None = None
         self._reader_task: asyncio.Task[None] | None = None
+        self._stderr_task: asyncio.Task[None] | None = None
+        # Ring of the worker's most-recent stderr lines, so a crash (stdout EOF)
+        # carries the traceback/native-fault message that caused it.
+        self._recent_stderr: collections.deque[str] = collections.deque(maxlen=_STDERR_RING_SIZE)
         self._writer: asyncio.StreamWriter | None = None
         self._pending: dict[str, asyncio.Future[dict[str, Any]]] = {}
         # The worker handles IPC strictly serially. Single-flight manifest_expand
@@ -152,6 +164,10 @@ class SteamWorkerClient:
         self._writer = self._process.stdin
         # asyncio.subprocess returns Process whose stdin is StreamWriter
         self._reader_task = asyncio.create_task(self._read_loop())
+        # Continuously drain stderr: (1) so the OS pipe buffer (~64 KiB) never
+        # fills and blocks the worker mid-fetch, and (2) so worker tracebacks and
+        # native crash messages are logged and retained for the death breadcrumb.
+        self._stderr_task = asyncio.create_task(self._drain_stderr())
         _log.info("steam_worker.spawned", pid=self._process.pid)
 
     async def stop(self) -> None:
@@ -178,6 +194,8 @@ class SteamWorkerClient:
                 await self._process.wait()
         if self._reader_task is not None:
             self._reader_task.cancel()
+        if self._stderr_task is not None:
+            self._stderr_task.cancel()
 
     async def auth_begin(self, username: str, password: str) -> dict[str, Any]:
         return await self._send_and_await(
@@ -262,6 +280,37 @@ class SteamWorkerClient:
         timeout = self._op_timeout_overrides.get(op)
         return await self._await_response(msg_id, timeout=timeout)
 
+    async def _drain_stderr(self) -> None:
+        """Read the worker's stderr line-by-line until EOF.
+
+        Without this the stderr PIPE is never consumed: a chatty worker would
+        fill the ~64 KiB OS buffer and block on its next write (stalling the
+        whole gevent hub), and — worse — when the worker dies we'd have no record
+        of the traceback or native fault that killed it. Each line is logged and
+        kept in `_recent_stderr` so `_on_worker_died` can attach the tail.
+        """
+        if self._process is None or self._process.stderr is None:
+            return
+        stderr = self._process.stderr
+        try:
+            while True:
+                try:
+                    raw = await stderr.readline()
+                except (ValueError, asyncio.LimitOverrunError):
+                    # An over-long stderr line (no newline within the buffer
+                    # limit). Drop it rather than letting the drain task die,
+                    # which would re-expose the pipe-fill stall.
+                    continue
+                if not raw:
+                    return
+                line = raw.decode("utf-8", errors="replace").rstrip("\n")
+                if not line:
+                    continue
+                self._recent_stderr.append(line)
+                _log.warning("steam_worker.stderr", line=line[:500])
+        except asyncio.CancelledError:
+            return
+
     async def _read_loop(self) -> None:
         if self._process is None:
             raise WorkerDiedError("_read_loop called with no process")
@@ -329,9 +378,15 @@ class SteamWorkerClient:
                 "steam_worker.restart_storm_guard_fired",
                 attempts=self._restart_attempts,
                 max=self._max_restart_attempts,
+                recent_stderr=list(self._recent_stderr)[-10:],
             )
         else:
-            _log.warning("steam_worker.died", reason=reason, attempts=self._restart_attempts)
+            _log.warning(
+                "steam_worker.died",
+                reason=reason,
+                attempts=self._restart_attempts,
+                recent_stderr=list(self._recent_stderr)[-10:],
+            )
         # Fail all pending futures so awaiters don't hang.
         for fut in self._pending.values():
             if not fut.done():

--- a/src/orchestrator/platform/steam/worker.py
+++ b/src/orchestrator/platform/steam/worker.py
@@ -33,6 +33,12 @@ from typing import Any, TypedDict  # noqa: E402
 _DEFAULT_SESSION_DIR = "/var/lib/orchestrator/steam_session"
 
 # Steam-next imports (post-monkey-patch).
+# gevent.Timeout subclasses BaseException (by design, so a stack-unwinding
+# timeout can't be swallowed by a bare `except Exception`). steam-next's CDN/CM
+# calls raise it when a depot is slow; left uncaught it escapes every handler and
+# kills the worker process (UAT-11: a 15s CDN timeout → steam_worker.died
+# reason=stdout_closed). We catch it explicitly. Available post-monkey-patch.
+from gevent import Timeout as GeventTimeout  # noqa: E402
 from steam.client import SteamClient  # type: ignore[import-not-found]  # noqa: E402
 from steam.enums import EResult  # type: ignore[import-not-found]  # noqa: E402
 
@@ -349,15 +355,22 @@ def _handle_manifest_fetch(msg_id: str, params: dict[str, str]) -> None:
                         "raw_path": str(blob_path),
                     }
                 )
-        except Exception:
-            # Failure mid-fetch: the orchestrator gets _err (no manifests list),
-            # so it can never clean these up. Delete them here before re-raising.
+        except (Exception, GeventTimeout):
+            # Failure mid-fetch (including a gevent.Timeout from a slow CDN
+            # depot): the orchestrator gets _err (no manifests list), so it can
+            # never clean these up. Delete them here before re-raising.
             for bp in written_blobs:
                 with contextlib.suppress(OSError):
                     bp.unlink()
             raise
 
         _ok(msg_id, {"manifests": payload, "skipped": skipped})
+    except GeventTimeout as e:
+        # A CDN/CM operation exceeded steam-next's internal timeout. Report a
+        # retryable error rather than silently recording a partial manifest set
+        # as success (the false-empty-library lesson, #109) — and crucially,
+        # never let the BaseException escape and crash the worker.
+        _err(msg_id, "SteamCDNTimeout", f"manifest fetch timed out (app {app_id}): {e}"[:200])
     except Exception as e:
         _err(msg_id, "SteamAPIError", str(e)[:200])
 
@@ -437,7 +450,17 @@ def main() -> int:
         if handler is None:
             _err(msg_id, "UnknownOp", op)
             continue
-        handler(msg_id, req.get("params") or {})
+        try:
+            handler(msg_id, req.get("params") or {})
+        except GeventTimeout as e:
+            # Defense in depth: a gevent.Timeout (BaseException) from any handler
+            # would otherwise unwind past this loop and kill the worker — failing
+            # every subsequent job until a restart. Convert to a retryable error
+            # and keep serving (UAT-11: a 15s CDN timeout crashed the worker).
+            _err(msg_id, "SteamCDNTimeout", f"steam operation timed out: {e}"[:200])
+        except Exception as e:
+            # Last-resort guard: no handler bug may take the worker down.
+            _err(msg_id, "SteamAPIError", f"{type(e).__name__}: {e}"[:200])
     return 0
 
 

--- a/tests/platform/steam/test_client_unit.py
+++ b/tests/platform/steam/test_client_unit.py
@@ -236,6 +236,7 @@ class TestReadLoopLargeResponse:
         client._max_restart_attempts = 3
         client._disabled = False
         client._reader_task = None
+        client._recent_stderr = __import__("collections").deque(maxlen=50)
 
         # Simulate a process whose stdout is a real StreamReader with tiny
         # limit; feed it a line that overflows.
@@ -460,6 +461,115 @@ class TestPerOpTimeoutOverride:
         assert "0.05" in str(exc.value)
 
 
+class TestWorkerStderrDrain:
+    """The worker subprocess is opaque: its stderr (gevent/steam-next tracebacks,
+    native crash messages like 'Segmentation fault') is the ONLY diagnostic when
+    it dies. It must be drained continuously — both so the pipe never fills and
+    stalls the worker (64 KiB OS buffer), and so a crash leaves a breadcrumb.
+    The last lines must surface in the steam_worker.died log (UAT-11: a worker
+    crashed mid manifest.fetch with reason=stdout_closed and zero diagnostics)."""
+
+    async def test_drain_stderr_captures_worker_lines_into_ring(self):
+        import asyncio
+        import collections
+
+        from orchestrator.platform.steam.client import SteamWorkerClient
+
+        client = SteamWorkerClient.__new__(SteamWorkerClient)
+        client._recent_stderr = collections.deque(maxlen=50)
+
+        loop = asyncio.get_event_loop()
+        stderr = asyncio.StreamReader(loop=loop)
+        stderr.feed_data(b"Traceback (most recent call last):\n")
+        stderr.feed_data(b"RuntimeError: greenlet boom\n")
+        stderr.feed_eof()
+
+        class _FakeProcess:
+            returncode = None
+
+        proc = _FakeProcess()
+        proc.stderr = stderr
+        client._process = proc
+
+        await client._drain_stderr()
+
+        captured = list(client._recent_stderr)
+        assert "RuntimeError: greenlet boom" in captured
+        assert "Traceback (most recent call last):" in captured
+
+    async def test_worker_death_log_includes_recent_stderr(self):
+        import collections
+        from unittest.mock import MagicMock, patch
+
+        from orchestrator.platform.steam.client import SteamWorkerClient
+
+        client = SteamWorkerClient.__new__(SteamWorkerClient)
+        client._max_restart_attempts = 3
+        client._restart_attempts = 0
+        client._disabled = False
+        client._writer = None
+        client._reader_task = None
+        client._pending = {}
+        client._recent_stderr = collections.deque(["Segmentation fault (core dumped)"], maxlen=50)
+
+        # Patch the module logger directly: structlog.capture_logs is defeated by
+        # the project's cache_logger_on_first_use config once the logger is cached
+        # earlier in the suite, so assert on the call kwargs instead.
+        fake_log = MagicMock()
+        with patch("orchestrator.platform.steam.client._log", fake_log):
+            client._on_worker_died(reason="stdout_closed")
+
+        fake_log.warning.assert_called_once()
+        _, kwargs = fake_log.warning.call_args
+        # The crash breadcrumb must travel with the death event.
+        assert "Segmentation fault (core dumped)" in str(kwargs.get("recent_stderr"))
+
+    async def test_start_creates_stderr_drain_task(self, monkeypatch):
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from orchestrator.core.settings import get_settings
+        from orchestrator.platform.steam.client import SteamWorkerClient
+
+        monkeypatch.setenv("ORCH_TOKEN", "a" * 32)
+        get_settings.cache_clear()
+
+        client = SteamWorkerClient()
+
+        eof_stderr = asyncio.StreamReader()
+        eof_stderr.feed_eof()
+        eof_stdout = asyncio.StreamReader()
+        eof_stdout.feed_eof()
+
+        class _FakeProcess:
+            pid = 4321
+            returncode = None
+            stdin = None
+
+        async def _fake_create(*_args, **_kwargs):
+            proc = _FakeProcess()
+            proc.stdout = eof_stdout
+            proc.stderr = eof_stderr
+            return proc
+
+        with patch(
+            "orchestrator.platform.steam.client.asyncio.create_subprocess_exec",
+            new=AsyncMock(side_effect=_fake_create),
+        ):
+            await client.start()
+
+        try:
+            assert isinstance(client._stderr_task, asyncio.Task), (
+                "start() must drain the worker's stderr so it can't fill the pipe "
+                "and so crashes leave a diagnostic breadcrumb"
+            )
+        finally:
+            if client._reader_task is not None:
+                client._reader_task.cancel()
+            if client._stderr_task is not None:
+                client._stderr_task.cancel()
+
+
 class TestRestartStormGuard:
     async def test_max_restart_attempts_exhausted_marks_disabled(self):
         from orchestrator.platform.steam.client import SteamWorkerClient
@@ -471,6 +581,7 @@ class TestRestartStormGuard:
         client._writer = None
         client._reader_task = None
         client._pending = {}
+        client._recent_stderr = __import__("collections").deque(maxlen=50)
 
         for _ in range(3):
             client._on_worker_died(reason="crash")

--- a/tests/platform/steam/test_worker_audit.py
+++ b/tests/platform/steam/test_worker_audit.py
@@ -59,12 +59,22 @@ def worker(monkeypatch):
     client_mod.SteamClient = _FakeSteamClient  # type: ignore[attr-defined]
     enums_mod = types.ModuleType("steam.enums")
     enums_mod.EResult = _EResult  # type: ignore[attr-defined]
+    # gevent stub. gevent.Timeout subclasses BaseException (NOT Exception) by
+    # design, so a bare `except Exception` can't swallow it — faithfully
+    # reproduce that so tests prove the worker catches it explicitly.
+    gevent_mod = types.ModuleType("gevent")
+
+    class _Timeout(BaseException):
+        pass
+
+    gevent_mod.Timeout = _Timeout  # type: ignore[attr-defined]
 
     for name, mod in [
         ("steam", steam),
         ("steam.monkey", monkey),
         ("steam.client", client_mod),
         ("steam.enums", enums_mod),
+        ("gevent", gevent_mod),
     ]:
         monkeypatch.setitem(sys.modules, name, mod)
 
@@ -194,3 +204,67 @@ def test_manifest_fetch_cleans_temp_blobs_on_failure(worker, monkeypatch, tmp_pa
     assert resp["ok"] is False  # the run failed
     leaked = list(tmp_path.glob("blob-*.zst"))
     assert leaked == [], f"leaked temp BLOB files on failure: {leaked}"
+
+
+def test_manifest_fetch_gevent_timeout_does_not_crash_worker(
+    worker, monkeypatch, tmp_path: Path
+) -> None:
+    """UAT-11 live: a slow CDN depot raised gevent.Timeout (a BaseException), which
+    escaped the handler's `except Exception` and KILLED the worker process
+    (steam_worker.died reason=stdout_closed). The handler must catch it and report
+    a clean, retryable SteamCDNTimeout — never let it propagate."""
+    zstd_mod = types.ModuleType("zstandard")
+    zstd_mod.ZstdCompressor = lambda level=3: None  # type: ignore[attr-defined]
+    cdn_mod = types.ModuleType("steam.client.cdn")
+    cdn_mod.CDNClient = lambda client: None  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "zstandard", zstd_mod)
+    monkeypatch.setitem(sys.modules, "steam.client.cdn", cdn_mod)
+
+    worker._client = _FakeSteamClient()
+
+    class _TimingOutCdn:
+        def get_app_depot_info(self, app_id):
+            return {}
+
+        def get_manifest_request_code(self, app_id, depot_id, gid):
+            # steam-next's internal AsyncResult.get() 15s budget elapsing.
+            raise worker.GeventTimeout(15)
+
+        def get_manifest(self, *a, **k):  # pragma: no cover - never reached
+            raise AssertionError("should not be called")
+
+    worker._cdn_client = _TimingOutCdn()
+    monkeypatch.setattr(
+        worker.enumerate_module, "manifest_gids_for_app", lambda depots, branch: [(1, 11)]
+    )
+    monkeypatch.setattr(worker, "_blob_temp_path", lambda prefix: tmp_path / f"blob-{prefix}.zst")
+
+    # Must NOT raise — that is the crash this test pins.
+    worker._handle_manifest_fetch("m4", {"app_id": "340"})
+
+    resp = worker._sent[-1]
+    assert resp["ok"] is False
+    assert resp["error"]["kind"] == "SteamCDNTimeout", resp
+
+
+def test_dispatch_loop_survives_handler_gevent_timeout(worker, monkeypatch) -> None:
+    """Defense in depth: even if some handler lets a gevent.Timeout escape, the
+    worker's main() dispatch loop must convert it to an IPC error and keep
+    serving — a single slow op must never take down the worker for every
+    subsequent job until a restart."""
+    import io
+    import json
+
+    def _boom(msg_id, _params):
+        raise worker.GeventTimeout(15)
+
+    monkeypatch.setitem(worker._HANDLERS, "boom.timeout", _boom)
+    line = json.dumps({"msg_id": "m5", "op": "boom.timeout", "params": {}}) + "\n"
+    monkeypatch.setattr(worker.sys, "stdin", io.StringIO(line))
+
+    rc = worker.main()  # must return cleanly, not propagate the BaseException
+
+    assert rc == 0
+    resp = worker._sent[-1]
+    assert resp["ok"] is False
+    assert resp["error"]["kind"] == "SteamCDNTimeout", resp


### PR DESCRIPTION
Two commits, found and fixed during the **UAT-11 live leg**. The first is instrumentation; the second is the real bug it uncovered.

## 1. Drain + capture worker stderr (`0653416`)

The Steam worker subprocess is opaque (separate gevent venv). Its `stderr` was spawned as a `PIPE` that nothing ever drained, so when it crashed the traceback was discarded — leaving `steam_worker.died reason=stdout_closed` with zero diagnostics.

- A dedicated task now drains the worker's stderr line-by-line for its lifetime, logs each as `steam_worker.stderr`, and keeps the last 50 in a ring. `steam_worker.died` / `restart_storm_guard_fired` carry the last 10 lines.
- Also closes a latent stall: an undrained `stderr` PIPE fills its ~64 KiB OS buffer under a chatty worker and blocks the next write.

## 2. Survive `gevent.Timeout` from a slow CDN depot (`b70043c`) — the actual blocker

With the drain in place, the next live fetch logged the real cause: `gevent.timeout.Timeout: 15 seconds`.

- **Root cause:** `gevent.Timeout` subclasses `BaseException` (so a stack-unwinding timeout can't be swallowed by a bare `except Exception`). steam-next's CDN/CM calls raise it on a slow depot, so it escaped **every** `except Exception` in the handlers and the dispatch loop, killing the worker → `stdout_closed`. Intermittent and CDN-timing-dependent (app 211 succeeded in 4s; app 340 crashed at 15s) — which is why it was never the `#15` cleanup change.
- **Fix (defense in depth):** the `manifest.fetch` handler catches it → retryable `SteamCDNTimeout` (fails the job rather than recording a partial manifest set as success — the `#109` lesson — and cleans temp BLOBs); and `main()`'s dispatch loop wraps every handler so no op's timeout can take the worker down.

## Live validation

Core loop already PASS live on the fixed image: manifest fetch → prefill (**ok=2430/2430**) → validate (**cached=2430, missing=0**) on Source SDK. The slow-depot crash path is being re-validated live against app 340.

## Tests

`TestWorkerStderrDrain` + `test_manifest_fetch_gevent_timeout_does_not_crash_worker` + `test_dispatch_loop_survives_handler_gevent_timeout` (the `gevent` stub's `Timeout` subclasses `BaseException` to faithfully reproduce the escape). Full suite **1190 pass**; mypy(strict)/ruff/gitleaks/semgrep clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)