### PR TITLE
fix(api): expose depot_id in /manifests (#127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — `GET /api/v1/manifests` now exposes `depot_id` (#127) — 2026-06-15
+
+UAT-9 live finding. Migration `0003` added `manifests.depot_id` (populated correctly by the BL12 manifest fetch — verified live), but the BL9 read endpoint's `SELECT` and `ManifestResponse` model predated the column, so every row came back `depot_id: null`. The DB was correct; this was purely a read-side exposure gap (F7's validator reads the DB directly, so it was unaffected).
+
+- `depot_id` is now in the manifests `SELECT`, the `ManifestResponse` model (`int | None` — nullable for rows written before the column existed), and the row mapping.
+- **Tests:** `TestManifestDepotIdExposure` (a stored `depot_id` is returned; a NULL one stays `null`); the per-manifest field-set test now includes `depot_id`. Full suite **1191 pass**; mypy(strict)/ruff/semgrep clean.
+
 ### Fixed — Steam worker crash on slow-CDN `gevent.Timeout` — 2026-06-14
 
 Root-caused via the new stderr drain (below) during the UAT-11 live leg: a manifest fetch for a Steam app with a slow CDN depot crashed the worker process (`steam_worker.died reason=stdout_closed`), failing that job **and every subsequent job until restart**. The captured stderr showed `gevent.timeout.Timeout: 15 seconds`.

--- a/src/orchestrator/api/routers/manifests.py
+++ b/src/orchestrator/api/routers/manifests.py
@@ -59,7 +59,7 @@ MANIFESTS_INCLUDE_ALLOW_LIST = IncludeAllowList(keys={"game"})
 
 # Manifests columns selected from the manifests table (excludes raw BLOB per spec D1).
 # All identifiers are SAFE — sourced from this constant, not user input.
-_MANIFEST_COLUMNS = "id, game_id, version, fetched_at, chunk_count, total_bytes"
+_MANIFEST_COLUMNS = "id, game_id, version, fetched_at, chunk_count, total_bytes, depot_id"
 
 _log = structlog.get_logger(__name__)
 
@@ -87,6 +87,9 @@ class ManifestResponse(BaseModel):
     fetched_at: str
     chunk_count: int
     total_bytes: int
+    # depot_id (#127): added in migration 0003 and populated by BL12 manifest
+    # fetch. Nullable for rows written before the column existed.
+    depot_id: int | None
     # Spec D4: always-present field; populated iff ?include=game was requested.
     game: GameSummary | None
 
@@ -215,6 +218,7 @@ async def list_manifests(
                 fetched_at=row["fetched_at"],
                 chunk_count=row["chunk_count"],
                 total_bytes=row["total_bytes"],
+                depot_id=row["depot_id"],
                 game=game,
             )
         )

--- a/tests/api/test_manifests_router.py
+++ b/tests/api/test_manifests_router.py
@@ -80,12 +80,46 @@ class TestManifestsHappyPath:
             "fetched_at",
             "chunk_count",
             "total_bytes",
+            "depot_id",
             "game",
         }
         for manifest in body["manifests"]:
             assert set(manifest.keys()) == expected_fields
             # game must be null without ?include=game
             assert manifest["game"] is None
+
+
+class TestManifestDepotIdExposure:
+    """#127: migration 0003 added manifests.depot_id (populated by BL12), but the
+    BL9 read endpoint's SELECT + response model predated the column, so every row
+    came back depot_id=null. The endpoint must expose the stored value (and stay
+    null for rows written before the column existed)."""
+
+    async def test_depot_id_exposed_when_set(self, client, populated_pool):
+        async with populated_pool.write_transaction() as tx:
+            await tx.execute("DELETE FROM manifests")
+            await tx.execute(
+                "INSERT INTO manifests "
+                "(game_id, version, fetched_at, chunk_count, total_bytes, depot_id, raw) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (1, "depot-set", "2026-06-01T00:00:00Z", 5, 100, 731, b"\x28\xb5\x2f\xfd"),
+            )
+            # A row predating the column (depot_id left NULL).
+            await tx.execute(
+                "INSERT INTO manifests "
+                "(game_id, version, fetched_at, chunk_count, total_bytes, raw) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (1, "depot-null", "2026-06-02T00:00:00Z", 5, 100, b"\x28\xb5\x2f\xfd"),
+            )
+
+        r = await client.get(
+            "/api/v1/manifests",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r.status_code == 200
+        by_version = {m["version"]: m for m in r.json()["manifests"]}
+        assert by_version["depot-set"]["depot_id"] == 731
+        assert by_version["depot-null"]["depot_id"] is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #127.

## Problem (UAT-9 live finding, SEV-3)

Migration `0003` added `manifests.depot_id` and the BL12 manifest fetch populates it correctly (verified live — all 8 Victoria 3 depots stored with their `depot_id`). But `GET /api/v1/manifests` returned `depot_id: null` for every row, because its `SELECT` and `ManifestResponse` model predated the column. The DB is correct; this was purely a read-side exposure gap. F7's validator reads the DB directly (not the API), so it was unaffected — but the manifests API and any UI consuming it couldn't show which depot a manifest belongs to.

## Fix

`depot_id` is now in:
- the manifests `SELECT` (`_MANIFEST_COLUMNS`),
- the `ManifestResponse` model — typed `int | None`, nullable for rows written before the column existed,
- the row → response mapping.

Kept focused per the issue (exposure only). Making `depot_id` filterable/sortable would be a separate, additive follow-up.

## Tests

`TestManifestDepotIdExposure` — a stored `depot_id` is returned; a NULL one stays `null`. The per-manifest field-set test now includes `depot_id`. Full suite **1191 pass**; mypy(strict)/ruff/gitleaks/semgrep clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)