### PR TITLE
chore(deps): bump starlette 1.1.0 → 1.3.1 for CVE fix (security)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Security — bump starlette 1.1.0 → 1.3.1 (2 CVEs) — 2026-06-15
+
+A newly-disclosed advisory flagged `starlette==1.1.0` with two vulnerabilities (`GHSA-82w8-qh3p-5jfq`, `GHSA-jp82-jpqv-5vv3`), failing the CI `Dependencies` (pip-audit) gate on every branch including `main`.
+
+- Pinned `starlette==1.3.1` (the fix version) explicitly in `requirements.in` and recompiled the hashed `requirements.txt`, mirroring the existing `python-dotenv` CVE-override precedent. `fastapi==0.136.3` requires only `starlette>=0.46.0` (no upper bound), so this is compatible **without** a FastAPI bump; only `starlette` moved.
+- Verified: `pip-audit --requirement requirements.txt --disable-pip --strict` → "No known vulnerabilities found"; full suite **1192 pass** against starlette 1.3.1.
+
 ### Fixed — DB pool writer now self-heals after a replacement storm (#152 / F-INT-2) — 2026-06-15
 
 UAT-11 integration finding. Readers already self-heal after a replacement storm (`_lost_reader_slots` + heal-on-acquire), but the writer did not: once the writer storm guard tripped (or a replacement open failed), `self._writer` was left pointing at the dead connection with `_writer_healthy=False` and `_checkout_writer` kept yielding it — **every write failed until a process restart** (health_check live-probes the writer → 503 → HEALTHCHECK container restart). SEV-3, recovery-by-restart, asymmetric with readers.

--- a/requirements.in
+++ b/requirements.in
@@ -11,3 +11,7 @@ pydantic-settings==2.14.1
 click==8.4.0
 # Transitive from pydantic-settings; pinned here to override CVE GHSA-mf9w-mj56-hr94 in 1.2.1.
 python-dotenv==1.2.2
+# Transitive from fastapi; pinned here to override CVEs GHSA-82w8-qh3p-5jfq +
+# GHSA-jp82-jpqv-5vv3 in 1.1.0 (fix 1.3.1). fastapi 0.136.3 requires only
+# starlette>=0.46.0, so this is compatible without a fastapi bump.
+starlette==1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -335,10 +335,12 @@ pyyaml==6.0.3 \
     --hash=sha256:fa160448684b4e94d80416c0fa4aac48967a969efe22931448d853ada8baf926 \
     --hash=sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0
     # via uvicorn
-starlette==1.1.0 \
-    --hash=sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382 \
-    --hash=sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f
-    # via fastapi
+starlette==1.3.1 \
+    --hash=sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0 \
+    --hash=sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6
+    # via
+    #   -r requirements.in
+    #   fastapi
 structlog==25.5.0 \
     --hash=sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98 \
     --hash=sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f


### PR DESCRIPTION
## Why

A newly-disclosed advisory flagged **`starlette==1.1.0`** with two vulnerabilities — `GHSA-82w8-qh3p-5jfq` and `GHSA-jp82-jpqv-5vv3` (fix: 1.3.1). The CI **`Dependencies`** job (`pip-audit --strict`) now fails on **every branch, including `main`** and the open PRs (#158, #159). This is a repo-wide blocker, so it lands on its own.

## What

- Pin `starlette==1.3.1` explicitly in `requirements.in` (mirroring the existing `python-dotenv` CVE-override precedent) and recompile the hashed `requirements.txt`.
- `fastapi==0.136.3` requires only `starlette>=0.46.0` (no upper bound), so **only `starlette` moved** — no FastAPI bump, no other dependency changes (verified by the lockfile diff).

## Verification

- `pip-audit --requirement requirements.txt --disable-pip --strict` → **"No known vulnerabilities found"** (exit 0) — the exact CI command.
- Full suite **1192 pass** against starlette 1.3.1.
- `starlette` is not a worker-venv dependency (`requirements-steam-worker.txt` unaffected).

## After merge

This unblocks the `Dependencies` gate everywhere. I'll rebase #158 and #159 onto `main` so they pick up the fix and go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)