### PR TITLE
fix(db): writer self-heal after replacement storm (#152, F-INT-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — DB pool writer now self-heals after a replacement storm (#152 / F-INT-2) — 2026-06-15
+
+UAT-11 integration finding. Readers already self-heal after a replacement storm (`_lost_reader_slots` + heal-on-acquire), but the writer did not: once the writer storm guard tripped (or a replacement open failed), `self._writer` was left pointing at the dead connection with `_writer_healthy=False` and `_checkout_writer` kept yielding it — **every write failed until a process restart** (health_check live-probes the writer → 503 → HEALTHCHECK container restart). SEV-3, recovery-by-restart, asymmetric with readers.
+
+- `_checkout_writer` now heals-on-checkout when the writer is known-dead: it opens a fresh writer connection (under `_writer_lock`, so it can't race a concurrent replacement swap), restores `_writer_healthy=True`, and best-effort-closes the old one — so writes recover **without a restart** once the fault clears. If the heal-open itself fails (persistent fault), it raises `PoolError` (loud → 503) rather than yielding a dead/closed connection.
+- **Tests:** `tests/db/test_pool_writer_self_heal.py` — recovery after the fault clears, and the loud-`PoolError` path when the heal-open fails. Full suite **1192 pass**; mypy(strict)/ruff/semgrep clean.
+
 ### Fixed — Steam worker crash on slow-CDN `gevent.Timeout` — 2026-06-14
 
 Root-caused via the new stderr drain (below) during the UAT-11 live leg: a manifest fetch for a Steam app with a slow CDN depot crashed the worker process (`steam_worker.died reason=stdout_closed`), failing that job **and every subsequent job until restart**. The captured stderr showed `gevent.timeout.Timeout: 15 seconds`.

--- a/src/orchestrator/db/pool.py
+++ b/src/orchestrator/db/pool.py
@@ -927,6 +927,30 @@ class Pool:
         async with self._writer_lock:
             if self._writer is None:
                 raise PoolClosedError(state="closed")
+            if not self._writer_healthy:
+                # Heal-on-checkout (#152 / F-INT-2): a replacement storm or a
+                # failed replacement open leaves `self._writer` pointing at a dead
+                # connection with `_writer_healthy=False` and nothing ever
+                # re-opens it — so every write failed until a process restart.
+                # Mirror the reader heal-on-acquire: open a fresh writer here so
+                # writes recover once the fault clears. If the open itself fails,
+                # raise PoolError (loud → 503) rather than yielding a dead
+                # connection. Safe under `_writer_lock` (held for the whole
+                # checkout, so a concurrent `_replace_connection` writer swap
+                # can't race this).
+                try:
+                    new_conn = await self._open_connection(role="writer")
+                except Exception as e:
+                    raise PoolError(
+                        "writer unavailable: replacement connection could not be "
+                        f"opened ({type(e).__name__})"
+                    ) from e
+                old = self._writer
+                self._writer = new_conn
+                self._writer_healthy = True
+                # Best-effort close of the old (possibly already-closed) writer.
+                self._spawn_bg(self._safe_close(old, role="writer"))
+                _log.warning("pool.writer_healed")
             try:
                 yield self._writer
             except (aiosqlite.OperationalError, ConnectionLostError) as e:

--- a/tests/db/test_pool_writer_self_heal.py
+++ b/tests/db/test_pool_writer_self_heal.py
@@ -1,0 +1,102 @@
+"""Regression tests for the SEV-3 writer self-heal gap (UAT-11 F-INT-2, #152).
+
+Readers recover after a replacement storm (`_lost_reader_slots` + heal-on-
+acquire), but the writer did not: when a writer replacement gives up — the
+storm guard trips, or the replacement open itself fails — `self._writer` is
+left pointing at the dead connection with `_writer_healthy=False`, and
+`_checkout_writer` kept yielding it. Every write then failed until a process
+restart (health_check live-probes the writer → 503 → HEALTHCHECK restart).
+
+These tests assert the fixed contract, mirroring the reader heal:
+  1. The writer heals on checkout once the underlying fault clears — writes
+     recover WITHOUT a restart, and the pool reports healthy again.
+  2. If the heal-open itself fails (persistent fault), a write raises
+     `PoolError` (loud → 503) rather than yielding a dead/closed connection.
+
+The outer `asyncio.wait_for(...)` is a HANG DETECTOR: a closed aiosqlite
+connection's `execute` can block on its dead worker thread, so on the buggy
+code the write would hang and `wait_for` raises `TimeoutError` instead of the
+expected result, failing the test loudly.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING
+
+import aiosqlite
+import pytest
+
+from orchestrator.db.pool import ConnectionLostError, Pool, PoolError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+import asyncio
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _kill_writer(pool: Pool, monkeypatch) -> None:
+    """Drive the writer into the dead state: a failing write triggers a
+    replacement whose open also fails, so `_safe_close` closes the old writer
+    and nothing replaces it — `self._writer` is now a CLOSED connection with
+    `_writer_healthy=False`."""
+
+    async def always_io_error(self, sql, parameters=()):
+        raise aiosqlite.OperationalError("disk I/O error")
+
+    async def fail_open(role):
+        raise aiosqlite.OperationalError("unable to open database file")
+
+    monkeypatch.setattr(aiosqlite.Connection, "execute", always_io_error)
+    monkeypatch.setattr(pool, "_open_connection", fail_open)
+
+    with contextlib.suppress(aiosqlite.OperationalError, ConnectionLostError, PoolError):
+        await pool.execute_write("CREATE TABLE IF NOT EXISTS _heal_probe (x INTEGER)")
+    # Let the fire-and-forget replacement task close the old writer + give up.
+    await asyncio.sleep(0.3)
+    assert pool._writer_healthy is False, "precondition: writer must be marked dead"
+
+
+async def test_writer_recovers_after_fault_clears(db_path: Path, monkeypatch):
+    async with Pool.create(database_path=db_path, readers_count=2) as pool:
+        await _kill_writer(pool, monkeypatch)
+
+        # Fault clears: restore real execute + open. The next write must heal a
+        # fresh writer on checkout and succeed — not yield the closed one.
+        monkeypatch.undo()
+        await asyncio.wait_for(
+            pool.execute_write("CREATE TABLE IF NOT EXISTS _heal_probe (x INTEGER)"),
+            timeout=5.0,
+        )
+
+        # The heal restored writer health (buggy code leaves it False forever,
+        # so health_check stays 503).
+        assert pool._writer_healthy is True
+
+        # And the pool keeps writing afterwards.
+        rowcount = await asyncio.wait_for(
+            pool.execute_write("INSERT INTO _heal_probe (x) VALUES (1)"), timeout=5.0
+        )
+        assert rowcount == 1
+
+
+async def test_writer_raises_poolerror_when_heal_open_fails(db_path: Path, monkeypatch):
+    async with Pool.create(database_path=db_path, readers_count=2) as pool:
+        await _kill_writer(pool, monkeypatch)
+
+        # Execute recovers but opening a replacement still fails: the writer can't
+        # be healed, so a write must surface a PoolError (loud) — never yield the
+        # dead/closed connection or hang.
+        monkeypatch.setattr(aiosqlite.Connection, "execute", aiosqlite.Connection.execute)
+
+        async def still_fail_open(role):
+            raise aiosqlite.OperationalError("unable to open database file")
+
+        monkeypatch.setattr(pool, "_open_connection", still_fail_open)
+
+        with pytest.raises(PoolError):
+            await asyncio.wait_for(
+                pool.execute_write("INSERT INTO _heal_probe (x) VALUES (1)"), timeout=5.0
+            )


### PR DESCRIPTION
Closes #152.

## Problem (UAT-11 F-INT-2, SEV-3)

Readers self-heal after a replacement storm (`_lost_reader_slots` + heal-on-acquire), but the **writer did not**. Once the writer storm guard tripped — or a replacement open failed — `self._writer` was left pointing at the dead connection with `_writer_healthy=False`, and `_checkout_writer` kept yielding it. **Every write then failed until a process restart.** `health_check` live-probes the writer so it surfaced (→ 503 → HEALTHCHECK restart), keeping it SEV-3 rather than SEV-2, but recovery was restart-only and asymmetric with the readers.

## Fix

`_checkout_writer` now **heals-on-checkout** when the writer is known-dead (mirroring `_acquire_reader`):
- Opens a fresh writer connection **under `_writer_lock`** (held for the whole checkout, so it can't race a concurrent `_replace_connection` writer swap), restores `_writer_healthy=True`, and best-effort-closes the old one.
- Writes recover **without a restart** once the fault clears.
- If the heal-open itself fails (persistent fault), it raises `PoolError` (loud → 503) rather than yielding a dead/closed connection or hanging.

## Why heal-on-checkout (not a writer deficit counter)

There's exactly one writer, so a boolean health flag suffices — a `_lost_reader_slots`-style counter would add state with no benefit. Deferring the open to actual demand (vs. re-opening eagerly inside `_replace_connection`) avoids re-introducing the hammering the storm guard exists to prevent — same philosophy as the reader heal.

## Tests

`tests/db/test_pool_writer_self_heal.py`:
- `test_writer_recovers_after_fault_clears` — drive the writer dead (failing write + failing replacement-open closes it), clear the fault, assert the next write heals + succeeds and `_writer_healthy` is restored. (RED on `main`: yields the closed connection → `ValueError: no active connection`.)
- `test_writer_raises_poolerror_when_heal_open_fails` — persistent open failure → `PoolError`, not a hang or dead-connection yield.

Full suite **1192 pass** (197 db tests + 2 new); mypy(strict)/ruff/gitleaks/semgrep clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)