### PR TITLE
test(api): guard trigger job_id correctness under concurrency (#123.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Documentation — #123.3 trigger `job_id` race verified resolved + guarded — 2026-06-15
+
+The #123.3 concern (a trigger endpoint's `ORDER BY id DESC LIMIT 1` re-read returning the *wrong* `job_id` under concurrency) is **obsolete**: the prefill/validate/manifest triggers already re-select filtered by `(kind, game_id, in-flight state)`, backed by the migration-0006/0007 partial UNIQUE indexes + `INSERT ... ON CONFLICT DO NOTHING`, so the returned id is deterministic per game. The issue's proposed `lastrowid` fix would in fact be *unreliable* here (a no-op `ON CONFLICT` INSERT leaves `lastrowid` stale). No code change needed.
+
+- Added `test_concurrent_triggers_across_games_return_correct_per_game_id` — fires concurrent validate POSTs across distinct games and asserts each response's `job_id` belongs to *its* game, locking the invariant in so a future regression to a global re-select is caught.
+
 ### Fixed — manifest `chunk_count` is now unique chunks, not summed refs (#121, #123.2) — 2026-06-15
 
 `_handle_manifest_fetch` stored `chunk_count` as `sum(len(mapping.chunks))` across all file mappings, which double-counts content-deduped chunks (Steam shares one chunk across many files). F7's `manifest.expand` + `validate` dedup by SHA, so the operator saw e.g. "1820 chunks" (BL12) vs the validator's "1100" for the same depot — confusing, and the "all cached" arithmetic looked inconsistent.

--- a/tests/api/test_validate_trigger_router.py
+++ b/tests/api/test_validate_trigger_router.py
@@ -58,6 +58,44 @@ class TestDedup:
         assert r2.status_code == 202
         assert r1.json()["job_id"] == r2.json()["job_id"]
 
+    async def test_concurrent_triggers_across_games_return_correct_per_game_id(
+        self, client, populated_pool
+    ):
+        """#123.3 regression: concurrent validate POSTs for DIFFERENT games must
+        each return a job_id belonging to THAT game — never another game's id from
+        a racy global re-select. The original issue feared a global
+        `ORDER BY id DESC LIMIT 1` re-read could return the wrong id under
+        concurrency; the current code instead re-selects filtered by
+        (kind, game_id, in-flight state), backed by the migration-0006 partial
+        UNIQUE index + `INSERT ... ON CONFLICT DO NOTHING`, so the returned id is
+        deterministic per game. (`lastrowid` — the issue's proposed fix — would be
+        unreliable here, since a no-op ON CONFLICT INSERT leaves it stale.) This
+        locks that invariant in."""
+        import asyncio
+
+        game_ids = [
+            await _ensure_steam_game(populated_pool, app_id=f"conc-{i}", title=f"g{i}")
+            for i in range(6)
+        ]
+
+        async def post(gid: int):
+            r = await client.post(
+                f"/api/v1/games/{gid}/validate",
+                headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+            )
+            return gid, r
+
+        results = await asyncio.gather(*(post(gid) for gid in game_ids))
+
+        for gid, r in results:
+            assert r.status_code == 202
+            job_id = r.json()["job_id"]
+            row = await populated_pool.read_one("SELECT game_id FROM jobs WHERE id=?", (job_id,))
+            assert row is not None and row["game_id"] == gid, (
+                f"trigger for game {gid} returned job {job_id} "
+                f"belonging to game {row and row['game_id']}"
+            )
+
     async def test_new_job_after_existing_finished(self, client, populated_pool):
         game_id = await _ensure_steam_game(populated_pool, app_id="fin-v", title="t")
         await populated_pool.execute_write(


### PR DESCRIPTION
Resolves #123 item 3 (verified obsolete + guarded). The #123 umbrella stays open for item 1 (double-compress, deferred).

## Finding

#123.3 feared a trigger endpoint's global `ORDER BY id DESC LIMIT 1` re-read could return the **wrong** `job_id` under concurrency. That's **obsolete**: the prefill/validate/manifest triggers already re-select **filtered by `(kind, game_id, in-flight state)`**, backed by the migration-0006/0007 partial UNIQUE indexes + `INSERT ... ON CONFLICT DO NOTHING`, so the returned id is deterministic per game. Two concurrent POSTs for the same game both re-select the single winning in-flight row → same correct id; POSTs for different games each get their own.

The issue's proposed `lastrowid` fix would in fact be **unreliable** here — a no-op `ON CONFLICT DO NOTHING` INSERT leaves `lastrowid` stale, so the filtered re-select is the *correct* pattern, not a workaround.

## Change (test-only)

`test_concurrent_triggers_across_games_return_correct_per_game_id` — fires concurrent (`asyncio.gather`) validate POSTs across 6 distinct games and asserts each response's `job_id` belongs to **its** game. This locks the invariant in: a future regression to a global re-select (the exact bug the issue feared) would fail this test.

Full suite **1196 pass**; ruff clean. No production code change.

## Recommendation

Close #123.3 as superseded by the dedup work (migrations 0006/0007), with this guard as the reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)