### PR TITLE
fix(validator): dedicated bounded executor for cache stat I/O (#123.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Infrastructure — dedicated bounded executor for cache stat I/O (#123.4) — 2026-06-15
+
+`validate_chunks` offloaded its `stat()` batches to the **shared default** thread pool (`run_in_executor(None, ...)`). asyncio also uses that pool for stdlib offloads such as `getaddrinfo` (DNS), so a hung NFS cache mount filling it with blocked `stat()` threads could starve the pool and stall the orchestrator's own HTTP probes (lancache heartbeat, Epic API) — a cross-subsystem failure from one bad mount.
+
+- Cache stat I/O now runs on a **dedicated, bounded `ThreadPoolExecutor`** (`thread_name_prefix="cache-stat"`, 2 workers — the batch loop is sequential and the jobs worker is serial, so the bound is for isolation, not parallelism). A hung mount now stalls at most validation, never DNS/HTTP.
+- The pool is created lazily (on the event-loop thread, so no creation race) and torn down in the app-lifespan shutdown (`shutdown_cache_stat_executor()`, idempotent; `cancel_futures=True` so a hung-mount backlog can't block shutdown). Ordering: the jobs worker is already stopped before the executor shuts down, so no validation is in flight.
+- **Tests:** `test_validate_chunks_uses_dedicated_cache_stat_pool` (stats run on a `cache-stat` thread, not the default pool), `test_shutdown_cache_stat_executor_is_idempotent_and_recreates`. Full suite **1192 pass**; mypy(strict)/ruff/semgrep clean.
+
 ### Fixed — Steam worker crash on slow-CDN `gevent.Timeout` — 2026-06-14
 
 Root-caused via the new stderr drain (below) during the UAT-11 live leg: a manifest fetch for a Steam app with a slow CDN depot crashed the worker process (`steam_worker.died reason=stdout_closed`), failing that job **and every subsequent job until restart**. The captured stderr showed `gevent.timeout.Timeout: 15 seconds`.

--- a/src/orchestrator/api/main.py
+++ b/src/orchestrator/api/main.py
@@ -55,6 +55,7 @@ from orchestrator.jobs.worker import worker_loop as jobs_worker_loop
 from orchestrator.lancache.heartbeat import LancacheProbe
 from orchestrator.platform.steam.client import SteamWorkerClient
 from orchestrator.scheduler.manager import SchedulerManager
+from orchestrator.validator.disk_stat import shutdown_cache_stat_executor
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -280,6 +281,9 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
                 await close_pool()
             except PoolError as e:
                 log.error("api.shutdown.pool_close_failed", reason=str(e))
+        # Tear down the dedicated cache-stat thread pool (#123.4). Idempotent and
+        # safe even if validation never ran (the executor is created lazily).
+        shutdown_cache_stat_executor()
         log.info("api.shutdown.complete")
 
 

--- a/src/orchestrator/validator/disk_stat.py
+++ b/src/orchestrator/validator/disk_stat.py
@@ -13,6 +13,7 @@ strings, and filesystem paths.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -54,6 +55,39 @@ class ValidationResult:
     error: str | None = None
 
 
+# #123.4: a DEDICATED, bounded thread pool for cache stat I/O. The validate
+# batch loop awaits each batch sequentially and the jobs worker is serial, so
+# one active worker suffices — the bound's purpose is ISOLATION, not parallelism.
+# `run_in_executor(None, ...)` would use the shared default pool, which asyncio
+# also uses for stdlib offloads like getaddrinfo (DNS). A hung NFS cache mount
+# stalling stat() threads would then starve that pool and freeze the
+# orchestrator's HTTP probes (lancache heartbeat, Epic API). With a dedicated
+# pool, a hung mount can stall at most validation.
+_CACHE_STAT_WORKERS = 2
+_cache_stat_executor: concurrent.futures.ThreadPoolExecutor | None = None
+
+
+def _get_cache_stat_executor() -> concurrent.futures.ThreadPoolExecutor:
+    global _cache_stat_executor
+    if _cache_stat_executor is None:
+        _cache_stat_executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=_CACHE_STAT_WORKERS,
+            thread_name_prefix="cache-stat",
+        )
+    return _cache_stat_executor
+
+
+def shutdown_cache_stat_executor() -> None:
+    """Tear down the dedicated cache-stat pool (idempotent; called from the app
+    lifespan shutdown). `wait=False, cancel_futures=True` drops any queued
+    batches so a hung-mount backlog can't block shutdown; in-flight stat threads
+    can't be force-killed, but normal shutdown won't wait on them."""
+    global _cache_stat_executor
+    if _cache_stat_executor is not None:
+        _cache_stat_executor.shutdown(wait=False, cancel_futures=True)
+        _cache_stat_executor = None
+
+
 def _stat_batch(paths: list[Path]) -> tuple[int, int]:
     """Count (cached, errors) for a batch. Runs in a thread.
 
@@ -89,16 +123,18 @@ def _stat_batch(paths: list[Path]) -> tuple[int, int]:
 async def validate_chunks(paths: list[Path], *, batch_size: int = 256) -> tuple[int, int]:
     """Return (cached, missing). Cached = a regular, non-empty file.
 
-    Stats are offloaded to the default executor in batches so a large
-    chunk list never blocks the event loop. Per-file stat errors (EACCES
-    etc.) count as missing and are aggregated into a single WARN per run.
+    Stats are offloaded to a dedicated, bounded executor (#123.4) in batches so
+    a large chunk list never blocks the event loop AND a hung cache mount can't
+    starve the shared default pool. Per-file stat errors (EACCES etc.) count as
+    missing and are aggregated into a single WARN per run.
     """
     loop = asyncio.get_running_loop()
+    executor = _get_cache_stat_executor()
     cached = 0
     errors = 0
     for i in range(0, len(paths), batch_size):
         batch = paths[i : i + batch_size]
-        batch_cached, batch_errors = await loop.run_in_executor(None, _stat_batch, batch)
+        batch_cached, batch_errors = await loop.run_in_executor(executor, _stat_batch, batch)
         cached += batch_cached
         errors += batch_errors
     if errors:

--- a/tests/validator/test_disk_stat.py
+++ b/tests/validator/test_disk_stat.py
@@ -84,6 +84,56 @@ async def test_symlink_not_counted_cached(tmp_path):
     assert (cached, missing) == (0, 1)
 
 
+async def test_validate_chunks_uses_dedicated_cache_stat_pool(tmp_path, monkeypatch):
+    """#123.4: cache stat I/O must run on a dedicated bounded executor, NOT the
+    shared default ThreadPoolExecutor. asyncio also uses the default pool for
+    stdlib offloads like getaddrinfo (DNS), so a hung NFS cache mount filling the
+    default pool would stall the orchestrator's HTTP probes (lancache heartbeat,
+    Epic API). Isolating cache stats bounds the blast radius to validation."""
+    import threading
+
+    from orchestrator.validator import disk_stat
+
+    seen_threads: list[str] = []
+    real_stat_batch = disk_stat._stat_batch
+
+    def recording_stat_batch(paths):
+        seen_threads.append(threading.current_thread().name)
+        return real_stat_batch(paths)
+
+    monkeypatch.setattr(disk_stat, "_stat_batch", recording_stat_batch)
+    f = tmp_path / "chunk"
+    f.write_bytes(b"data")
+
+    await validate_chunks([f])
+
+    assert seen_threads, "no stat batch ran"
+    assert all(name.startswith("cache-stat") for name in seen_threads), (
+        f"stats ran on the shared default pool, not the dedicated one: {seen_threads}"
+    )
+
+
+async def test_shutdown_cache_stat_executor_is_idempotent_and_recreates(tmp_path):
+    """#123.4: the lifespan teardown calls shutdown_cache_stat_executor(); it must
+    be safe to call when the pool was never created and twice in a row, and a
+    later validation must transparently re-create the pool."""
+    from orchestrator.validator import disk_stat
+
+    # Never-created + double shutdown: no error.
+    disk_stat.shutdown_cache_stat_executor()
+    disk_stat.shutdown_cache_stat_executor()
+    assert disk_stat._cache_stat_executor is None
+
+    # A validation after shutdown re-creates the pool and still works.
+    f = tmp_path / "chunk"
+    f.write_bytes(b"data")
+    cached, missing = await validate_chunks([f])
+    assert (cached, missing) == (1, 0)
+    assert disk_stat._cache_stat_executor is not None
+
+    disk_stat.shutdown_cache_stat_executor()
+
+
 # --- validate_game helpers ---------------------------------------------
 
 


### PR DESCRIPTION
Closes #123 item 4.

## Problem

`validate_chunks` offloaded its `stat()` batches to the **shared default** thread pool (`run_in_executor(None, ...)`). asyncio *also* uses that pool for stdlib offloads such as `getaddrinfo` (DNS). On the NFS-mounted lancache cache, a hung mount filling the pool with blocked `stat()` threads could starve it and stall the orchestrator's own HTTP probes (lancache heartbeat, Epic API) — a cross-subsystem failure from one bad mount. (`validate_chunks` is the only explicit `run_in_executor` user, but the default pool is shared implicitly.)

## Fix

Cache stat I/O now runs on a **dedicated, bounded `ThreadPoolExecutor`** (`thread_name_prefix="cache-stat"`, 2 workers). The batch loop is sequential and the jobs worker is serial, so only ~1 worker is ever active — the bound is for **isolation, not parallelism**. A hung mount now stalls at most validation, never DNS/HTTP.

- Created lazily on the event-loop thread (so no creation race), torn down in the app-lifespan shutdown via `shutdown_cache_stat_executor()` (idempotent; `cancel_futures=True` so a hung-mount backlog can't block shutdown).
- Ordering is safe: the jobs worker (which runs validations) is stopped *before* the executor shuts down, so nothing is in flight.

## Tests

- `test_validate_chunks_uses_dedicated_cache_stat_pool` — stats run on a `cache-stat`-named thread, not the default pool (RED on `main`: ran on `asyncio_0`).
- `test_shutdown_cache_stat_executor_is_idempotent_and_recreates`.

Full suite **1192 pass**; mypy(strict)/ruff/gitleaks/semgrep clean. Branch is up to date with `main` (includes the starlette 1.3.1 fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)