### PR TITLE
test(api): assert health route via OpenAPI schema, not app.routes (fastapi 0.137)

### DIFF
--- a/tests/api/test_app_factory.py
+++ b/tests/api/test_app_factory.py
@@ -14,12 +14,13 @@ class TestAppFactory:
         assert isinstance(app, FastAPI)
 
     def test_health_route_mounted(self):
+        # Assert via the OpenAPI schema, not `app.routes`: FastAPI 0.137+ no
+        # longer flattens included-router endpoints into `app.routes` (they're
+        # nested inside internal `_IncludedRouter` objects), so walking
+        # `app.routes` can't see `/api/v1/health`. The OpenAPI paths are the
+        # authoritative, version-stable list of mounted endpoints.
         app = create_app()
-        # Not every entry in app.routes is a path-bearing Route: FastAPI 0.137+
-        # adds internal `_IncludedRouter` objects (and Mounts) without a `.path`.
-        # Guard with getattr so route introspection survives FastAPI internals.
-        paths = {getattr(route, "path", None) for route in app.routes}
-        assert "/api/v1/health" in paths
+        assert "/api/v1/health" in app.openapi()["paths"]
 
     def test_openapi_security_scheme_registered(self):
         """Spec §3.3 + §5.4: even with auth-as-middleware, the OpenAPI


### PR DESCRIPTION
Properly unblocks **#165** (fastapi 0.136.3 → 0.137.1). Supersedes the partial fix in #166.

## Why #166 wasn't enough

#166's `getattr(route, "path", None)` stopped the `AttributeError`, but the check still failed: FastAPI 0.137 **no longer flattens included-router endpoints into `app.routes`** — they're nested inside internal `_IncludedRouter` objects. So `/api/v1/health` isn't a direct entry in `app.routes` at all anymore, and `assert "/api/v1/health" in paths` failed (the set was just docs/openapi routes + the wrapper).

## Fix

Assert via `app.openapi()["paths"]` — the OpenAPI schema is the authoritative, version-stable list of mounted endpoints (and matches the existing `test_openapi_security_scheme_registered` pattern in the same file).

**Verified by installing both versions locally:** passes under fastapi **0.137.1** and **0.136.3**. No source code iterates `app.routes` (grep-confirmed), so the 0.137 router nesting is test-only — app runtime is unaffected (the other 1197 tests pass on 0.137.1).

## After merge

I'll `@dependabot rebase` #165 → green → yours to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)