### PR TITLE
feat(prefill): log WHY chunks failed, not just the count (#169 step 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Infrastructure — prefill logs WHY chunks failed (#169, step 1) — 2026-06-16
+
+A failed prefill recorded only the failure **count** (`prefill: 2430/2430 chunks failed`), so diagnosing it meant code-spelunking. The downloader already captured per-chunk `(uri, reason)` tuples; they just weren't surfaced.
+
+- `prefill.completed` (steam) and a new `prefill.epic.chunks_failed` (epic) now carry a `failure_reasons` histogram (top reasons → counts, e.g. `{'http 403': 2418, 'ConnectError': 12}`), and the game's `last_error` includes the dominant reasons — so `403`-needs-token vs `404`-not-found vs `ConnectError`-lancache-down is visible from the CLI/API and logs.
+- **Tests:** `_summarize_failures` (count + top-N), and `last_error` includes the reason. Full suite **1212 pass**; mypy(strict)/ruff/semgrep clean.
+- Step 1 of #169 (the F5 prefill download failing on newly-versioned Steam chunks): this makes the cause diagnosable; the actual download fix follows once the live HTTP status is read.
+
 ### Fixed — steam worker restarts on a wedged op (#153 / F-INT-6) — 2026-06-16
 
 When a steam op timed out (`IPCTimeoutError`) or was cancelled (job-runtime timeout → `CancelledError`), the **serial** worker subprocess was left wedged on the abandoned op, and the next steam job queued behind it (potentially timing out too).

--- a/src/orchestrator/jobs/handlers/prefill.py
+++ b/src/orchestrator/jobs/handlers/prefill.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+from collections import Counter
 from typing import TYPE_CHECKING, Any
 
 import structlog
@@ -28,6 +29,23 @@ if TYPE_CHECKING:
     from orchestrator.platform.steam.client import SteamWorkerClient
 
 _log = structlog.get_logger(__name__)
+
+
+def _summarize_failures(failures: list[tuple[str, str]], *, top: int = 5) -> dict[str, int]:
+    """Tally prefill chunk-failure reasons (e.g. ``{'http 403': 2418,
+    'ConnectError': 12}``), keeping the ``top`` most common (#169). Lets a failed
+    prefill be diagnosed from the log / the game's ``last_error`` without code
+    spelunking — e.g. an `http 403` (CDN auth token needed) vs `http 404`
+    (chunk not found) vs `ConnectError` (lancache down)."""
+    return dict(Counter(reason for _uri, reason in failures).most_common(top))
+
+
+def _failure_suffix(failure_reasons: dict[str, int]) -> str:
+    """`` (http 403: 2418, ConnectError: 12)`` for last_error, or `""` if none."""
+    if not failure_reasons:
+        return ""
+    return " (" + ", ".join(f"{r}: {n}" for r, n in failure_reasons.items()) + ")"
+
 
 # Epic manifest upsert (depot_id is NULL — Epic has no depots). Keyed on
 # (game_id, version); a re-fetch updates the existing row.
@@ -149,12 +167,22 @@ async def _epic_prefill_inner(
     settings = get_settings()
     result = await epic_prefill_chunks(paths, cdn_host, cdn_base, settings)
     if result.chunks_failed > 0:
+        failure_reasons = _summarize_failures(result.failures)
+        _log.warning(
+            "prefill.epic.chunks_failed",
+            job_id=job_id,
+            game_id=game_id,
+            failed=result.chunks_failed,
+            total=result.chunks_total,
+            failure_reasons=failure_reasons,
+        )
+        last_error = (
+            f"prefill: {result.chunks_failed}/{result.chunks_total} chunks failed"
+            f"{_failure_suffix(failure_reasons)}"
+        )[:200]
         await deps.pool.execute_write(
             "UPDATE games SET status='failed', last_error=? WHERE id=?",
-            (
-                f"prefill: {result.chunks_failed}/{result.chunks_total} chunks failed"[:200],
-                game_id,
-            ),
+            (last_error, game_id),
         )
         raise RuntimeError(
             f"epic prefill failed: {result.chunks_failed}/{result.chunks_total} chunks"
@@ -250,6 +278,7 @@ async def _steam_prefill_inner(
 
     settings = get_settings()
     result = await prefill_chunks(uris, settings)
+    failure_reasons = _summarize_failures(result.failures)
     _log.info(
         "prefill.completed",
         job_id=job_id,
@@ -257,15 +286,17 @@ async def _steam_prefill_inner(
         total=result.chunks_total,
         ok=result.chunks_ok,
         failed=result.chunks_failed,
+        failure_reasons=failure_reasons,
     )
 
     if result.chunks_failed > 0:
+        last_error = (
+            f"prefill: {result.chunks_failed}/{result.chunks_total} chunks failed"
+            f"{_failure_suffix(failure_reasons)}"
+        )[:200]
         await deps.pool.execute_write(
             "UPDATE games SET status='failed', last_error=? WHERE id=?",
-            (
-                f"prefill: {result.chunks_failed}/{result.chunks_total} chunks failed"[:200],
-                game_id,
-            ),
+            (last_error, game_id),
         )
         raise RuntimeError(f"prefill failed: {result.chunks_failed}/{result.chunks_total} chunks")
 

--- a/tests/jobs/test_prefill_handler.py
+++ b/tests/jobs/test_prefill_handler.py
@@ -138,3 +138,44 @@ async def test_registered():
 
     _register_builtin_handlers()
     assert "prefill" in HANDLERS
+
+
+async def test_summarize_failures_counts_reasons():
+    from orchestrator.jobs.handlers.prefill import _summarize_failures
+
+    failures = [
+        ("/a", "http 403"),
+        ("/b", "http 403"),
+        ("/c", "ConnectError"),
+        ("/d", "http 403"),
+    ]
+    assert _summarize_failures(failures) == {"http 403": 3, "ConnectError": 1}
+
+
+async def test_summarize_failures_keeps_only_top_n():
+    from orchestrator.jobs.handlers.prefill import _summarize_failures
+
+    failures = [(f"/{i}", f"reason-{i}") for i in range(10)]  # 10 distinct reasons
+    assert len(_summarize_failures(failures, top=3)) == 3
+
+
+async def test_chunk_failure_last_error_includes_reason(pool, monkeypatch):
+    """#169: a failed prefill must record WHY (the dominant chunk-failure reason)
+    in the game's last_error, not just the count — so the operator can tell a
+    403-needs-token from a 404-not-found without reading logs."""
+    game_id = await _seed_game(pool)
+    await _seed_manifest(pool, game_id)
+
+    async def fake_prefill(uris, settings, *, on_progress=None):
+        return PrefillResult(
+            2,
+            0,
+            2,
+            [("/depot/731/chunk/x", "http 403"), ("/depot/731/chunk/y", "http 403")],
+        )
+
+    monkeypatch.setattr("orchestrator.jobs.handlers.prefill.prefill_chunks", fake_prefill)
+    with pytest.raises(RuntimeError):
+        await prefill_handler(_job(game_id), Deps(pool=pool, steam_client=_StubSteam()))
+    g = await pool.read_one("SELECT last_error FROM games WHERE id=?", (game_id,))
+    assert "http 403" in g["last_error"]


### PR DESCRIPTION
Step 1 of #169. Pure observability — makes a failed prefill diagnosable.

## Change

A failed prefill recorded only the **count** (`prefill: 2430/2430 chunks failed`), so diagnosing it meant code-spelunking — even though the downloader already captured per-chunk `(uri, reason)` tuples. Now:

- `_summarize_failures` builds a top-N reason histogram (`{'http 500': 50, ...}`).
- It's surfaced in `prefill.completed` (steam) + a new `prefill.epic.chunks_failed` (epic) log event, and in the game's `last_error` (so it's visible from the CLI/API too).

## Why it mattered immediately

Deployed this and re-ran prefill on game 9 (no Steam auth needed — the download is pure httpx): `failure_reasons={'http 500': 50}` — every chunk gets **HTTP 500 from lancache** on the newer Source SDK manifest. (Fake-sha → 404; older manifest still cached.) Full diagnosis + the two candidate fixes (CDN auth token vs host-side lancache investigation) are in #169.

## Tests

`_summarize_failures` (count + top-N), `last_error` includes the reason. Full suite **1212 pass**; mypy(strict)/ruff/gitleaks/semgrep clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)