### PR TITLE
fix(steam): manifest chunk_count = unique chunks; drop dead name field (#121, #123.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — manifest `chunk_count` is now unique chunks, not summed refs (#121, #123.2) — 2026-06-15
+
+`_handle_manifest_fetch` stored `chunk_count` as `sum(len(mapping.chunks))` across all file mappings, which double-counts content-deduped chunks (Steam shares one chunk across many files). F7's `manifest.expand` + `validate` dedup by SHA, so the operator saw e.g. "1820 chunks" (BL12) vs the validator's "1100" for the same depot — confusing, and the "all cached" arithmetic looked inconsistent.
+
+- `chunk_count` now uses the protobuf's true value, `ContentManifestMetadata.unique_chunks` — the same unique count F7 validates against. If that field is *absent* (a steam-next rename / older protobuf) it falls back to the summed refs **and warns to stderr** (drained by the orchestrator), so a silent revert to double-counting is visible rather than masked. A legitimately-empty depot (`unique_chunks == 0`) is preserved as 0.
+- **#123.2:** dropped the dead `name` field from the manifest IPC payload — the orchestrator handler never consumed it.
+- **Tests:** `test_manifest_fetch_chunk_count_is_unique_not_summed`, `test_manifest_fetch_chunk_count_falls_back_when_field_absent`. Full suite **1192 pass**; mypy(strict)/ruff/semgrep clean.
+- **Deferred (adversarial review):** #122 (mid-fetch `NotAuthenticated` masking) — the quick `connected`/`logged_on` proxy conflates a transient CM socket drop with real auth loss, which would force a needless 2FA re-auth (SEV-2); it will be redone with EResult-based detection. #123.1 (double-compression) — changes the stored BLOB format and needs the F7 expand round-trip validated live first.
+
 ### Fixed — Steam worker crash on slow-CDN `gevent.Timeout` — 2026-06-14
 
 Root-caused via the new stderr drain (below) during the UAT-11 live leg: a manifest fetch for a Steam app with a slow CDN depot crashed the worker process (`steam_worker.died reason=stdout_closed`), failing that job **and every subsequent job until restart**. The captured stderr showed `gevent.timeout.Timeout: 15 seconds`.

--- a/src/orchestrator/jobs/handlers/manifest_fetch.py
+++ b/src/orchestrator/jobs/handlers/manifest_fetch.py
@@ -13,7 +13,7 @@ inside the worker venv.
 
 Per spike-A3 (`spikes/spike_a3_steam_manifest.md`):
 - IPC contract: worker returns `{manifests: [{depot_id, manifest_gid,
-  name, total_bytes, chunk_count, raw_path}, ...]}` — one entry per
+  total_bytes, chunk_count, raw_path}, ...]}` — one entry per
   depot for the requested app_id. `raw_path` is a temp file on the
   shared container FS (S2-1: avoids the 10 MiB IPC line cap); this
   handler reads, stores, and deletes it.

--- a/src/orchestrator/platform/steam/worker.py
+++ b/src/orchestrator/platform/steam/worker.py
@@ -262,8 +262,8 @@ def _handle_manifest_fetch(msg_id: str, params: dict[str, str]) -> None:
     """Fetch ALL depot manifests for a Steam app (BL12, post-spike-a3).
 
     Constructs a CDNClient lazily, calls `cdn.get_manifests(app_id)`,
-    extracts {depot_id, manifest_gid, name, total_bytes, chunk_count,
-    raw_b64} per manifest, returns the list.
+    extracts {depot_id, manifest_gid, total_bytes, chunk_count, raw_path}
+    per manifest, returns the list.
 
     Per spike-a3:
     - `CDNDepotManifest.cdn_client` back-reference prevents pickle —
@@ -341,17 +341,34 @@ def _handle_manifest_fetch(msg_id: str, params: dict[str, str]) -> None:
                 blob_path.write_bytes(compressed)
                 written_blobs.append(blob_path)
 
-                chunk_count = 0
-                for mapping in mfst.payload.mappings:
-                    chunk_count += len(mapping.chunks)
+                # #121: report the manifest's UNIQUE chunk count (protobuf
+                # ContentManifestMetadata.unique_chunks) — what F7's SHA-deduped
+                # validate counts — not the sum of per-file mapping refs, which
+                # double-counts content-deduped chunks (operator saw "1820" here
+                # vs the validator's "1100"). `unique_chunks` legitimately being 0
+                # (an empty depot) is distinct from the field being ABSENT (a
+                # steam-next rename / older protobuf): only the latter falls back
+                # to the summed refs, and it warns to stderr so a silent revert to
+                # the double-counting bug is visible rather than masked.
+                raw_unique = getattr(mfst.metadata, "unique_chunks", None)
+                if raw_unique is None:
+                    unique_chunks = sum(len(mapping.chunks) for mapping in mfst.payload.mappings)
+                    print(  # noqa: T201 — surfaced via the orchestrator's stderr drain
+                        f"manifest_fetch: metadata.unique_chunks missing for depot "
+                        f"{mfst.depot_id}; chunk_count fell back to summed mapping refs",
+                        file=sys.stderr,
+                    )
+                else:
+                    unique_chunks = int(raw_unique or 0)
 
+                # #123.2: `name` was sent over IPC but the orchestrator handler
+                # never consumes it — drop the dead field.
                 payload.append(
                     {
                         "depot_id": int(mfst.depot_id),
                         "manifest_gid": int(mfst.gid),
-                        "name": str(getattr(mfst, "name", "") or ""),
                         "total_bytes": int(mfst.metadata.cb_disk_original or 0),
-                        "chunk_count": chunk_count,
+                        "chunk_count": unique_chunks,
                         "raw_path": str(blob_path),
                     }
                 )

--- a/tests/platform/steam/test_worker_audit.py
+++ b/tests/platform/steam/test_worker_audit.py
@@ -268,3 +268,120 @@ def test_dispatch_loop_survives_handler_gevent_timeout(worker, monkeypatch) -> N
     resp = worker._sent[-1]
     assert resp["ok"] is False
     assert resp["error"]["kind"] == "SteamCDNTimeout", resp
+
+
+def _stub_cdn_modules(worker, monkeypatch, tmp_path, cdn) -> None:
+    """Stub the lazy imports `_handle_manifest_fetch` performs + the CDN client
+    + the blob temp path, routing blobs into tmp_path."""
+    zstd_mod = types.ModuleType("zstandard")
+
+    class _Compressor:
+        def compress(self, data):
+            return data
+
+    zstd_mod.ZstdCompressor = lambda level=3: _Compressor()  # type: ignore[attr-defined]
+    cdn_mod = types.ModuleType("steam.client.cdn")
+    cdn_mod.CDNClient = lambda client: None  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "zstandard", zstd_mod)
+    monkeypatch.setitem(sys.modules, "steam.client.cdn", cdn_mod)
+    worker._cdn_client = cdn
+    monkeypatch.setattr(worker, "_blob_temp_path", lambda prefix: tmp_path / f"blob-{prefix}.zst")
+
+
+def test_manifest_fetch_chunk_count_is_unique_not_summed(worker, monkeypatch, tmp_path) -> None:
+    """#121 + #123.2: chunk_count must be the manifest's unique_chunks (what F7's
+    SHA-deduped validate counts), NOT the sum of per-file mapping refs (which
+    double-counts content-deduped chunks). And the dead `name` IPC field — which
+    the orchestrator handler never consumes — must not be sent."""
+
+    class _Meta:
+        cb_disk_original = 9999
+        unique_chunks = 2  # the true unique count (protobuf field 7)
+
+    class _Mapping:
+        def __init__(self, n):
+            self.chunks = [object()] * n
+
+    class _Manifest:
+        depot_id = 1
+        gid = 11
+        metadata = _Meta()
+        # 2 + 1 = 3 mapping refs, but only 2 UNIQUE chunks (one is shared).
+        payload = type("P", (), {"mappings": [_Mapping(2), _Mapping(1)]})()
+
+        def serialize(self):
+            return b"protobuf-bytes"
+
+    class _Cdn:
+        def get_app_depot_info(self, app_id):
+            return {}
+
+        def get_manifest_request_code(self, app_id, depot_id, gid):
+            return 0
+
+        def get_manifest(self, app_id, depot_id, gid, decrypt=True, manifest_request_code=0):
+            return _Manifest()
+
+    worker._client = _FakeSteamClient()
+    _stub_cdn_modules(worker, monkeypatch, tmp_path, _Cdn())
+    monkeypatch.setattr(
+        worker.enumerate_module, "manifest_gids_for_app", lambda depots, branch: [(1, 11)]
+    )
+
+    worker._handle_manifest_fetch("m6", {"app_id": "440"})
+
+    resp = worker._sent[-1]
+    assert resp["ok"] is True, resp
+    entry = resp["result"]["manifests"][0]
+    assert entry["chunk_count"] == 2, "chunk_count must be unique_chunks, not the summed refs (3)"
+    assert "name" not in entry, "the dead `name` field must not be sent (#123.2)"
+
+
+def test_manifest_fetch_chunk_count_falls_back_when_field_absent(
+    worker, monkeypatch, tmp_path
+) -> None:
+    """#121 robustness: if a manifest's metadata has no `unique_chunks` attribute
+    (steam-next rename / older protobuf), chunk_count falls back to the summed
+    mapping refs rather than dropping to 0 — so the count is never silently lost.
+    (A silent revert to the double-count is surfaced via a stderr warning, which
+    the orchestrator drains.)"""
+
+    class _Meta:
+        cb_disk_original = 9999
+        # NO unique_chunks attribute at all.
+
+    class _Mapping:
+        def __init__(self, n):
+            self.chunks = [object()] * n
+
+    class _Manifest:
+        depot_id = 1
+        gid = 11
+        metadata = _Meta()
+        payload = type("P", (), {"mappings": [_Mapping(2), _Mapping(1)]})()
+
+        def serialize(self):
+            return b"protobuf-bytes"
+
+    class _Cdn:
+        def get_app_depot_info(self, app_id):
+            return {}
+
+        def get_manifest_request_code(self, app_id, depot_id, gid):
+            return 0
+
+        def get_manifest(self, app_id, depot_id, gid, decrypt=True, manifest_request_code=0):
+            return _Manifest()
+
+    worker._client = _FakeSteamClient()
+    _stub_cdn_modules(worker, monkeypatch, tmp_path, _Cdn())
+    monkeypatch.setattr(
+        worker.enumerate_module, "manifest_gids_for_app", lambda depots, branch: [(1, 11)]
+    )
+
+    worker._handle_manifest_fetch("m7", {"app_id": "440"})
+
+    resp = worker._sent[-1]
+    assert resp["ok"] is True, resp
+    # No unique_chunks → fall back to the summed refs (2 + 1 = 3), not 0.
+    assert resp["result"]["manifests"][0]["chunk_count"] == 3


### PR DESCRIPTION
Closes #121. Partially addresses #123 (item 2). #122 and #123 item 1 stay open with notes (see below).

## #121 — `chunk_count` double-counted content-deduped chunks (SEV-3)

`_handle_manifest_fetch` stored `chunk_count = sum(len(mapping.chunks))` across all file mappings. Steam content-dedups chunks (one chunk referenced by many files), so this **over-counts**. F7's `manifest.expand` + `validate` dedup by SHA, so the operator saw e.g. **"1820 chunks" (BL12) vs the validator's "1100"** for the same depot — confusing, and the "all cached" arithmetic looked inconsistent.

`chunk_count` now uses the protobuf's true value — `ContentManifestMetadata.unique_chunks` — the same unique count F7 validates against. Robustness (per adversarial review): if that field is *absent* (steam-next rename / older protobuf), it falls back to the summed refs **and warns to stderr** (drained by the orchestrator), so a silent revert to double-counting is visible. A legitimately-empty depot (`unique_chunks == 0`) is preserved as `0`.

## #123.2 — dead `name` IPC field

The worker sent `name` per manifest but the orchestrator handler never consumed it. Dropped from the payload + docstrings.

## Deferred (adversarial pre-commit review pulled these)

A reviewer refuted the original 4-fix batch and surfaced a real **SEV-2** in my first cut of #122:

- **#122** (mid-fetch `NotAuthenticated` masking): my quick fix checked `connected`/`logged_on`, but those mean "CM socket up," not "credentials valid." A *transient* CM disconnect (refresh token still valid) would mislabel a benign error as `NotAuthenticated` → orchestrator sets `auth_status='expired'` → forces the operator to needlessly re-auth with 2FA. Pulled; will redo with **EResult-based** auth-loss detection + live validation.
- **#123.1** (double-compression): `serialize()` defaults to ZIP, then we zstd it — wasteful. But changing it alters the stored BLOB format and needs the F7 `manifest.expand` round-trip validated live before shipping. Deferred.

## Tests

`test_manifest_fetch_chunk_count_is_unique_not_summed` (unique, not summed; no `name`), `test_manifest_fetch_chunk_count_falls_back_when_field_absent`. Full suite **1192 pass**; mypy(strict)/ruff/gitleaks/semgrep clean.

## Live validation

The unique-count against the real Steam CDN is pending the batch's live round (alongside merging the other open hardening PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)