### PR TITLE
feat(f8): block-list + scheduled prefill driver (version-diff)

### DIFF
--- a/.claude/build-progress.json
+++ b/.claude/build-progress.json
@@ -21,10 +21,11 @@
     "F5-steam-prefill",
     "f6-epic-prefill",
     "f13-scheduled-sweep",
-    "f11-cli"
+    "f11-cli",
+    "f8-block-list"
   ],
-  "features_since_last_test": 0,
-  "features_since_last_health_check": 5,
+  "features_since_last_test": 1,
+  "features_since_last_health_check": 1,
   "test_interval": 2,
   "last_test_session": "2026-06-14",
   "testing_required": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,28 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Added — F8 block list + scheduled prefill driver (version-diff) — 2026-06-17
+
+The orchestrator becomes the automatic **Steam+Epic prefill driver** (completes F12's "diff enqueues prefills"): a 6h cycle prefills only the games that actually changed, with an operator block-list to exclude games.
+
+- **Block-list REST resource** (`GET/POST/DELETE /api/v1/block-list`): paginated wrapped envelope + allow-list filters (`platform`/`source`), idempotent POST (`201` new / `200` existing, accepts an unknown `(platform, app_id)` for pre-blocking), idempotent DELETE (`{removed: 0|1}`). `block_list` is the single source of truth — no schema change (the table shipped in `0001_initial.sql`).
+- **CLI** `game block <id> [--reason]` / `game unblock <id>` (resolve id→`(platform, app_id)` via the list, then POST/DELETE), and a `BLOCKED` column on `game list`. New `OrchClient.delete`.
+- **`games.blocked`** (bool) on `GET /api/v1/games` via a correlated `EXISTS` subquery (no JOIN → no filter-clause ambiguity).
+- **Scheduled prefill driver** (`enqueue_scheduled_prefill`, registered on the library-sync interval, `scheduled_prefill_enabled`): one diff insert enqueues `prefill` for owned games where `cached_version IS NULL OR cached_version <> current_version OR status='validation_failed'`, excluding block-listed ones (`ON CONFLICT DO NOTHING` + the migration-0006 in-flight index dedup).
+
+### Changed — version tracking populates the dormant `current_version`/`cached_version` columns — 2026-06-17
+
+- `library_sync` now writes `current_version` from enumeration: Steam = public-branch `buildid` (composite SHA-256 of sorted depot:gid as fallback), Epic = `buildVersion`. `COALESCE` preserves a known-good version when an enumeration carries none (never erases tracking).
+- Prefill is the **sole** writer of `cached_version` (= `current_version`, on full success). Steam prefill now **re-fetches a fresh manifest when version-diverged** so a patched game caches *current* content (not the stale manifest); Epic already fetched fresh. Validate updates `status` but never `cached_version` (a standalone sweep can validate a stale manifest).
+
+### Data Model — `current_version`/`cached_version` now populated; `block_list` now consumed — 2026-06-17
+
+No migration. The two version columns (vestigial since `0001`) are now maintained, and the `block_list` table (also from `0001`) gains its first reader/writer.
+
+### Security — block-list endpoints bearer-gated + bound-checked — 2026-06-17
+
+All three block-list endpoints are behind the global bearer middleware; inputs are bounded by pydantic `Literal`/`Field` AND the table CHECK constraints; all SQL is parameterized (allow-list field names only). An adversarial-review pass found and we fixed two SEV-2 correctness defects test-first (Epic infinite re-prefill; steam stale-manifest false version-stamp) and one SEV-4 (CLI `unblock` now URL-encodes `app_id`). Full suite **1253 pass**; mypy(strict)/ruff/semgrep/gitleaks clean. See `docs/security-audits/f8-block-list-security-audit.md`.
+
 ### Infrastructure — prefill logs WHY chunks failed (#169, step 1) — 2026-06-16
 
 A failed prefill recorded only the failure **count** (`prefill: 2430/2430 chunks failed`), so diagnosing it meant code-spelunking. The downloader already captured per-chunk `(uri, reason)` tuples; they just weren't surfaced.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1191,4 +1191,74 @@ ruff/mypy(strict)/gitleaks/semgrep clean. New deps: none.
 
 ---
 
+## Feature 22: F8 — Block List + Scheduled Prefill Driver (version-diff)
+
+**Phase Built:** 2 (Milestone B / F8)
+**Status:** Complete pending live UAT (2026-06-17)
+
+**Summary:** Makes the orchestrator the automatic Steam+Epic prefill driver
+(completes F12's "diff enqueues prefills"). A scheduled 6h cycle prefills only
+games that are new, version-diverged, or `validation_failed` — and an operator
+block-list excludes specific games. Adds the block-list REST resource + CLI and
+populates the previously-vestigial `current_version`/`cached_version` columns.
+The last orchestrator-repo MVP feature before the Game_shelf integration
+(F14–F17). **No DB migration** — `block_list` and the version columns already
+shipped in `0001_initial.sql`.
+
+**Key Interfaces:**
+  - `src/orchestrator/api/routers/block_list.py` — `GET/POST/DELETE
+    /api/v1/block-list` (paginated F9 envelope; idempotent POST 201/200,
+    pre-block OK; idempotent DELETE `{removed}`)
+  - `src/orchestrator/scheduler/jobs.py::enqueue_scheduled_prefill` — the
+    version-diff `INSERT...SELECT` (registered on the library-sync interval via
+    `scheduler/manager.py`; `settings.scheduled_prefill_enabled`)
+  - `src/orchestrator/platform/steam/enumerate.py::_app_version_token` — Steam
+    version token (buildid → depot-gid composite)
+  - `src/orchestrator/jobs/handlers/{library_sync,prefill}.py` — write
+    `current_version` / `cached_version`
+  - `src/orchestrator/api/routers/games.py` — `blocked` via correlated `EXISTS`
+  - `src/orchestrator/cli/commands/game.py` — `block`/`unblock` + `BLOCKED`
+    column; `cli/client.py::OrchClient.delete`
+
+**Locked decisions (spec 2026-06-17):**
+  - **Version-diff model** (O(changed games)/cycle), not blanket re-prefill.
+  - **`block_list` is the single source of truth** — never mutates
+    `games.status`; "blocked" is an orthogonal computed flag.
+  - **Prefill is the sole `cached_version` writer**; steam prefill re-fetches a
+    fresh manifest when version-diverged so a patch caches current content.
+  - **Manual prefill/validate bypass the block-list; the F13 sweep is not
+    block-filtered** (validation still runs on blocked games).
+  - **Orchestrator role = driver:** intended to retire the host Steam/Epic
+    prefill cron after a live parallel-run (GOG + chmod-heal cron stay).
+
+**Test Coverage:** new block-list router tests (CRUD/idempotency/pre-block/
+envelope/401/400/503), CLI block/unblock (+ URL-encode), `games.blocked`,
+scheduler diff (selects changed/null/validation_failed, excludes blocked+
+unowned, dedups), version-token population (steam composite + epic buildVersion),
+`cached_version` written only on full prefill success, steam manifest-refresh on
+divergence, validate-never-writes-`cached_version`. Full suite **1253 pass**;
+ruff/mypy(strict)/semgrep/gitleaks clean. New deps: none.
+
+**Adversarial review:** caught two SEV-2 correctness defects (Epic infinite
+re-prefill; steam stale-manifest false version-stamp) + one SEV-4 (CLI
+`unblock` URL-encoding) — all fixed test-first. See
+`docs/security-audits/f8-block-list-security-audit.md`.
+
+**Related docs:** spec `docs/superpowers/specs/2026-06-17-f8-block-list-design.md`;
+plan `docs/superpowers/plans/2026-06-17-f8-block-list.md`.
+
+**Known Limitations:**
+  - **Cold-start adoption is a (WAN-free) prefill pass**, not stat-only: a game
+    cached by external tools has no orchestrator manifest, so the first
+    scheduled cycle prefills it (all cache HITs → 0 WAN, but re-reads chunks
+    locally). A chunk-level disk-stat skip inside prefill is a clean future
+    optimization.
+  - **Scheduled Steam prefill needs a valid session** — an expired session fails
+    the cycle's jobs (and flips `auth_status='expired'`) until re-auth.
+  - **Eventual consistency:** the prefill job runs on its own interval,
+    independent of library sync — a fresh patch is enqueued within ~2 cycles.
+  - **Live UAT pending** — the full driver cycle needs a Steam 2FA login.
+
+---
+
 <!-- Copy the section above for each new feature. Number sequentially. -->

--- a/docs/security-audits/f8-block-list-security-audit.md
+++ b/docs/security-audits/f8-block-list-security-audit.md
@@ -1,0 +1,58 @@
+# F8 — Block List + Scheduled Prefill Driver — Security Audit
+
+**Date:** 2026-06-17
+**Feature:** F8 (block list + version-diff scheduled prefill driver)
+**Auditor:** AI agent (Senior Security Engineer persona) + adversarial-review subagent
+**Branch:** `feat/f8-block-list`
+
+## Scope
+
+New/changed surface: `block_list` REST router (GET/POST/DELETE), `games.blocked`
+flag, the `enqueue_scheduled_prefill` diff, `current_version`/`cached_version`
+population, the steam prefill manifest-refresh, and the CLI `game block/unblock`.
+
+## Method
+
+TDD throughout, then a full gate sweep (pytest 1253, ruff, `mypy --strict`,
+semgrep `orchestrator-rules.yaml` = 0 findings, gitleaks = no leaks) plus a
+dedicated adversarial-review subagent instructed to *refute* — attacking SQL
+injection, the diff's NULL-safety, the POST race, over-blocking, auth, and the
+`cached_version` invariant.
+
+## Findings & disposition
+
+| ID | Sev | Finding | Disposition |
+|----|-----|---------|-------------|
+| S2-1 | SEV-2 | Epic prefill never wrote `cached_version` → every owned Epic game re-prefilled on every 6h tick forever (the `IS NULL` diff arm stays true). | **Fixed** — Epic success now stamps `cached_version=current_version` (Epic always fetches a fresh manifest, so it's accurate). Regression test added. |
+| S2-2 | SEV-2 | Steam prefill reused stale manifests; a *patched* game would download old chunks yet get stamped `cached_version=current_version`, so the patch was silently never prefilled. | **Fixed** — steam prefill now re-fetches a fresh manifest when version-diverged (`cached_version != current_version`); `cached_version` is the **sole** responsibility of prefill (validate no longer writes it, since a standalone sweep can validate a stale manifest). Tests cover diverged-refetch + up-to-date-reuse + validate-never-writes. |
+| S4-1 | SEV-4 | CLI `unblock` did not URL-encode `app_id`; an Epic appName with `/` would mis-route the DELETE. | **Fixed** — `quote(app_id, safe="")` on the path segment. Test added. |
+| S3-1 | SEV-3 | A `current_version IS NULL` + `cached_version` set row is silently skipped by the diff with no diagnostic. | **Accepted (low risk)** — `library_sync`'s `COALESCE` preserves a prior non-null `current_version`, so this requires a never-versioned-yet-cached row (not reachable via the normal pipeline). Noted as a known limitation; safe direction (never blind-prefills). |
+
+## Cleared (no defect) — adversarially verified
+
+- **SQL injection / column ambiguity:** `block_list` GET and `games.blocked`
+  build WHERE/ORDER only from allow-list-validated field names; all user values
+  bind through `?` placeholders. `games.blocked` uses a correlated `EXISTS`
+  subquery (alias `b`) — the outer clauses reference bare `games.*` columns, no
+  ambiguity. POST/DELETE/INSERT/SELECT all parameterized. semgrep no-f-string-sql
+  passes (static `_COLUMNS` interpolation only, with `# noqa: S608`).
+- **POST 201-vs-200 race:** `execute_write` serializes on the single writer
+  connection; the first INSERT gets `rowcount=1` → 201, a concurrent duplicate
+  hits `ON CONFLICT DO NOTHING` → `rowcount=0` → 200. No false 201s.
+- **Over-blocking:** `block_list` is consulted only by `enqueue_scheduled_prefill`
+  (skip) and the `games.blocked` display flag. Manual `POST /games/{id}/prefill`
+  and `/validate`, and the F13 sweep, never reference it — exactly per spec.
+- **Input bounds:** `app_id` ≤64, `reason` ≤500, `platform`/`source` are pydantic
+  `Literal`s — enforced at the API layer AND by the table CHECK constraints.
+- **Auth:** all three block-list endpoints are under `/api/v1` and not in
+  `AUTH_EXEMPT_PATHS`; the global bearer middleware gates them (verified by
+  `test_post_requires_auth_401`).
+- **DoS / idempotency:** duplicate-block floods are O(1) no-ops (`ON CONFLICT`);
+  the scheduled enqueue is bounded by library size and deduped by the
+  migration-0006 in-flight index.
+
+## Conclusion
+
+No open findings above SEV-3. The two SEV-2 correctness defects surfaced by the
+adversarial pass were fixed test-first and re-verified. No secrets, no injection,
+no auth gaps.

--- a/docs/superpowers/plans/2026-06-17-f8-block-list.md
+++ b/docs/superpowers/plans/2026-06-17-f8-block-list.md
@@ -1,0 +1,1222 @@
+# F8 — Block List + Scheduled Prefill Driver — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **NO per-task commits.** Per the project workflow, implement ALL tasks TDD-style (write failing test → verify red → implement → verify green), then Task 13 does the single combined gate-sweep + security audit + adversarial-verify + docs + one `feat(f8)` commit + PR.
+
+**Goal:** Make the orchestrator the automatic Steam+Epic prefill driver — a 6h cycle that prefills only changed/never-cached/validation-failed owned games (version-diff), with an operator block-list to exclude games.
+
+**Architecture:** Populate the vestigial `games.current_version` (from library enumeration) and `cached_version` (on prefill/validate success). A new scheduler job diffs them and enqueues prefill only for divergent, non-block-listed games. A new `block_list` REST resource (table already exists) + CLI `game block/unblock` manage exclusions; existing cache is adopted via a widened validation sweep (stat-only, no re-download).
+
+**Tech Stack:** Python 3.12, FastAPI, aiosqlite (via `orchestrator.db.pool`), APScheduler, Click, httpx, pydantic v2, structlog, pytest.
+
+**Conventions (apply to every task):**
+- Tests: `.venv/bin/pytest <path> -v`. Lint: `.venv/bin/ruff check` + `.venv/bin/ruff format`. Types: `.venv/bin/mypy --strict src/`.
+- DB writes via `pool.execute_write(sql, params)`; reads via `pool.read_one` / `pool.read_all`. **No raw `sqlite3`; no f-string SQL with user values** — all values bound via `?`. SQL built from allow-list-validated field names carries `# noqa: S608` + a `# nosem` note (see `games.py:185-192`).
+- **No DB migration** — `block_list` already exists in `0001_initial.sql`.
+- `block_list` is the single source of truth — never mutate `games.status` on block/unblock.
+- `cached_version` is written ONLY on full prefill success AND clean validation, set equal to `current_version`.
+- Never echo/log credentials or tokens.
+
+---
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `src/orchestrator/platform/steam/enumerate.py` | emit a per-app `version` token (buildid / depot-gid composite) | 1 |
+| `src/orchestrator/platform/epic/models.py` | `EpicLibraryItem.build_version` field | 2 |
+| `src/orchestrator/platform/epic/library.py` | populate `build_version` in `_to_item` | 2 |
+| `src/orchestrator/jobs/handlers/library_sync.py` | upsert `current_version` (steam + epic) | 3 |
+| `src/orchestrator/jobs/handlers/prefill.py` | set `cached_version=current_version` on full success | 4 |
+| `src/orchestrator/jobs/handlers/validate.py` | set `cached_version=current_version` on clean validation | 5 |
+| `src/orchestrator/jobs/handlers/sweep.py` | widen candidate query for cold-start adoption | 6 |
+| `src/orchestrator/scheduler/jobs.py` | new `enqueue_scheduled_prefill` (diff insert) | 7 |
+| `src/orchestrator/scheduler/manager.py` | register the 6h scheduled-prefill job | 8 |
+| `src/orchestrator/core/settings.py` | `scheduled_prefill_enabled` flag | 8 |
+| `src/orchestrator/api/routers/block_list.py` | **new** GET/POST/DELETE block-list router | 9 |
+| `src/orchestrator/api/main.py` | register the block-list router | 9 |
+| `src/orchestrator/api/routers/games.py` | `blocked: bool` via EXISTS subquery | 10 |
+| `src/orchestrator/cli/client.py` | `OrchClient.delete()` | 11 |
+| `src/orchestrator/cli/commands/game.py` | `game block` / `game unblock` + `blocked` column | 11 |
+
+---
+
+## Task 1: Steam per-app version token
+
+**Files:**
+- Modify: `src/orchestrator/platform/steam/enumerate.py` (`_extract_app_metadata` ~line 113-144; add `_app_version_token` helper near `manifest_gids_for_app`)
+- Test: `tests/platform/steam/test_enumerate.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/platform/steam/test_enumerate.py  (add)
+from orchestrator.platform.steam.enumerate import _app_version_token, _extract_app_metadata
+
+
+class TestAppVersionToken:
+    def test_prefers_public_branch_buildid(self):
+        depots = {"branches": {"public": {"buildid": "1788499"}}, "1234": {"manifests": {}}}
+        assert _app_version_token(depots) == "1788499"
+
+    def test_composite_when_no_buildid(self):
+        # no branches.public.buildid -> deterministic hash of sorted depot:gid pairs
+        depots = {"1234": {"manifests": {"public": {"gid": "555"}}},
+                  "1200": {"manifests": {"public": {"gid": "777"}}}}
+        tok = _app_version_token(depots)
+        # same input (order-independent) -> same token
+        assert tok == _app_version_token(
+            {"1200": {"manifests": {"public": {"gid": "777"}}},
+             "1234": {"manifests": {"public": {"gid": "555"}}}}
+        )
+        assert tok is not None and tok != "1788499"
+
+    def test_none_when_no_version_info(self):
+        assert _app_version_token({"branches": {"public": {}}}) is None
+
+    def test_extract_app_metadata_includes_version(self):
+        apps_response = {"apps": {"10": {
+            "common": {"name": "Game"},
+            "depots": {"branches": {"public": {"buildid": "42"}}, "11": {"manifests": {}}},
+        }}}
+        out = _extract_app_metadata(apps_response, [10])
+        assert out == [{"app_id": 10, "name": "Game", "depots": [11], "version": "42"}]
+```
+
+- [ ] **Step 2: Run to verify red**
+
+Run: `.venv/bin/pytest tests/platform/steam/test_enumerate.py -k "AppVersionToken or includes_version" -v`
+Expected: FAIL — `ImportError: cannot import name '_app_version_token'`.
+
+- [ ] **Step 3: Implement**
+
+```python
+# enumerate.py — add near manifest_gids_for_app (after extract_manifest_gid)
+import hashlib
+
+def _app_version_token(depots: Any) -> str | None:
+    """A stable per-app version string. Prefers the public-branch buildid
+    (changes on every app update); falls back to a SHA-256 of the sorted
+    (depot_id, manifest_gid) pairs so any depot manifest change shifts it.
+    Returns None when neither is available (game then treated as needing prefill)."""
+    if isinstance(depots, dict):
+        buildid = (((depots.get("branches") or {}).get("public") or {}).get("buildid"))
+        if buildid is not None and str(buildid):
+            return str(buildid)
+    pairs = manifest_gids_for_app(depots, "public")
+    if not pairs:
+        return None
+    joined = ",".join(f"{d}:{g}" for d, g in sorted(pairs))
+    return hashlib.sha256(joined.encode()).hexdigest()
+```
+
+In `_extract_app_metadata`, change the append (was line ~143):
+
+```python
+        out.append({
+            "app_id": int(app_id),
+            "name": name,
+            "depots": depot_ids,
+            "version": _app_version_token(depots_dict),
+        })
+```
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `.venv/bin/pytest tests/platform/steam/test_enumerate.py -v`
+Expected: PASS (all, including pre-existing).
+
+---
+
+## Task 2: Epic `build_version` on the library item
+
+**Files:**
+- Modify: `src/orchestrator/platform/epic/models.py` (`EpicLibraryItem`), `src/orchestrator/platform/epic/library.py` (`_to_item` ~line 49)
+- Test: `tests/platform/epic/test_library.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/platform/epic/test_library.py  (add)
+from orchestrator.platform.epic.library import _to_item
+
+
+def test_to_item_carries_build_version():
+    rec = {
+        "appName": "Fortnite", "title": "Fortnite",
+        "namespace": "fn", "catalogItemId": "abc", "buildVersion": "++Fortnite-29.00",
+    }
+    item = _to_item(rec)
+    assert item is not None
+    assert item.build_version == "++Fortnite-29.00"
+
+
+def test_to_item_build_version_optional():
+    rec = {"appName": "X", "title": "X", "namespace": "n", "catalogItemId": "c"}
+    item = _to_item(rec)
+    assert item is not None and item.build_version is None
+```
+
+- [ ] **Step 2: Run to verify red**
+
+Run: `.venv/bin/pytest tests/platform/epic/test_library.py -k build_version -v`
+Expected: FAIL — `AttributeError: 'EpicLibraryItem' object has no attribute 'build_version'`.
+
+- [ ] **Step 3: Implement**
+
+In `models.py`, add to the `EpicLibraryItem` dataclass/model a field `build_version: str | None = None` (match the existing declaration style — if it's a `@dataclass`, add `build_version: str | None = None`; if pydantic `BaseModel`, add `build_version: str | None = None`).
+
+In `library.py` `_to_item`, read the field from the asset record (key is `buildVersion`) and pass it when constructing the item:
+
+```python
+    build_version = rec.get("buildVersion")
+    return EpicLibraryItem(
+        # ...existing kwargs unchanged...
+        build_version=(str(build_version) if build_version else None),
+    )
+```
+
+(If `_to_item` currently returns `EpicLibraryItem(app_name=..., title=..., namespace=..., catalog_item_id=...)`, add the `build_version=` kwarg to that call.)
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `.venv/bin/pytest tests/platform/epic/test_library.py -v`
+Expected: PASS.
+
+---
+
+## Task 3: `library_sync` writes `current_version`
+
+**Files:**
+- Modify: `src/orchestrator/jobs/handlers/library_sync.py` (`_UPSERT_SQL` line 24-31; steam call line 142; epic call line 72)
+- Test: `tests/jobs/test_library_sync_handler.py` (or the existing library-sync test module)
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/jobs/test_library_sync_handler.py  (add — adapt to existing fixture names)
+async def test_steam_sync_writes_current_version(pool, steam_deps_with_app):
+    # steam_deps_with_app stubs steam_client.library_enumerate -> one app with version
+    # (mirror the existing happy-path fixture; ensure the stubbed app dict includes
+    #  "version": "42")
+    await _steam_library_sync({"id": 1, "platform": "steam"}, steam_deps_with_app)
+    row = await pool.read_one("SELECT current_version FROM games WHERE platform='steam'")
+    assert row["current_version"] == "42"
+
+
+async def test_steam_sync_preserves_cached_version_and_status(pool, steam_deps_with_app):
+    # pre-seed a game row with cached_version + a lifecycle status; re-sync must not clobber them
+    await pool.execute_write(
+        "INSERT INTO games (platform, app_id, title, owned, status, cached_version, current_version)"
+        " VALUES ('steam','10','Old',1,'up_to_date','99','99')"
+    )
+    await _steam_library_sync({"id": 1, "platform": "steam"}, steam_deps_with_app)  # app_id 10, version 42
+    row = await pool.read_one("SELECT status, cached_version, current_version FROM games WHERE app_id='10'")
+    assert row["status"] == "up_to_date"        # untouched
+    assert row["cached_version"] == "99"        # untouched
+    assert row["current_version"] == "42"       # updated
+```
+
+Add the import: `from orchestrator.jobs.handlers.library_sync import _steam_library_sync`.
+
+- [ ] **Step 2: Run to verify red**
+
+Run: `.venv/bin/pytest tests/jobs/test_library_sync_handler.py -k current_version -v`
+Expected: FAIL — `current_version` is `None` (column not written) / KeyError on the stubbed app `"version"`.
+
+- [ ] **Step 3: Implement**
+
+Replace `_UPSERT_SQL` (lines 24-31):
+
+```python
+_UPSERT_SQL = (
+    "INSERT INTO games (platform, app_id, title, owned, metadata, current_version) "
+    "VALUES (?, ?, ?, 1, ?, ?) "
+    "ON CONFLICT(platform, app_id) DO UPDATE SET "
+    "  title = excluded.title, "
+    "  owned = 1, "
+    "  metadata = excluded.metadata, "
+    "  current_version = excluded.current_version"
+)
+```
+
+Update the module docstring line 7-9 to note `current_version` is now also updated (still preserves `status`, `cached_version`, and other lifecycle columns).
+
+Steam call site (line 142) — read the version and pass it:
+
+```python
+        version = app.get("version")
+        await deps.pool.execute_write(
+            _UPSERT_SQL, ("steam", str(app_id_raw), title, metadata, version)
+        )
+```
+
+Epic call site (line 72):
+
+```python
+        await deps.pool.execute_write(
+            _UPSERT_SQL, ("epic", item.app_name, item.title, metadata, item.build_version)
+        )
+```
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `.venv/bin/pytest tests/jobs/test_library_sync_handler.py -v`
+Expected: PASS. (If the existing steam fixture builds apps without `"version"`, `app.get("version")` yields `None` — harmless; update the happy-path fixture to include `"version"` only where the new assertions need it.)
+
+---
+
+## Task 4: Prefill success writes `cached_version`
+
+**Files:**
+- Modify: `src/orchestrator/jobs/handlers/prefill.py` (line 315-317)
+- Test: `tests/jobs/test_prefill_handler.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/jobs/test_prefill_handler.py  (add — mirror the existing fake_prefill happy path)
+async def test_full_success_sets_cached_version_to_current(pool, prefill_deps, monkeypatch):
+    # seed a game with current_version set, cached_version NULL
+    await pool.execute_write(
+        "INSERT INTO games (platform, app_id, title, owned, current_version, status)"
+        " VALUES ('steam','10','G',1,'42','downloading')"
+    )
+    gid = (await pool.read_one("SELECT id FROM games WHERE app_id='10'"))["id"]
+    # stub prefill_chunks -> all chunks ok (mirror existing happy-path stub)
+    async def fake_prefill(uris, settings, *, on_progress=None):
+        return PrefillResult(chunks_total=1, chunks_ok=1, chunks_failed=0, failures=[])
+    monkeypatch.setattr("orchestrator.jobs.handlers.prefill.prefill_chunks", fake_prefill)
+    monkeypatch.setattr("orchestrator.jobs.handlers.prefill._load_chunk_uris",
+                        _async_return(["http://x/chunk/abc"]))
+    await _steam_prefill_inner(1, gid, {"app_id": "10"}, prefill_deps, prefill_deps.steam_client)
+    row = await pool.read_one("SELECT cached_version, last_prefilled_at FROM games WHERE id=?", (gid,))
+    assert row["cached_version"] == "42"
+    assert row["last_prefilled_at"] is not None
+
+
+async def test_partial_failure_leaves_cached_version_stale(pool, prefill_deps, monkeypatch):
+    await pool.execute_write(
+        "INSERT INTO games (platform, app_id, title, owned, current_version, cached_version)"
+        " VALUES ('steam','11','G',1,'42','OLD')"
+    )
+    gid = (await pool.read_one("SELECT id FROM games WHERE app_id='11'"))["id"]
+    async def fake_prefill(uris, settings, *, on_progress=None):
+        return PrefillResult(chunks_total=2, chunks_ok=1, chunks_failed=1, failures=[{"status": 500}])
+    monkeypatch.setattr("orchestrator.jobs.handlers.prefill.prefill_chunks", fake_prefill)
+    monkeypatch.setattr("orchestrator.jobs.handlers.prefill._load_chunk_uris",
+                        _async_return(["u1", "u2"]))
+    with pytest.raises(RuntimeError):
+        await _steam_prefill_inner(1, gid, {"app_id": "11"}, prefill_deps, prefill_deps.steam_client)
+    row = await pool.read_one("SELECT cached_version FROM games WHERE id=?", (gid,))
+    assert row["cached_version"] == "OLD"   # unchanged on failure
+```
+
+(Use the module's existing test helpers for stubbing `_load_chunk_uris` / `prefill_chunks`; `_async_return` is a tiny `async def` returning the value — define locally if not already present. Match the real `PrefillResult` constructor field names.)
+
+- [ ] **Step 2: Run to verify red**
+
+Run: `.venv/bin/pytest tests/jobs/test_prefill_handler.py -k cached_version -v`
+Expected: FAIL — `cached_version` is `None` after success.
+
+- [ ] **Step 3: Implement**
+
+Replace the success-path `last_prefilled_at` write (lines 315-317):
+
+```python
+    await deps.pool.execute_write(
+        "UPDATE games SET last_prefilled_at=CURRENT_TIMESTAMP, "
+        "cached_version=current_version WHERE id=?",
+        (game_id,),
+    )
+```
+
+(The failure branch at lines 292-301 is unchanged — it sets `status='failed'` and raises before reaching this write, so `cached_version` stays stale.)
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `.venv/bin/pytest tests/jobs/test_prefill_handler.py -v`
+Expected: PASS.
+
+---
+
+## Task 5: Clean validation writes `cached_version`
+
+**Files:**
+- Modify: `src/orchestrator/jobs/handlers/validate.py` (`validate_one_game`, lines 66-79)
+- Test: `tests/jobs/test_validate_handler.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/jobs/test_validate_handler.py  (add)
+async def test_clean_validation_sets_cached_version(pool, validate_deps, monkeypatch):
+    await pool.execute_write(
+        "INSERT INTO games (platform, app_id, title, owned, current_version, status)"
+        " VALUES ('steam','10','G',1,'42','unknown')"
+    )
+    gid = (await pool.read_one("SELECT id FROM games WHERE app_id='10'"))["id"]
+    _stub_validate_game(monkeypatch, outcome="cached", manifest_version="42",
+                        total=3, cached=3, missing=0)
+    await validate_one_game(pool, validate_deps, gid, get_settings())
+    row = await pool.read_one("SELECT status, cached_version FROM games WHERE id=?", (gid,))
+    assert row["status"] == "up_to_date"
+    assert row["cached_version"] == "42"   # == current_version
+
+
+async def test_failed_validation_leaves_cached_version_unchanged(pool, validate_deps, monkeypatch):
+    await pool.execute_write(
+        "INSERT INTO games (platform, app_id, title, owned, current_version, cached_version, status)"
+        " VALUES ('steam','11','G',1,'42','OLD','up_to_date')"
+    )
+    gid = (await pool.read_one("SELECT id FROM games WHERE app_id='11'"))["id"]
+    _stub_validate_game(monkeypatch, outcome="missing", manifest_version="42",
+                        total=3, cached=1, missing=2)
+    await validate_one_game(pool, validate_deps, gid, get_settings())
+    row = await pool.read_one("SELECT status, cached_version FROM games WHERE id=?", (gid,))
+    assert row["status"] == "validation_failed"
+    assert row["cached_version"] == "OLD"   # unchanged
+```
+
+(`_stub_validate_game` monkeypatches `orchestrator.jobs.handlers.validate.validate_game` to return a `ValidationResult` with the given fields — mirror the existing validate-handler test stubbing.)
+
+- [ ] **Step 2: Run to verify red**
+
+Run: `.venv/bin/pytest tests/jobs/test_validate_handler.py -k cached_version -v`
+Expected: FAIL — `cached_version` is `None` after a clean validation.
+
+- [ ] **Step 3: Implement**
+
+Replace the status-update block (lines 66-79) so the `up_to_date` path also copies `current_version` into `cached_version`:
+
+```python
+    new_status = _STATUS_FOR.get(result.outcome)
+    if new_status == "up_to_date":
+        # Clean validation: what's on disk == the current version. Adopt it.
+        await pool.execute_write(
+            "UPDATE games SET status='up_to_date', last_validated_at=CURRENT_TIMESTAMP, "
+            "cached_version=current_version WHERE id=?",
+            (game_id,),
+        )
+    elif new_status is not None:  # 'validation_failed' — do NOT touch cached_version
+        await pool.execute_write(
+            "UPDATE games SET status=?, last_validated_at=CURRENT_TIMESTAMP WHERE id=?",
+            (new_status, game_id),
+        )
+    else:
+        # outcome='error' (infra failure). Never clobber a classified status, but
+        # resolve the transient 'downloading' so a freshly-prefilled game isn't stuck.
+        await pool.execute_write(
+            "UPDATE games SET status='failed', last_error=? WHERE id=? AND status='downloading'",
+            ((f"validate: {result.error}"[:200] if result.error else "validate: error"), game_id),
+        )
+```
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `.venv/bin/pytest tests/jobs/test_validate_handler.py -v`
+Expected: PASS.
+
+---
+
+## Task 6: Widen the sweep candidate query (cold-start adoption)
+
+**Files:**
+- Modify: `src/orchestrator/jobs/handlers/sweep.py` (`_CANDIDATE_SQL`, lines 24-28)
+- Test: `tests/jobs/test_sweep_handler.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/jobs/test_sweep_handler.py  (add)
+async def test_sweep_includes_unknown_and_not_downloaded(pool, sweep_deps, monkeypatch):
+    for app_id, status in [("1", "unknown"), ("2", "not_downloaded"),
+                           ("3", "up_to_date"), ("4", "validation_failed")]:
+        await pool.execute_write(
+            "INSERT INTO games (platform, app_id, title, owned, status)"
+            " VALUES ('steam', ?, 'G', 1, ?)", (app_id, status)
+        )
+    seen: list[int] = []
+    _stub_validate_one_game(monkeypatch, record_into=seen, outcome="cached")
+    _stub_validator_healthy(monkeypatch, True)
+    await sweep_handler({"id": 1}, sweep_deps)
+    # all four candidate statuses validated (adoption pass covers unknown/not_downloaded)
+    assert len(seen) == 4
+```
+
+(`_stub_validate_one_game` patches `orchestrator.jobs.handlers.sweep.validate_one_game` to append `game_id` to `record_into`; `_stub_validator_healthy` patches `validator_self_test` -> True. Mirror existing sweep tests.)
+
+- [ ] **Step 2: Run to verify red**
+
+Run: `.venv/bin/pytest tests/jobs/test_sweep_handler.py -k unknown_and_not_downloaded -v`
+Expected: FAIL — only 2 validated (up_to_date + validation_failed).
+
+- [ ] **Step 3: Implement**
+
+Replace `_CANDIDATE_SQL` (lines 24-28):
+
+```python
+_CANDIDATE_SQL = (
+    "SELECT id, status FROM games "
+    "WHERE platform='steam' "
+    "AND status IN ('up_to_date','validation_failed','unknown','not_downloaded') "
+    "ORDER BY id"
+)
+```
+
+Update the module docstring (line 4) to note the candidate set now also covers never-validated games so the cold-start sweep adopts an existing cache.
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `.venv/bin/pytest tests/jobs/test_sweep_handler.py -v`
+Expected: PASS.
+
+---
+
+## Task 7: `enqueue_scheduled_prefill` (the version-diff insert)
+
+**Files:**
+- Modify: `src/orchestrator/scheduler/jobs.py` (append the new callback)
+- Test: `tests/scheduler/test_jobs.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/scheduler/test_jobs.py  (add)
+from orchestrator.scheduler.jobs import enqueue_scheduled_prefill
+
+
+async def _seed_game(pool, app_id, *, owned=1, current="42", cached=None, status="up_to_date", platform="steam"):
+    await pool.execute_write(
+        "INSERT INTO games (platform, app_id, title, owned, current_version, cached_version, status)"
+        " VALUES (?, ?, 'G', ?, ?, ?, ?)",
+        (platform, app_id, owned, current, cached, status),
+    )
+
+
+class TestEnqueueScheduledPrefill:
+    async def test_enqueues_never_cached(self, pool):
+        await _seed_game(pool, "1", current="42", cached=None)
+        n = await enqueue_scheduled_prefill(pool)
+        assert n == 1
+        row = await pool.read_one("SELECT kind, platform, state, source FROM jobs LIMIT 1")
+        assert (row["kind"], row["state"], row["source"]) == ("prefill", "queued", "scheduler")
+
+    async def test_enqueues_when_version_diverged(self, pool):
+        await _seed_game(pool, "1", current="42", cached="41")
+        assert await enqueue_scheduled_prefill(pool) == 1
+
+    async def test_enqueues_validation_failed(self, pool):
+        await _seed_game(pool, "1", current="42", cached="42", status="validation_failed")
+        assert await enqueue_scheduled_prefill(pool) == 1
+
+    async def test_skips_up_to_date(self, pool):
+        await _seed_game(pool, "1", current="42", cached="42", status="up_to_date")
+        assert await enqueue_scheduled_prefill(pool) == 0
+
+    async def test_skips_unowned(self, pool):
+        await _seed_game(pool, "1", owned=0, current="42", cached=None)
+        assert await enqueue_scheduled_prefill(pool) == 0
+
+    async def test_skips_blocked(self, pool):
+        await _seed_game(pool, "1", current="42", cached=None)
+        await pool.execute_write(
+            "INSERT INTO block_list (platform, app_id, source) VALUES ('steam','1','api')"
+        )
+        assert await enqueue_scheduled_prefill(pool) == 0
+
+    async def test_dedups_inflight_prefill(self, pool):
+        await _seed_game(pool, "1", current="42", cached=None)
+        gid = (await pool.read_one("SELECT id FROM games LIMIT 1"))["id"]
+        await pool.execute_write(
+            "INSERT INTO jobs (kind, game_id, platform, state, source)"
+            " VALUES ('prefill', ?, 'steam', 'queued', 'api')", (gid,)
+        )
+        assert await enqueue_scheduled_prefill(pool) == 0  # ON CONFLICT DO NOTHING
+```
+
+- [ ] **Step 2: Run to verify red**
+
+Run: `.venv/bin/pytest tests/scheduler/test_jobs.py -k ScheduledPrefill -v`
+Expected: FAIL — `ImportError: cannot import name 'enqueue_scheduled_prefill'`.
+
+- [ ] **Step 3: Implement** (append to `jobs.py`)
+
+```python
+async def enqueue_scheduled_prefill(pool: Pool) -> int:
+    """Enqueue 'prefill' jobs for owned games that are new, version-diverged, or
+    validation_failed — and not block-listed (F8 scheduled prefill driver).
+
+    One bulk INSERT...SELECT. ON CONFLICT DO NOTHING + the migration-0006 in-flight
+    UNIQUE index dedups against a prefill already queued/running for a game. Returns
+    the number of rows enqueued (rowcount). Never raises — a failing scheduler tick
+    must not degrade APScheduler.
+    """
+    try:
+        inserted = await pool.execute_write(
+            "INSERT INTO jobs (kind, game_id, platform, state, source) "
+            "SELECT 'prefill', g.id, g.platform, 'queued', 'scheduler' "
+            "FROM games g "
+            "WHERE g.owned = 1 "
+            "  AND (g.cached_version IS NULL "
+            "       OR g.cached_version <> g.current_version "
+            "       OR g.status = 'validation_failed') "
+            "  AND NOT EXISTS ("
+            "      SELECT 1 FROM block_list b "
+            "      WHERE b.platform = g.platform AND b.app_id = g.app_id) "
+            "ON CONFLICT DO NOTHING"
+        )
+        _log.info("scheduler.scheduled_prefill.enqueued", count=inserted)
+        return inserted
+    except PoolError as e:
+        _log.error("scheduler.scheduled_prefill.db_error", reason=str(e)[:200])
+        return 0
+    except Exception as e:
+        _log.error(
+            "scheduler.scheduled_prefill.unexpected_error",
+            error=type(e).__name__,
+            reason=str(e)[:200],
+        )
+        return 0
+```
+
+**Note on the diff:** a game with `current_version IS NULL` (never version-resolved) is caught by the `cached_version IS NULL` clause and enqueued, which resolves it. `cached_version <> current_version` is NULL-safe because the `cached_version IS NULL` disjunct already covers the NULL-cached case.
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `.venv/bin/pytest tests/scheduler/test_jobs.py -v`
+Expected: PASS.
+
+---
+
+## Task 8: Register the scheduled-prefill job
+
+**Files:**
+- Modify: `src/orchestrator/core/settings.py` (add `scheduled_prefill_enabled: bool = True`)
+- Modify: `src/orchestrator/scheduler/manager.py` (job id, constructor param, registration)
+- Modify: the lifespan/factory that constructs `SchedulerManager` (pass `scheduled_prefill_enabled` from settings — find via `grep -rn "SchedulerManager(" src/orchestrator`)
+- Test: `tests/scheduler/test_manager.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/scheduler/test_manager.py  (add)
+async def test_registers_scheduled_prefill_job(pool):
+    from orchestrator.scheduler.manager import SCHEDULED_PREFILL_JOB_ID, SchedulerManager
+    mgr = SchedulerManager(
+        pool=pool, enabled=True, library_sync_interval_sec=21600,
+        validation_sweep_enabled=False, scheduled_prefill_enabled=True,
+    )
+    await mgr.start()
+    try:
+        assert SCHEDULED_PREFILL_JOB_ID in mgr.get_registered_job_ids()
+    finally:
+        await mgr.shutdown()
+
+
+async def test_scheduled_prefill_disabled_not_registered(pool):
+    from orchestrator.scheduler.manager import SCHEDULED_PREFILL_JOB_ID, SchedulerManager
+    mgr = SchedulerManager(
+        pool=pool, enabled=True, library_sync_interval_sec=21600,
+        validation_sweep_enabled=False, scheduled_prefill_enabled=False,
+    )
+    await mgr.start()
+    try:
+        assert SCHEDULED_PREFILL_JOB_ID not in mgr.get_registered_job_ids()
+    finally:
+        await mgr.shutdown()
+```
+
+- [ ] **Step 2: Run to verify red**
+
+Run: `.venv/bin/pytest tests/scheduler/test_manager.py -k scheduled_prefill -v`
+Expected: FAIL — `ImportError`/`TypeError` (no such constant / unexpected kwarg).
+
+- [ ] **Step 3: Implement**
+
+`settings.py`: add the field next to the other scheduler settings:
+
+```python
+    scheduled_prefill_enabled: bool = True
+```
+
+`manager.py`:
+- Add the import: `from orchestrator.scheduler.jobs import (enqueue_library_sync, enqueue_scheduled_prefill, enqueue_validation_sweep)`.
+- Add the constant (after line 39): `SCHEDULED_PREFILL_JOB_ID = "scheduled_prefill"`.
+- Add constructor param + field:
+
+```python
+        validation_sweep_cron: str = "0 3 * * 0",
+        scheduled_prefill_enabled: bool = True,
+    ) -> None:
+        ...
+        self._scheduled_prefill_enabled = scheduled_prefill_enabled
+```
+
+- Register the job inside `start()`, after the validation-sweep block (before `scheduler.start()`):
+
+```python
+            if self._scheduled_prefill_enabled:
+                scheduler.add_job(
+                    enqueue_scheduled_prefill,
+                    trigger=IntervalTrigger(seconds=self._library_sync_interval_sec),
+                    args=(self._pool,),
+                    id=SCHEDULED_PREFILL_JOB_ID,
+                    name="Enqueue scheduled prefill (version-diff)",
+                    replace_existing=True,
+                )
+```
+
+Update the construction site (from the grep) to pass `scheduled_prefill_enabled=settings.scheduled_prefill_enabled`.
+
+**Scheduling note:** the prefill job runs on the same 6h interval as `library_sync`, independent of it (no completion-chaining). This is eventually-consistent: a freshly released patch is enqueued once both the next `library_sync` (refreshing `current_version`) and the next prefill diff have run — worst-case ~2 cycles. Acceptable for a 6h cadence, and avoids coupling the worker handler to scheduling.
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `.venv/bin/pytest tests/scheduler/test_manager.py -v`
+Expected: PASS.
+
+---
+
+## Task 9: Block-list REST router
+
+**Files:**
+- Create: `src/orchestrator/api/routers/block_list.py`
+- Modify: `src/orchestrator/api/main.py` (import + `include_router`, after line 397)
+- Test: `tests/api/test_block_list_router.py` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/api/test_block_list_router.py  (new)
+from __future__ import annotations
+
+VALID_TOKEN = "a" * 32
+AUTH = {"Authorization": f"Bearer {VALID_TOKEN}"}
+
+
+class TestBlockListPost:
+    async def test_post_creates_returns_201(self, client, populated_pool):
+        r = await client.post("/api/v1/block-list",
+                              json={"platform": "steam", "app_id": "730", "reason": "no"}, headers=AUTH)
+        assert r.status_code == 201
+        body = r.json()
+        assert body["platform"] == "steam" and body["app_id"] == "730"
+        assert body["reason"] == "no" and body["source"] == "api"
+        assert set(body) == {"id", "platform", "app_id", "reason", "source", "blocked_at"}
+
+    async def test_post_idempotent_returns_200(self, client, populated_pool):
+        await client.post("/api/v1/block-list", json={"platform": "steam", "app_id": "730"}, headers=AUTH)
+        r = await client.post("/api/v1/block-list", json={"platform": "steam", "app_id": "730"}, headers=AUTH)
+        assert r.status_code == 200
+
+    async def test_post_accepts_unknown_app_id_preblock(self, client, populated_pool):
+        r = await client.post("/api/v1/block-list",
+                              json={"platform": "epic", "app_id": "never-seen"}, headers=AUTH)
+        assert r.status_code == 201
+
+    async def test_post_rejects_extra_field_422(self, client, populated_pool):
+        r = await client.post("/api/v1/block-list",
+                              json={"platform": "steam", "app_id": "1", "nope": 1}, headers=AUTH)
+        assert r.status_code == 422
+
+    async def test_post_rejects_bad_platform_422(self, client, populated_pool):
+        r = await client.post("/api/v1/block-list", json={"platform": "gog", "app_id": "1"}, headers=AUTH)
+        assert r.status_code == 422
+
+    async def test_post_requires_auth_401(self, client, populated_pool):
+        r = await client.post("/api/v1/block-list", json={"platform": "steam", "app_id": "1"})
+        assert r.status_code == 401
+
+
+class TestBlockListGet:
+    async def test_get_empty_envelope(self, client, populated_pool):
+        async with populated_pool.write_transaction() as tx:
+            await tx.execute("DELETE FROM block_list")
+        r = await client.get("/api/v1/block-list", headers=AUTH)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["block_list"] == [] and body["meta"]["total"] == 0
+
+    async def test_get_filter_by_platform(self, client, populated_pool):
+        for p, a in [("steam", "1"), ("epic", "2")]:
+            await client.post("/api/v1/block-list", json={"platform": p, "app_id": a}, headers=AUTH)
+        r = await client.get("/api/v1/block-list?platform=steam", headers=AUTH)
+        rows = r.json()["block_list"]
+        assert [x["platform"] for x in rows] == ["steam"]
+
+    async def test_get_rejects_unknown_filter_400(self, client, populated_pool):
+        r = await client.get("/api/v1/block-list?bogus=1", headers=AUTH)
+        assert r.status_code == 400
+
+
+class TestBlockListDelete:
+    async def test_delete_present_removes_1(self, client, populated_pool):
+        await client.post("/api/v1/block-list", json={"platform": "steam", "app_id": "9"}, headers=AUTH)
+        r = await client.delete("/api/v1/block-list/steam/9", headers=AUTH)
+        assert r.status_code == 200 and r.json() == {"removed": 1}
+
+    async def test_delete_absent_idempotent_removes_0(self, client, populated_pool):
+        r = await client.delete("/api/v1/block-list/steam/absent", headers=AUTH)
+        assert r.status_code == 200 and r.json() == {"removed": 0}
+```
+
+- [ ] **Step 2: Run to verify red**
+
+Run: `.venv/bin/pytest tests/api/test_block_list_router.py -v`
+Expected: FAIL — 404 on all routes (router not registered).
+
+- [ ] **Step 3: Implement** (`src/orchestrator/api/routers/block_list.py`)
+
+```python
+"""Block-list REST resource (F8). GET (paginated) / POST (idempotent) / DELETE.
+
+block_list is the single source of truth for "skip during scheduled prefill".
+POST accepts an unknown (platform, app_id) so an app can be pre-blocked before
+the orchestrator has enumerated it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+import structlog
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict, Field
+
+from orchestrator.api._query_helpers import (
+    FilterAllowList,
+    FilterFieldSpec,
+    QueryParamError,
+    SortAllowList,
+    SortField as _SortField,
+    SortFieldResponse,
+    build_order_by_clause,
+    build_where_clause,
+    parse_filters,
+    parse_pagination,
+    parse_sort,
+)
+from orchestrator.api.dependencies import get_pool_dep
+from orchestrator.db.pool import PoolError
+
+if TYPE_CHECKING:
+    from orchestrator.db.pool import Pool
+
+_log = structlog.get_logger(__name__)
+router = APIRouter(prefix="/api/v1", tags=["block_list"])
+
+DEFAULT_LIMIT = 50
+MAX_LIMIT = 500
+DEFAULT_SORT = (_SortField(field="blocked_at", direction="desc"),)
+TIE_BREAKER = _SortField(field="id", direction="asc")
+
+BLOCK_FILTER_ALLOW_LIST = FilterAllowList(
+    {
+        "platform": FilterFieldSpec(ops={"eq", "in"}, value_type=str),
+        "source": FilterFieldSpec(ops={"eq", "in"}, value_type=str),
+    }
+)
+BLOCK_SORT_ALLOW_LIST = SortAllowList(fields={"blocked_at", "platform", "app_id", "id"})
+
+_COLUMNS = "id, platform, app_id, reason, source, blocked_at"
+
+
+class BlockEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    id: int
+    platform: Literal["steam", "epic"]
+    app_id: str
+    reason: str | None
+    source: Literal["cli", "gameshelf", "api", "config"]
+    blocked_at: str
+
+
+class BlockListMeta(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    total: int
+    limit: int
+    offset: int
+    has_more: bool
+    applied_filters: dict[str, dict[str, object]]
+    applied_sort: list[SortFieldResponse]
+
+
+class BlockListResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    block_list: list[BlockEntry]
+    meta: BlockListMeta
+
+
+class BlockCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    platform: Literal["steam", "epic"]
+    app_id: str = Field(min_length=1, max_length=64)
+    reason: str | None = Field(default=None, max_length=500)
+    source: Literal["cli", "gameshelf", "api", "config"] = "api"
+
+
+def _row_to_entry(row: dict[str, object]) -> dict[str, object]:
+    return {
+        "id": int(row["id"]),  # type: ignore[arg-type]
+        "platform": row["platform"],
+        "app_id": row["app_id"],
+        "reason": row["reason"],
+        "source": row["source"],
+        "blocked_at": row["blocked_at"],
+    }
+
+
+@router.get("/block-list", response_model=BlockListResponse)
+async def list_block_list(
+    request: Request,
+    pool: Pool = Depends(get_pool_dep),  # noqa: B008
+) -> JSONResponse:
+    try:
+        pagination = parse_pagination(request.query_params, default_limit=DEFAULT_LIMIT, max_limit=MAX_LIMIT)
+        filters = parse_filters(request.query_params, allow_list=BLOCK_FILTER_ALLOW_LIST)
+        sort = parse_sort(request.query_params, allow_list=BLOCK_SORT_ALLOW_LIST,
+                          default=list(DEFAULT_SORT), tie_breaker=TIE_BREAKER)
+    except QueryParamError as e:
+        return JSONResponse(content={"detail": str(e)}, status_code=400)
+
+    where_sql, where_params = build_where_clause(filters, allow_list=BLOCK_FILTER_ALLOW_LIST)
+    order_sql = build_order_by_clause(sort, allow_list=BLOCK_SORT_ALLOW_LIST)
+    # nosem: S608 — where_sql/order_sql are allow-list-validated field names only;
+    # values flow through `?` placeholders (see games.py + _query_helpers invariants).
+    count_sql = f"SELECT COUNT(*) AS total FROM block_list {where_sql}".strip()  # noqa: S608
+    rows_sql = (f"SELECT {_COLUMNS} FROM block_list {where_sql} {order_sql} LIMIT ? OFFSET ?").strip()  # noqa: S608
+    rows_params = [*where_params, pagination.limit, pagination.offset]
+
+    try:
+        count_row = await pool.read_one(count_sql, where_params)
+        rows = await pool.read_all(rows_sql, rows_params)
+    except PoolError as e:
+        _log.error("api.block_list.read_failed", reason=str(e))
+        return JSONResponse(content={"detail": "database unavailable"}, status_code=503)
+
+    total = int(count_row["total"]) if count_row else 0
+    entries = [_row_to_entry(r) for r in rows]
+    body = BlockListResponse(
+        block_list=[BlockEntry(**e) for e in entries],  # type: ignore[arg-type]
+        meta=BlockListMeta(
+            total=total, limit=pagination.limit, offset=pagination.offset,
+            has_more=(pagination.offset + len(entries) < total),
+            applied_filters={f: dict(ops) for f, ops in filters.items()},
+            applied_sort=[SortFieldResponse(field=s.field, direction=s.direction) for s in sort],
+        ),
+    )
+    return JSONResponse(content=body.model_dump(by_alias=True))
+
+
+@router.post("/block-list", response_model=BlockEntry,
+             responses={200: {"description": "Already blocked"}, 201: {"description": "Blocked"}})
+async def create_block(
+    payload: BlockCreate,
+    pool: Pool = Depends(get_pool_dep),  # noqa: B008
+) -> JSONResponse:
+    try:
+        inserted = await pool.execute_write(
+            "INSERT INTO block_list (platform, app_id, reason, source) VALUES (?, ?, ?, ?) "
+            "ON CONFLICT(platform, app_id) DO NOTHING",
+            (payload.platform, payload.app_id, payload.reason, payload.source),
+        )
+        row = await pool.read_one(
+            f"SELECT {_COLUMNS} FROM block_list WHERE platform=? AND app_id=?",
+            (payload.platform, payload.app_id),
+        )
+    except PoolError as e:
+        _log.error("api.block_list.write_failed", reason=str(e))
+        return JSONResponse(content={"detail": "database unavailable"}, status_code=503)
+    if row is None:  # pragma: no cover - write succeeded but row vanished
+        return JSONResponse(content={"detail": "database unavailable"}, status_code=503)
+    entry = BlockEntry(**_row_to_entry(row))  # type: ignore[arg-type]
+    return JSONResponse(content=entry.model_dump(), status_code=201 if inserted else 200)
+
+
+@router.delete("/block-list/{platform}/{app_id}")
+async def delete_block(
+    platform: str,
+    app_id: str,
+    pool: Pool = Depends(get_pool_dep),  # noqa: B008
+) -> JSONResponse:
+    try:
+        removed = await pool.execute_write(
+            "DELETE FROM block_list WHERE platform=? AND app_id=?", (platform, app_id)
+        )
+    except PoolError as e:
+        _log.error("api.block_list.delete_failed", reason=str(e))
+        return JSONResponse(content={"detail": "database unavailable"}, status_code=503)
+    return JSONResponse(content={"removed": int(removed)}, status_code=200)
+```
+
+In `main.py`, add the import alongside the other routers and register after `games_router` (line 397):
+
+```python
+    from orchestrator.api.routers.block_list import router as block_list_router
+    # ...
+    app.include_router(block_list_router)
+```
+
+(Match the existing import style — the other routers are imported at the top of `main.py`; add `block_list` there and include it in the same block as the others.)
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `.venv/bin/pytest tests/api/test_block_list_router.py -v`
+Expected: PASS. Confirm `parse_pagination`/`parse_filters`/`parse_sort`/`build_*` import names match `_query_helpers.py` (they are the same names `games.py` imports).
+
+---
+
+## Task 10: `blocked` field on GameResponse
+
+**Files:**
+- Modify: `src/orchestrator/api/routers/games.py` (`GameResponse` ~line 86, `rows_sql` ~line 190, row mapping ~line 254)
+- Test: `tests/api/test_games_router.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/api/test_games_router.py  (add)
+class TestGamesBlockedField:
+    async def test_blocked_true_when_in_block_list(self, client, populated_pool):
+        g = (await client.get("/api/v1/games", headers={"Authorization": f"Bearer {'a'*32}"})).json()["games"][0]
+        await populated_pool.execute_write(
+            "INSERT INTO block_list (platform, app_id, source) VALUES (?, ?, 'api')",
+            (g["platform"], g["app_id"]),
+        )
+        body = (await client.get("/api/v1/games", headers={"Authorization": f"Bearer {'a'*32}"})).json()
+        match = next(x for x in body["games"] if x["id"] == g["id"])
+        assert match["blocked"] is True
+        others = [x for x in body["games"] if x["id"] != g["id"]]
+        assert all(x["blocked"] is False for x in others)
+```
+
+- [ ] **Step 2: Run to verify red**
+
+Run: `.venv/bin/pytest tests/api/test_games_router.py -k blocked -v`
+Expected: FAIL — `KeyError: 'blocked'` / response model has no such field.
+
+- [ ] **Step 3: Implement**
+
+Add `blocked: bool` to `GameResponse` (after `metadata`, line 110):
+
+```python
+    metadata: dict[str, Any] | None
+    blocked: bool
+```
+
+Change `rows_sql` (line 190-192) to add a correlated `EXISTS` subquery — no JOIN, so the allow-list `where_sql`/`order_sql` (bare `games` column names) stay unambiguous:
+
+```python
+    rows_sql = (
+        f"SELECT {_GAMES_COLUMNS}, "
+        "EXISTS(SELECT 1 FROM block_list b "
+        "WHERE b.platform=games.platform AND b.app_id=games.app_id) AS blocked "
+        f"FROM games {where_sql} {order_sql} LIMIT ? OFFSET ?"  # noqa: S608
+    ).strip()
+```
+
+In the `GameResponse(...)` construction (after `metadata=metadata,`, line 268), add:
+
+```python
+                    metadata=metadata,
+                    blocked=bool(row["blocked"]),
+```
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `.venv/bin/pytest tests/api/test_games_router.py -v`
+Expected: PASS (the existing games tests still pass — `blocked` is additive).
+
+---
+
+## Task 11: CLI `game block` / `game unblock` + `blocked` column
+
+**Files:**
+- Modify: `src/orchestrator/cli/client.py` (add `delete`)
+- Modify: `src/orchestrator/cli/commands/game.py` (block/unblock commands + list column)
+- Test: `tests/cli/test_cmd_game.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/cli/test_cmd_game.py  (add — mirror the existing `mock` fixture pattern)
+import httpx
+
+
+def test_game_block_resolves_and_posts(mock):
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/api/v1/games":
+            return httpx.Response(200, json={"games": [
+                {"id": 5, "platform": "steam", "app_id": "730", "title": "CS", "status": "up_to_date", "blocked": False}
+            ], "meta": {}})
+        assert req.method == "POST" and req.url.path == "/api/v1/block-list"
+        import json as _j
+        body = _j.loads(req.content)
+        assert body == {"platform": "steam", "app_id": "730", "reason": "x", "source": "cli"}
+        return httpx.Response(201, json={"id": 1, "platform": "steam", "app_id": "730",
+                                         "reason": "x", "source": "cli", "blocked_at": "t"})
+    r = mock(["game", "block", "5", "--reason", "x"], handler)
+    assert r.exit_code == 0 and "730" in r.output
+
+
+def test_game_block_unknown_id_exit_1(mock):
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"games": [], "meta": {}})
+    r = mock(["game", "block", "999"], handler)
+    assert r.exit_code == 1
+
+
+def test_game_unblock_resolves_and_deletes(mock):
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/api/v1/games":
+            return httpx.Response(200, json={"games": [
+                {"id": 5, "platform": "steam", "app_id": "730", "title": "CS", "status": "up_to_date", "blocked": True}
+            ], "meta": {}})
+        assert req.method == "DELETE" and req.url.path == "/api/v1/block-list/steam/730"
+        return httpx.Response(200, json={"removed": 1})
+    r = mock(["game", "unblock", "5"], handler)
+    assert r.exit_code == 0
+
+
+def test_game_list_shows_blocked_column(mock):
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"games": [
+            {"id": 5, "platform": "steam", "app_id": "730", "title": "CS", "status": "up_to_date", "blocked": True}
+        ], "meta": {}})
+    r = mock(["game", "list"], handler)
+    assert r.exit_code == 0 and "BLOCKED" in r.output
+```
+
+- [ ] **Step 2: Run to verify red**
+
+Run: `.venv/bin/pytest tests/cli/test_cmd_game.py -k "block or blocked_column" -v`
+Expected: FAIL — no `block`/`unblock` command; `BLOCKED` not in output; `OrchClient` has no `delete`.
+
+- [ ] **Step 3: Implement**
+
+`client.py` — add after `post` (line 104):
+
+```python
+    def delete(self, path: str, json: dict[str, Any] | None = None) -> Any:
+        return self._request("DELETE", path, json=json)
+```
+
+`game.py` — add a resolve helper + two commands, and the list column. Add helper near `_trigger`:
+
+```python
+def _resolve_app(ctx: click.Context, game_id: int) -> tuple[object, tuple[str, str]]:
+    """Return (client, (platform, app_id)) for a known game id, or raise ApiError."""
+    client = make_client(ctx)
+    data = client.get("/api/v1/games", limit=500)
+    match = next((g for g in data["games"] if g["id"] == game_id), None)
+    if match is None:
+        raise ApiError(f"game {game_id} not found (in the first 500)")
+    return client, (match["platform"], match["app_id"])
+
+
+@game.command("block")
+@click.argument("game_id", type=int, callback=_positive_int)
+@click.option("--reason", default=None, help="Optional note (<=500 chars).")
+@click.pass_context
+@handles_api_errors
+def game_block(ctx: click.Context, game_id: int, reason: str | None) -> None:
+    """Exclude a game from scheduled prefill."""
+    client, (platform, app_id) = _resolve_app(ctx, game_id)
+    client.post("/api/v1/block-list",
+                json={"platform": platform, "app_id": app_id, "reason": reason, "source": "cli"})
+    output.success(f"blocked game {game_id} ({platform}:{app_id}) from scheduled prefill.")
+
+
+@game.command("unblock")
+@click.argument("game_id", type=int, callback=_positive_int)
+@click.pass_context
+@handles_api_errors
+def game_unblock(ctx: click.Context, game_id: int) -> None:
+    """Remove a game from the block list (idempotent)."""
+    client, (platform, app_id) = _resolve_app(ctx, game_id)
+    resp = client.delete(f"/api/v1/block-list/{platform}/{app_id}")
+    removed = (resp or {}).get("removed", 0)
+    if removed:
+        output.success(f"unblocked game {game_id} ({platform}:{app_id}).")
+    else:
+        output.success(f"game {game_id} ({platform}:{app_id}) was not blocked.")
+```
+
+In `game_list` (line 49-59), add the blocked column:
+
+```python
+    rows = [
+        [
+            str(g["id"]),
+            g["platform"],
+            g["app_id"],
+            (g.get("title") or "")[:40],
+            output.status_label(g["status"]),
+            "yes" if g.get("blocked") else "-",
+        ]
+        for g in data["games"]
+    ]
+    click.echo(output.table(["ID", "PLATFORM", "APP_ID", "TITLE", "STATUS", "BLOCKED"], rows))
+```
+
+(Remove the `reason` mypy concern: `json=` dict values are `str | None` — `OrchClient.post`/`delete` accept `dict[str, Any] | None`, fine.)
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `.venv/bin/pytest tests/cli/test_cmd_game.py -v`
+Expected: PASS.
+
+---
+
+## Task 12: Full-suite + adjacent regression check
+
+- [ ] **Step 1:** Run the whole suite: `.venv/bin/pytest -q`
+Expected: all pass. Pay attention to existing library_sync / games-router / scheduler tests that may assert exact column sets or job counts.
+- [ ] **Step 2:** Fix any regressions revealed (e.g., a library_sync happy-path fixture that now needs a `"version"` key; a games-router snapshot asserting the field set — add `blocked`).
+- [ ] **Step 3:** `.venv/bin/ruff check src tests && .venv/bin/ruff format --check src tests`
+- [ ] **Step 4:** `.venv/bin/mypy --strict src/` — resolve any typing gaps (annotate new functions fully; `BlockCreate`/`BlockEntry` are typed; the `_resolve_app` return tuple is annotated).
+
+---
+
+## Task 13: Gate sweep, audit, docs, commit, PR
+
+- [ ] **Step 1: Process checklist — start the feature**
+`bash scripts/process-checklist.sh --start-feature "f8-block-list"`
+
+- [ ] **Step 2: Full gate sweep**
+```
+.venv/bin/pytest -q
+.venv/bin/ruff check src tests && .venv/bin/ruff format --check src tests
+.venv/bin/mypy --strict src/
+gitleaks detect --no-banner
+semgrep --config .semgrep.yml --error   # or the repo's configured semgrep invocation
+```
+Expected: all green. Mark: `bash scripts/process-checklist.sh --complete-step build_loop:tests_written` … through `build_loop:implemented` per the actual step ids (tests_written, tests_verified_failing, implemented).
+
+- [ ] **Step 3: Security audit doc**
+Write `docs/security-audits/f8-block-list-security-audit.md` covering: SQL-injection surface (block-list filters/sort go through the same allow-list + `?` placeholders as games — no raw interpolation of values; `DELETE`/`POST` use bound params), auth (all block-list endpoints behind bearer middleware; verified by `test_post_requires_auth_401`), input bounds (`app_id` ≤64, `reason` ≤500, `platform`/`source` Literal — enforced by pydantic AND the table CHECK constraints), idempotency/DoS (ON CONFLICT — a flood of duplicate blocks is O(1) no-ops), and the scheduled-prefill enqueue (bounded by library size, deduped by the in-flight index). Mark `build_loop:security_audit`.
+
+- [ ] **Step 4: Adversarial-verify Workflow** over the batch (every prior batch caught a real defect). Dispatch a single adversarial reviewer (Agent tool, code-reviewer or general) to attack: NULL-safety of the diff `<>`, column-ambiguity in the games EXISTS subquery, the 201-vs-200 rowcount logic, block-list bypass of manual triggers (should still work), and the `cached_version` write only-on-success invariant. Fix anything real test-first.
+
+- [ ] **Step 5: Docs**
+- `CHANGELOG.md` (8 categories): **Added** — block-list REST API (GET/POST/DELETE) + CLI `game block/unblock` + `games.blocked`; scheduled prefill driver (version-diff). **Changed** — `library_sync` now writes `current_version`; prefill/validate write `cached_version`; sweep candidate set widened for cold-start adoption. **Data Model** — `games.current_version`/`cached_version` now populated (no schema change); `block_list` now consumed. **Security** — block-list endpoints bearer-gated + bound-checked.
+- `FEATURES.md`: new "Feature N: F8 — Block List + Scheduled Prefill Driver" record (status Complete pending live UAT), key interfaces, and the cold-start adoption note.
+- Mark `build_loop:documentation_updated`.
+
+- [ ] **Step 6: Feature record**
+`bash scripts/test-gate.sh --record-feature "f8-block-list"` and `bash scripts/process-checklist.sh --complete-step build_loop:feature_recorded`.
+
+- [ ] **Step 7: Evaluate gate** — present the implementation evaluation (what was built, risks, the eventual-consistency scheduling choice, cold-start procedure) to the Orchestrator; on approval run `bash .claude/framework/hooks/mark-evaluated.sh "..."`.
+
+- [ ] **Step 8: Commit** — bring the A/B/C commit structure to the Orchestrator FIRST (per the commit-approval protocol), then a single `feat(f8): block-list + scheduled prefill driver (version-diff)` commit. `gitleaks protect --staged` before committing.
+
+- [ ] **Step 9: PR** — open with `gh pr create`. Do NOT merge — the Orchestrator merges on GitHub.
+
+---
+
+## Cold-start adoption (operational, post-merge)
+
+After deploy, trigger one validation sweep so the existing 12 TB cache is adopted (stat-only, no re-download): the widened sweep validates every owned Steam game; cached ones get `cached_version=current_version` and the scheduled diff then skips them. Document this in the PR body and FEATURES record. Live verification (full driver cycle) needs a Steam session (2FA) — flag as the manual UAT step.

--- a/docs/superpowers/specs/2026-06-17-f8-block-list-design.md
+++ b/docs/superpowers/specs/2026-06-17-f8-block-list-design.md
@@ -1,0 +1,173 @@
+# F8 — Block List + Scheduled Prefill Driver (version-diff) — Design
+
+**Status:** Approved (design) — 2026-06-17
+**Feature:** F8 (MVP must-have) + completion of F12's "diff enqueues prefills" step
+**Phase:** 2 (Construction)
+**Author:** Orchestrator + AI agent (brainstorming session 2026-06-17)
+
+---
+
+## 1. Goal
+
+Make the orchestrator the **automatic Steam+Epic prefill driver** (End-state 1): on a recurring 6-hour cycle it detects which owned games are new or patched and prefills only those, validates the result, and lets the operator **block** specific games from that automatic prefill. This is the last orchestrator-repo MVP feature before the Game_shelf integration (F14–F17).
+
+The orchestrator's prefill (F5/F6) is intended to **supersede the host's standalone SteamPrefill/EpicPrefill cron jobs** for Steam and Epic (GOG is out of scope — that cron stays; so does the `chmod_fix.sh` heal cron). The recommended rollout is parallel-run-then-retire: prove the orchestrator fills+validates correctly live, then disable the Steam/Epic cron.
+
+## 2. Background & key discoveries
+
+Established during the design session by reading the codebase:
+
+- **`block_list` table already exists** (migration `0001_initial.sql`) exactly as needed: `id`, `platform CHECK IN ('steam','epic')`, `app_id`, `reason` (nullable, ≤500), `source CHECK IN ('cli','gameshelf','api','config')`, `blocked_at`, `UNIQUE(platform, app_id)`, no FK to `games` (so an unknown app_id can be pre-blocked). **No migration is required.**
+- **`block_list` is referenced nowhere in code** — it is a dormant table.
+- **There is no scheduled-prefill loop today.** Prefill is enqueued only by the manual `POST /api/v1/games/{id}/prefill` trigger. The scheduler runs `library_sync` (interval) and `sweep` (cron) only. The Manifesto user-journey (§94, "F12 diff enqueues prefills") describes the missing step.
+- **`current_version` / `cached_version` columns exist on `games` but nothing writes them** — they are vestigial today. They must be populated for the version-diff model.
+- **Steam library enumeration already fetches version data.** The batched product-info call carries each depot's manifest GID (`manifest_gids_for_app` / `extract_manifest_gid` in `platform/steam/enumerate.py` already parse them) and the public-branch `buildid`. So Steam `current_version` is obtainable for free during the existing library sync.
+- **Epic library enumeration carries `buildVersion`** per asset in the library/assets response.
+- **Prefill respects the cache** — no `nocache`/bypass anywhere in the orchestrator code. Re-running prefill on an already-cached game pulls **0 bytes over WAN** (all lancache HITs); only changed chunks (a patch's delta) are fetched from the CDN. (The `BYPASS`/`?nocache=1` entries seen in the lancache access log come from a LAN Steam client or the standalone cron tool, not the orchestrator.)
+- **F7 validation is disk-stat only** — it `stat()`s cache files (existence + size) against a manifest's computed cache keys; it does not download or read full chunk bytes. This makes it the cheap way to confirm "already cached at the latest version."
+
+## 3. Design decisions (resolved forks)
+
+1. **Orchestrator role = prefill driver** (not just verifier). Build the scheduled diff-enqueue.
+2. **Version-diff model** (not blanket re-prefill). Track `current_version` + `cached_version`; each cycle enqueues prefill only for games that changed / were never cached / failed validation. Cost is O(changed games) per cycle, not O(library).
+3. **`block_list` table is the single source of truth** for "blocked". Do **not** overwrite `games.status='blocked'` (it would clobber lifecycle state and need a fragile restore on unblock). "Blocked" is orthogonal to lifecycle status, surfaced as a computed `blocked: bool`.
+4. **Existing cache is adopted, not rebuilt.** Validation success (not just prefill success) writes `cached_version = current_version`. Cold-start = run a validation sweep once: every already-cached game gets `cached_version` seeded via stat-only validation (no prefill, no download), so the scheduled diff then skips it.
+5. **Manual triggers bypass the block-list.** `POST /games/{id}/prefill` and `/validate` are unchanged (operator override).
+6. **The F13 validation sweep is not filtered by the block-list.** Per the F8 spec, validation still runs on blocked games; blocking only suppresses *scheduled prefill*.
+
+## 4. Components
+
+### 4.1 Version tracking
+
+**`current_version` — written during `library_sync`** (the upsert in `jobs/handlers/library_sync.py`):
+
+- **Steam:** the public-branch `buildid` (as a string) is the primary token — it changes on every app update. If `buildid` is absent, fall back to a deterministic composite: the SHA-256 (hex) of the sorted `"<depot_id>:<manifest_gid>"` pairs from `manifest_gids_for_app(depots, "public")`. `platform/steam/enumerate.py` must propagate the per-app version token (it currently returns only `{app_id, name, depots}` — add the version token), and the `_UPSERT_SQL` must set `current_version = excluded.current_version`.
+- **Epic:** the `buildVersion` string from the library/assets `EpicLibraryItem`. The Epic library-sync upsert sets `current_version` from it.
+- `current_version` is data-only — writing it does **not** change `status`, `cached_version`, or other lifecycle columns (preserves the BL11 "library_sync touches title/owned/metadata only" invariant, extended to add `current_version`).
+
+**`cached_version` — written on confirmed-cached:**
+
+- **Prefill handler**, on **full success** only, sets `cached_version = <version it prefilled>` (= the game's `current_version` at prefill time) and `last_prefilled_at`. Partial/failed prefill leaves `cached_version` unchanged.
+- **Validate handler**, on a **clean validation** (all chunks present), sets `cached_version = <version it validated>` (= `current_version`). A failed validation leaves `cached_version` unchanged and flips `status='validation_failed'` (existing behavior).
+
+### 4.2 Scheduled prefill driver (completes F12)
+
+- New `enqueue_scheduled_prefill(pool)` in `scheduler/jobs.py`, mirroring `enqueue_library_sync` / `enqueue_validation_sweep`.
+- Registered in `scheduler/manager.py` on the 6-hour interval (the `SCHEDULE_CRON`/library-sync cadence), fired **after** the library sync so newly-enumerated versions are current. `replace_existing=True`, `coalesce=True` (consistent with existing jobs).
+- Single bulk diff insert:
+  ```sql
+  INSERT INTO jobs (kind, game_id, platform, state, source)
+  SELECT 'prefill', g.id, g.platform, 'queued', 'scheduler'
+  FROM games g
+  WHERE g.owned = 1
+    AND (g.cached_version IS NULL
+         OR g.cached_version <> g.current_version
+         OR g.status = 'validation_failed')
+    AND NOT EXISTS (
+      SELECT 1 FROM block_list b
+      WHERE b.platform = g.platform AND b.app_id = g.app_id)
+  ON CONFLICT DO NOTHING
+  ```
+- `ON CONFLICT DO NOTHING` + the existing migration-0006 in-flight partial-unique index dedups against a prefill already queued/running for that game. Completed prefills are eligible again only when their game next diverges (version change or `validation_failed`).
+- Rows with `current_version IS NULL` (never enumerated/version-resolved) are covered by the `cached_version IS NULL` clause and will be prefilled, which resolves their version.
+
+### 4.3 Block-list API (`api/routers/block_list.py`, new)
+
+Mirrors F9 conventions (bearer auth via middleware, `ConfigDict(extra="forbid")` on all models, `_query_helpers` pagination, `PoolError → 503`):
+
+- **`GET /api/v1/block-list`** — paginated wrapped envelope `{"block_list": [BlockEntry...], "meta": {...}}`. Filters: `platform` (eq, in), `source` (eq, in). Sort allow-list: `blocked_at`, `platform`, `app_id`, `id` (default `blocked_at:desc`, tie-break `id:asc`). `limit`/`offset` pagination (NOT `per_page`).
+- **`POST /api/v1/block-list`** — body `{platform, app_id, reason?, source?}` (`source` defaults to `'api'`). Idempotent: `INSERT ... ON CONFLICT(platform, app_id) DO NOTHING`, then SELECT and return the row. Accepts **unknown** `(platform, app_id)` (pre-block). `201` on new insert, `200` on existing. `422` on schema violation (extra fields / bad `platform` / `app_id` length / `reason` >500), `503` on PoolError.
+- **`DELETE /api/v1/block-list/{platform}/{app_id}`** — idempotent: `DELETE ... WHERE platform=? AND app_id=?`. Returns `200 {"removed": <0|1>}` (succeeds even when absent). `503` on PoolError.
+
+`BlockEntry` response model fields: `id, platform, app_id, reason, source, blocked_at` (`extra="forbid"`).
+
+### 4.4 Games API — `blocked` field
+
+- Add `blocked: bool` to `GameResponse` (`api/routers/games.py`), computed via `LEFT JOIN block_list b ON b.platform = g.platform AND b.app_id = g.app_id` and selecting `b.id IS NOT NULL AS blocked`. `block_list` is the source of truth; `games.status` is not consulted for blocked-ness. The new field is additive (allowed under `extra="forbid"` since it is declared).
+
+### 4.5 CLI (`cli/commands/game.py`)
+
+- **`game block <game_id> [--reason TEXT]`** — resolve `game_id → (platform, app_id)` client-side (reuse the `game show` list-filter approach, since there is no detail endpoint), then `POST /api/v1/block-list {platform, app_id, reason, source:'cli'}`. Print confirmation. Exit 1 if the game id is not found.
+- **`game unblock <game_id>`** — resolve `game_id → (platform, app_id)`, then `DELETE /api/v1/block-list/{platform}/{app_id}`. Print confirmation (idempotent — reports removed/not-blocked).
+- **`game list`** — add a `blocked` column (a glyph or `yes`/`-`) sourced from the new `GameResponse.blocked` field.
+- Pre-blocking *unknown* games stays API-only (Game_shelf/config use `source='gameshelf'|'config'`), matching the Manifesto's `game block <id>` CLI shape.
+
+### 4.6 Cold-start cache adoption
+
+- Operational procedure, not new code beyond §4.1's "validation writes `cached_version`": after deploy, run a validation sweep across owned games (the existing F13 sweep mechanism / a one-shot). Already-cached games validate clean (stat-only) and get `cached_version = current_version` seeded → the scheduled diff skips them. Genuinely missing/outdated games remain `cached_version IS NULL` / divergent → prefilled.
+- **Default mechanism:** reuse the existing F13 sweep, widening its candidate query so the adoption pass also includes never-validated owned games (currently it targets `status IN ('up_to_date','validation_failed')`; add `'unknown'`/`'not_downloaded'` for the adoption pass). The operator triggers one sweep after deploy; thereafter the weekly sweep keeps `cached_version` honest.
+
+## 5. Data flow (steady state)
+
+```
+scheduler (every 6h)
+  ├─ enqueue_library_sync ──► worker: library_sync_handler
+  │       └─ enumerate owned apps + versions ─► UPSERT games (title, owned, metadata, current_version)
+  └─ enqueue_scheduled_prefill (after sync)
+          └─ diff query ─► enqueue 'prefill' jobs (source='scheduler') for changed/never-cached/validation_failed, non-blocked, owned
+                 └─ worker: prefill_handler (F5/F6)
+                        ├─ fetch latest manifest, request chunks via lancache (HIT=local, MISS=CDN delta)
+                        ├─ on full success: cached_version = current_version, last_prefilled_at
+                        └─ enqueue 'validate' job
+                               └─ worker: validate_handler (F7 disk-stat)
+                                      ├─ clean: cached_version = current_version, status=up_to_date
+                                      └─ missing chunks: status=validation_failed (→ re-prefilled next cycle)
+
+manual POST /games/{id}/prefill | /validate  ─► bypass block-list (operator override)
+F13 weekly sweep ─► validates cached games (NOT block-filtered); keeps cached_version honest, catches eviction
+block-list API/CLI ─► add/remove rows in block_list (source of truth)
+```
+
+## 6. Block semantics
+
+- A game is "blocked" iff a `block_list` row exists for its `(platform, app_id)`.
+- Blocking only suppresses **scheduled** prefill enqueue (§4.2 filter). It does not delete cache, change `games.status`, or stop manual prefill/validate or the F13 sweep.
+- Version-diff catches upstream **patches**; the F13 sweep's `validation_failed` catches local **eviction**. The `enqueue_scheduled_prefill` condition combines both for complete "needs prefill" coverage.
+
+## 7. Error handling & status codes
+
+- Block-list `POST`: `201` new / `200` existing / `422` invalid body / `503` PoolError. Never `5xx` on a duplicate (idempotent).
+- Block-list `DELETE`: `200 {"removed": 0|1}` / `503` PoolError.
+- Block-list `GET`: `200` envelope / `400` bad query params (via `_query_helpers`) / `503` PoolError.
+- All non-health endpoints require bearer auth (middleware) → uniform `401`.
+- `enqueue_scheduled_prefill` swallows nothing silently: it logs the enqueued count (structured log) and lets pool errors propagate to the scheduler's existing error handling (consistent with `enqueue_library_sync`).
+
+## 8. Testing strategy (TDD)
+
+- **`tests/api/test_block_list_router.py`** (new): GET empty/populated + envelope shape + filters/sort/pagination; POST new (`201`) / duplicate (`200`, idempotent) / pre-block unknown app_id / invalid body (`422`, extra=forbid) / PoolError (`503`); DELETE present (`removed:1`) / absent (`removed:0`) / PoolError.
+- **`tests/cli/test_cmd_game.py`** (extend): `game block <id>` resolves and POSTs (assert path/body/source); `--reason` carried; unknown id → exit 1; `game unblock <id>` resolves and DELETEs; idempotent unblock message; `game list` renders the blocked column.
+- **`tests/api/test_games_router.py`** (extend): `GameResponse.blocked` true/false via LEFT JOIN.
+- **`tests/scheduler/` (new or extend)**: `enqueue_scheduled_prefill` selects changed / `cached_version IS NULL` / `validation_failed`; excludes blocked and unowned; dedups via ON CONFLICT; sets `source='scheduler'`.
+- **`tests/platform/steam/` + library_sync tests**: `current_version` populated from buildid (and composite fallback); Epic `buildVersion` populated.
+- **`tests/jobs/test_prefill_handler.py`** (extend): `cached_version` set on full success only, untouched on partial/failure.
+- **`tests/jobs/test_validate_handler.py`** (extend): `cached_version` set on clean validation; untouched + `validation_failed` on missing chunks.
+
+## 9. Known limitations
+
+- **Scheduled Steam prefill needs a valid session.** With an expired session, the cycle's prefill jobs fail auth (and flip `platforms.auth_status='expired'`) until the operator re-authenticates. Documented; not auto-recovered.
+- **Steam version token format** is `buildid`-primary with a depot-GID composite fallback; final selection pinned in the plan against live product-info output.
+- **Epic `buildVersion` wiring** depends on the library/assets response carrying it on `EpicLibraryItem`; confirmed present in the model path during planning.
+- **Cold-start adoption** requires one validation sweep over owned games; until it runs (or the weekly F13 sweep covers a game), a game with `cached_version IS NULL` will be prefilled once (WAN-free if already cached, but a full prefill pass rather than stat-only) — running the adoption sweep first avoids this.
+
+## 10. Out of scope (future / not this feature)
+
+- Retiring the host Steam/Epic prefill cron (operational step after a live parallel-run proves the driver).
+- GOG prefill (orchestrator is Steam+Epic only).
+- `GET /api/v1/games/{id}` detail endpoint (#141) — CLI continues to resolve via the list.
+- Per-game prefill scheduling/priority, bandwidth throttling, partial-library selection.
+- Game_shelf block-list management UI (F16) — consumes this API later.
+
+## 11. File-level change map (for planning)
+
+- `src/orchestrator/platform/steam/enumerate.py` — emit per-app version token (buildid / depot-GID composite).
+- `src/orchestrator/jobs/handlers/library_sync.py` — Steam + Epic upserts set `current_version`.
+- `src/orchestrator/platform/epic/{library,models}.py` — carry `buildVersion` on `EpicLibraryItem` (verify/extend).
+- `src/orchestrator/jobs/handlers/prefill.py` — set `cached_version` + `last_prefilled_at` on full success.
+- `src/orchestrator/jobs/handlers/validate.py` — set `cached_version` on clean validation.
+- `src/orchestrator/scheduler/jobs.py` — new `enqueue_scheduled_prefill(pool)`.
+- `src/orchestrator/scheduler/manager.py` — register the 6h scheduled-prefill job.
+- `src/orchestrator/api/routers/block_list.py` — new router (GET/POST/DELETE).
+- `src/orchestrator/api/app.py` (or router registration) — mount the block-list router.
+- `src/orchestrator/api/routers/games.py` — `blocked` field + LEFT JOIN.
+- `src/orchestrator/cli/commands/game.py` — `block` / `unblock` subcommands + `list` column.
+- Tests per §8. No DB migration. CHANGELOG/FEATURES updated at build time.

--- a/src/orchestrator/api/main.py
+++ b/src/orchestrator/api/main.py
@@ -27,6 +27,7 @@ from orchestrator.api.middleware import (
 )
 from orchestrator.api.routers.auth import router as auth_router
 from orchestrator.api.routers.auth import set_steam_client_singleton
+from orchestrator.api.routers.block_list import router as block_list_router
 from orchestrator.api.routers.epic_auth import router as epic_auth_router
 from orchestrator.api.routers.epic_sync import router as epic_sync_router
 from orchestrator.api.routers.games import router as games_router
@@ -189,6 +190,7 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         library_sync_interval_sec=settings.scheduler_library_sync_interval_sec,
         validation_sweep_enabled=settings.validation_sweep_enabled,
         validation_sweep_cron=settings.validation_sweep_cron,
+        scheduled_prefill_enabled=settings.scheduled_prefill_enabled,
     )
     try:
         await scheduler_manager.start()
@@ -395,6 +397,7 @@ def create_app() -> FastAPI:
     app.include_router(health_router)
     app.include_router(platforms_router)
     app.include_router(games_router)
+    app.include_router(block_list_router)
     app.include_router(jobs_router)
     app.include_router(manifests_router)
     app.include_router(manifest_trigger_router)

--- a/src/orchestrator/api/routers/block_list.py
+++ b/src/orchestrator/api/routers/block_list.py
@@ -1,0 +1,196 @@
+"""Block-list REST resource (F8). GET (paginated) / POST (idempotent) / DELETE.
+
+`block_list` is the single source of truth for "skip during scheduled prefill".
+POST accepts an unknown ``(platform, app_id)`` so an app can be pre-blocked
+before the orchestrator has enumerated it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
+
+import structlog
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict, Field
+
+from orchestrator.api._query_helpers import (
+    FilterAllowList,
+    FilterFieldSpec,
+    QueryParamError,
+    SortAllowList,
+    SortFieldResponse,
+    build_order_by_clause,
+    build_where_clause,
+    parse_filters,
+    parse_pagination,
+    parse_sort,
+)
+from orchestrator.api._query_helpers import (
+    SortField as _SortField,
+)
+from orchestrator.api.dependencies import get_pool_dep
+from orchestrator.db.pool import PoolError
+
+if TYPE_CHECKING:
+    from orchestrator.db.pool import Pool
+
+_log = structlog.get_logger(__name__)
+router = APIRouter(prefix="/api/v1", tags=["block_list"])
+
+DEFAULT_LIMIT = 50
+MAX_LIMIT = 500
+DEFAULT_SORT = (_SortField(field="blocked_at", direction="desc"),)
+TIE_BREAKER = _SortField(field="id", direction="asc")
+
+BLOCK_FILTER_ALLOW_LIST = FilterAllowList(
+    {
+        "platform": FilterFieldSpec(ops={"eq", "in"}, value_type=str),
+        "source": FilterFieldSpec(ops={"eq", "in"}, value_type=str),
+    }
+)
+BLOCK_SORT_ALLOW_LIST = SortAllowList(fields={"blocked_at", "platform", "app_id", "id"})
+
+_COLUMNS = "id, platform, app_id, reason, source, blocked_at"
+
+
+class BlockEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    id: int
+    platform: Literal["steam", "epic"]
+    app_id: str
+    reason: str | None
+    source: Literal["cli", "gameshelf", "api", "config"]
+    blocked_at: str
+
+
+class BlockListMeta(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    total: int
+    limit: int
+    offset: int
+    has_more: bool
+    applied_filters: dict[str, dict[str, Any]]
+    applied_sort: list[SortFieldResponse]
+
+
+class BlockListResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    block_list: list[BlockEntry]
+    meta: BlockListMeta
+
+
+class BlockCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    platform: Literal["steam", "epic"]
+    app_id: str = Field(min_length=1, max_length=64)
+    reason: str | None = Field(default=None, max_length=500)
+    source: Literal["cli", "gameshelf", "api", "config"] = "api"
+
+
+def _entry_kwargs(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": int(row["id"]),
+        "platform": row["platform"],
+        "app_id": row["app_id"],
+        "reason": row["reason"],
+        "source": row["source"],
+        "blocked_at": row["blocked_at"],
+    }
+
+
+@router.get("/block-list", response_model=BlockListResponse)
+async def list_block_list(
+    request: Request,
+    pool: Pool = Depends(get_pool_dep),  # noqa: B008  FastAPI idiomatic
+) -> JSONResponse:
+    try:
+        pagination = parse_pagination(
+            request.query_params, default_limit=DEFAULT_LIMIT, max_limit=MAX_LIMIT
+        )
+        filters = parse_filters(request.query_params, allow_list=BLOCK_FILTER_ALLOW_LIST)
+        sort = parse_sort(
+            request.query_params,
+            allow_list=BLOCK_SORT_ALLOW_LIST,
+            default=list(DEFAULT_SORT),
+            tie_breaker=TIE_BREAKER,
+        )
+    except QueryParamError as e:
+        return JSONResponse(content={"detail": str(e)}, status_code=400)
+
+    where_sql, where_params = build_where_clause(filters, allow_list=BLOCK_FILTER_ALLOW_LIST)
+    order_sql = build_order_by_clause(sort, allow_list=BLOCK_SORT_ALLOW_LIST)
+    # nosem: S608 — where_sql/order_sql are built from allow-list-validated field
+    # names only; user values flow through `?` placeholders (see games.py +
+    # _query_helpers security invariants).
+    count_sql = f"SELECT COUNT(*) AS total FROM block_list {where_sql}".strip()  # noqa: S608
+    rows_sql = (
+        f"SELECT {_COLUMNS} FROM block_list {where_sql} {order_sql} LIMIT ? OFFSET ?"  # noqa: S608
+    ).strip()
+    rows_params = [*where_params, pagination.limit, pagination.offset]
+
+    try:
+        count_row = await pool.read_one(count_sql, where_params)
+        rows = await pool.read_all(rows_sql, rows_params)
+    except PoolError as e:
+        _log.error("api.block_list.read_failed", reason=str(e))
+        return JSONResponse(content={"detail": "database unavailable"}, status_code=503)
+
+    total = int(count_row["total"]) if count_row else 0
+    entries = [BlockEntry(**_entry_kwargs(r)) for r in rows]
+    body = BlockListResponse(
+        block_list=entries,
+        meta=BlockListMeta(
+            total=total,
+            limit=pagination.limit,
+            offset=pagination.offset,
+            has_more=(pagination.offset + len(entries) < total),
+            applied_filters={f: dict(ops) for f, ops in filters.items()},
+            applied_sort=[SortFieldResponse(field=s.field, direction=s.direction) for s in sort],
+        ),
+    )
+    return JSONResponse(content=body.model_dump(by_alias=True))
+
+
+@router.post(
+    "/block-list",
+    response_model=BlockEntry,
+    responses={200: {"description": "Already blocked"}, 201: {"description": "Blocked"}},
+)
+async def create_block(
+    payload: BlockCreate,
+    pool: Pool = Depends(get_pool_dep),  # noqa: B008
+) -> JSONResponse:
+    try:
+        inserted = await pool.execute_write(
+            "INSERT INTO block_list (platform, app_id, reason, source) VALUES (?, ?, ?, ?) "
+            "ON CONFLICT(platform, app_id) DO NOTHING",
+            (payload.platform, payload.app_id, payload.reason, payload.source),
+        )
+        row = await pool.read_one(
+            f"SELECT {_COLUMNS} FROM block_list WHERE platform=? AND app_id=?",  # noqa: S608
+            (payload.platform, payload.app_id),
+        )
+    except PoolError as e:
+        _log.error("api.block_list.write_failed", reason=str(e))
+        return JSONResponse(content={"detail": "database unavailable"}, status_code=503)
+    if row is None:  # pragma: no cover — write succeeded but row vanished
+        return JSONResponse(content={"detail": "database unavailable"}, status_code=503)
+    entry = BlockEntry(**_entry_kwargs(row))
+    return JSONResponse(content=entry.model_dump(), status_code=201 if inserted else 200)
+
+
+@router.delete("/block-list/{platform}/{app_id}")
+async def delete_block(
+    platform: str,
+    app_id: str,
+    pool: Pool = Depends(get_pool_dep),  # noqa: B008
+) -> JSONResponse:
+    try:
+        removed = await pool.execute_write(
+            "DELETE FROM block_list WHERE platform=? AND app_id=?", (platform, app_id)
+        )
+    except PoolError as e:
+        _log.error("api.block_list.delete_failed", reason=str(e))
+        return JSONResponse(content={"detail": "database unavailable"}, status_code=503)
+    return JSONResponse(content={"removed": int(removed)}, status_code=200)

--- a/src/orchestrator/api/routers/games.py
+++ b/src/orchestrator/api/routers/games.py
@@ -108,6 +108,7 @@ class GameResponse(BaseModel):
     last_prefilled_at: str | None
     last_error: str | None
     metadata: dict[str, Any] | None
+    blocked: bool
 
 
 class GamesMeta(BaseModel):
@@ -187,8 +188,14 @@ async def list_games(
     # _query_helpers security invariants and the Hypothesis property test
     # in tests/api/test_query_helpers.py::TestSqlInjectionResistance.
     count_sql = f"SELECT COUNT(*) AS total FROM games {where_sql}".strip()  # noqa: S608
+    # F8: `blocked` via a correlated EXISTS subquery (NOT a JOIN) so the
+    # allow-list `where_sql`/`order_sql` (bare `games` column names) stay
+    # unambiguous — block_list also has platform/app_id columns.
     rows_sql = (
-        f"SELECT {_GAMES_COLUMNS} FROM games {where_sql} {order_sql} LIMIT ? OFFSET ?"  # noqa: S608
+        f"SELECT {_GAMES_COLUMNS}, "  # noqa: S608
+        "EXISTS(SELECT 1 FROM block_list b "
+        "WHERE b.platform=games.platform AND b.app_id=games.app_id) AS blocked "
+        f"FROM games {where_sql} {order_sql} LIMIT ? OFFSET ?"
     ).strip()
     rows_params = [*where_params, pagination.limit, pagination.offset]
 
@@ -266,6 +273,7 @@ async def list_games(
                     last_prefilled_at=row["last_prefilled_at"],
                     last_error=last_error,
                     metadata=metadata,
+                    blocked=bool(row["blocked"]),
                 )
             )
         except ValidationError as e:

--- a/src/orchestrator/cli/client.py
+++ b/src/orchestrator/cli/client.py
@@ -102,3 +102,6 @@ class OrchClient:
 
     def post(self, path: str, json: dict[str, Any] | None = None) -> Any:
         return self._request("POST", path, json=json)
+
+    def delete(self, path: str, json: dict[str, Any] | None = None) -> Any:
+        return self._request("DELETE", path, json=json)

--- a/src/orchestrator/cli/commands/game.py
+++ b/src/orchestrator/cli/commands/game.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from urllib.parse import quote
+
 import click
 
 from orchestrator.cli import output
 from orchestrator.cli.base import handles_api_errors, make_client
-from orchestrator.cli.client import ApiError
+from orchestrator.cli.client import ApiError, OrchClient
 
 # games.status CHECK set — surfaced via click.Choice so a typo'd --status is
 # rejected up front instead of silently returning an empty table (UAT-11 S11-E-04).
@@ -53,10 +55,11 @@ def game_list(ctx: click.Context, platform: str | None, status_: str | None, lim
             g["app_id"],
             (g.get("title") or "")[:40],
             output.status_label(g["status"]),
+            "yes" if g.get("blocked") else "-",
         ]
         for g in data["games"]
     ]
-    click.echo(output.table(["ID", "PLATFORM", "APP_ID", "TITLE", "STATUS"], rows))
+    click.echo(output.table(["ID", "PLATFORM", "APP_ID", "TITLE", "STATUS", "BLOCKED"], rows))
 
 
 @game.command("show")
@@ -106,3 +109,47 @@ def game_validate(ctx: click.Context, game_id: int) -> None:
 def game_manifest(ctx: click.Context, game_id: int) -> None:
     """Trigger a manifest fetch."""
     _trigger(ctx, game_id, "manifest/fetch", "manifest_fetch")
+
+
+def _resolve_app(ctx: click.Context, game_id: int) -> tuple[OrchClient, str, str]:
+    """Return (client, platform, app_id) for a known game id, or raise ApiError.
+
+    Resolves via the list (no detail endpoint), mirroring ``game show``. Needed
+    because the block-list is keyed by (platform, app_id), not game id."""
+    client = make_client(ctx)
+    data = client.get("/api/v1/games", limit=500)
+    match = next((g for g in data["games"] if g["id"] == game_id), None)
+    if match is None:
+        raise ApiError(f"game {game_id} not found (in the first 500)")
+    return client, match["platform"], match["app_id"]
+
+
+@game.command("block")
+@click.argument("game_id", type=int, callback=_positive_int)
+@click.option("--reason", default=None, help="Optional note (<=500 chars).")
+@click.pass_context
+@handles_api_errors
+def game_block(ctx: click.Context, game_id: int, reason: str | None) -> None:
+    """Exclude a game from scheduled prefill."""
+    client, platform, app_id = _resolve_app(ctx, game_id)
+    client.post(
+        "/api/v1/block-list",
+        json={"platform": platform, "app_id": app_id, "reason": reason, "source": "cli"},
+    )
+    output.success(f"blocked game {game_id} ({platform}:{app_id}) from scheduled prefill.")
+
+
+@game.command("unblock")
+@click.argument("game_id", type=int, callback=_positive_int)
+@click.pass_context
+@handles_api_errors
+def game_unblock(ctx: click.Context, game_id: int) -> None:
+    """Remove a game from the block list (idempotent)."""
+    client, platform, app_id = _resolve_app(ctx, game_id)
+    # Encode app_id — an Epic appName can contain '/' which would otherwise split
+    # into extra path segments and mis-route the DELETE.
+    resp = client.delete(f"/api/v1/block-list/{platform}/{quote(app_id, safe='')}")
+    if (resp or {}).get("removed"):
+        output.success(f"unblocked game {game_id} ({platform}:{app_id}).")
+    else:
+        output.success(f"game {game_id} ({platform}:{app_id}) was not blocked.")

--- a/src/orchestrator/core/settings.py
+++ b/src/orchestrator/core/settings.py
@@ -127,6 +127,8 @@ class Settings(BaseSettings):
     # F13 — scheduled validation sweep.
     validation_sweep_enabled: bool = True
     validation_sweep_cron: str = "0 3 * * 0"  # 5-field cron (min hour dom mon dow), UTC
+    # F8: the scheduled prefill driver runs on the library-sync interval.
+    scheduled_prefill_enabled: bool = True
     sweep_batch_size: int = Field(default=10, ge=1)
 
     # --- Misc --------------------------------------------------------

--- a/src/orchestrator/jobs/handlers/library_sync.py
+++ b/src/orchestrator/jobs/handlers/library_sync.py
@@ -5,8 +5,10 @@ Called by the jobs worker when a `library_sync` job is claimed. Calls
 operator's owned apps into the `games` table.
 
 Idempotent: `INSERT ... ON CONFLICT(platform, app_id) DO UPDATE` updates
-title/owned/metadata only — `status`, `cached_version`, and other
-lifecycle columns are preserved (plan P11).
+title/owned/metadata/current_version only — `status`, `cached_version`, and
+other lifecycle columns are preserved (plan P11). `current_version` carries the
+latest upstream version token (F8) so the scheduled-prefill diff can detect
+patches without clobbering what was last cached.
 """
 
 from __future__ import annotations
@@ -22,12 +24,15 @@ if TYPE_CHECKING:
 _log = structlog.get_logger(__name__)
 
 _UPSERT_SQL = (
-    "INSERT INTO games (platform, app_id, title, owned, metadata) "
-    "VALUES (?, ?, ?, 1, ?) "
+    "INSERT INTO games (platform, app_id, title, owned, metadata, current_version) "
+    "VALUES (?, ?, ?, 1, ?, ?) "
     "ON CONFLICT(platform, app_id) DO UPDATE SET "
     "  title = excluded.title, "
     "  owned = 1, "
-    "  metadata = excluded.metadata"
+    "  metadata = excluded.metadata, "
+    # Keep a known-good version if this enumeration didn't carry one (a depot
+    # with no buildid, or a transient gap) — never erase version tracking.
+    "  current_version = COALESCE(excluded.current_version, games.current_version)"
 )
 
 
@@ -69,7 +74,9 @@ async def _epic_library_sync(job: dict[str, Any], deps: Deps) -> None:
             {"namespace": item.namespace, "catalog_item_id": item.catalog_item_id},
             separators=(",", ":"),
         )
-        await deps.pool.execute_write(_UPSERT_SQL, ("epic", item.app_name, item.title, metadata))
+        await deps.pool.execute_write(
+            _UPSERT_SQL, ("epic", item.app_name, item.title, metadata, item.build_version)
+        )
         upserted += 1
     _log.info("library_sync.epic.upserted", job_id=job_id, upserted=upserted)
 
@@ -139,7 +146,10 @@ async def _steam_library_sync(job: dict[str, Any], deps: Deps) -> None:
             {"depots": list(depots), "steam_packages": []},
             separators=(",", ":"),
         )
-        await deps.pool.execute_write(_UPSERT_SQL, ("steam", str(app_id_raw), title, metadata))
+        version = app.get("version")
+        await deps.pool.execute_write(
+            _UPSERT_SQL, ("steam", str(app_id_raw), title, metadata, version)
+        )
         upserted += 1
 
     _log.info(

--- a/src/orchestrator/jobs/handlers/prefill.py
+++ b/src/orchestrator/jobs/handlers/prefill.py
@@ -197,8 +197,12 @@ async def _epic_prefill_inner(
             game_id=game_id,
             hit_ratio=round(hit_ratio, 3),
         )
+    # F8: Epic prefill always fetches a FRESH manifest (signed URLs expire), so
+    # the cache now reflects current_version — adopt it so the scheduled diff
+    # stops re-enqueuing this game every cycle.
     await deps.pool.execute_write(
-        "UPDATE games SET status='up_to_date', last_prefilled_at=CURRENT_TIMESTAMP WHERE id=?",
+        "UPDATE games SET status='up_to_date', last_prefilled_at=CURRENT_TIMESTAMP, "
+        "cached_version=current_version WHERE id=?",
         (game_id,),
     )
     _log.info(
@@ -229,7 +233,10 @@ async def _steam_prefill(job: dict[str, Any], deps: Deps) -> None:
     if game_id is None:
         raise ValueError("prefill job has no game_id")
 
-    game = await deps.pool.read_one("SELECT id, app_id, platform FROM games WHERE id=?", (game_id,))
+    game = await deps.pool.read_one(
+        "SELECT id, app_id, platform, cached_version, current_version FROM games WHERE id=?",
+        (game_id,),
+    )
     if game is None:
         raise ValueError(f"game {game_id} not found in games table")
     if game["platform"] != "steam":
@@ -260,21 +267,22 @@ async def _steam_prefill_inner(
     deps: Deps,
     steam_client: SteamWorkerClient,
 ) -> None:
-    # Ensure manifests exist (fetch once if the game has none).
+    # F8 (S2-2): fetch a FRESH manifest when the game is version-diverged
+    # (cached_version != current_version, incl. never-cached) so prefill caches
+    # the CURRENT content — otherwise a patched game would re-download the stale
+    # manifest's chunks yet get stamped cached_version=current_version, silently
+    # never prefilling the patch. A redundant re-prefill of an up-to-date game
+    # (cached == current; None != None is False) reuses the existing manifest.
+    diverged = game["cached_version"] != game["current_version"]
     uris = await _load_chunk_uris(deps, game_id)
-    if not uris:
-        existing = await deps.pool.read_one(
-            "SELECT 1 AS one FROM manifests WHERE game_id=? AND depot_id IS NOT NULL LIMIT 1",
-            (game_id,),
-        )
-        if existing is None:
-            try:
-                app_id_int = int(game["app_id"])
-            except (TypeError, ValueError) as e:
-                raise ValueError(f"game {game_id} app_id not numeric") from e
-            _log.info("prefill.fetching_manifests", job_id=job_id, game_id=game_id)
-            await steam_client.manifest_fetch(app_id_int)
-            uris = await _load_chunk_uris(deps, game_id)
+    if diverged or not uris:
+        try:
+            app_id_int = int(game["app_id"])
+        except (TypeError, ValueError) as e:
+            raise ValueError(f"game {game_id} app_id not numeric") from e
+        _log.info("prefill.fetching_manifests", job_id=job_id, game_id=game_id, diverged=diverged)
+        await steam_client.manifest_fetch(app_id_int)
+        uris = await _load_chunk_uris(deps, game_id)
 
     settings = get_settings()
     result = await prefill_chunks(uris, settings)
@@ -312,7 +320,12 @@ async def _steam_prefill_inner(
         "VALUES ('validate', ?, 'steam', 'queued', 'scheduler') ON CONFLICT DO NOTHING",
         (game_id,),
     )
+    # F8: full success → what's cached is now the current version. The validate
+    # job (enqueued above) will re-affirm this, but recording it here means the
+    # scheduled-prefill diff skips this game immediately even before validation.
     await deps.pool.execute_write(
-        "UPDATE games SET last_prefilled_at=CURRENT_TIMESTAMP WHERE id=?", (game_id,)
+        "UPDATE games SET last_prefilled_at=CURRENT_TIMESTAMP, "
+        "cached_version=current_version WHERE id=?",
+        (game_id,),
     )
     _log.info("prefill.validate_enqueued", job_id=job_id, game_id=game_id)

--- a/src/orchestrator/jobs/handlers/validate.py
+++ b/src/orchestrator/jobs/handlers/validate.py
@@ -65,6 +65,10 @@ async def validate_one_game(
 
     new_status = _STATUS_FOR.get(result.outcome)
     if new_status is not None:
+        # F8: validate does NOT write cached_version — prefill is the sole writer
+        # (it controls manifest freshness). A standalone sweep can validate a
+        # stale stored manifest, so stamping current_version here could falsely
+        # mark a patched game as cached. See the F8 spec "prefill-sole-writer".
         await pool.execute_write(
             "UPDATE games SET status=?, last_validated_at=CURRENT_TIMESTAMP WHERE id=?",
             (new_status, game_id),

--- a/src/orchestrator/platform/epic/library.py
+++ b/src/orchestrator/platform/epic/library.py
@@ -53,11 +53,13 @@ def _to_item(rec: dict[str, Any]) -> EpicLibraryItem | None:
     if not app_name or not namespace or not catalog:
         return None
     title = (rec.get("metadata") or {}).get("title") or app_name
+    build_version = rec.get("buildVersion")
     return EpicLibraryItem(
         app_name=str(app_name),
         namespace=str(namespace),
         catalog_item_id=str(catalog),
         title=str(title),
+        build_version=(str(build_version) if build_version else None),
     )
 
 

--- a/src/orchestrator/platform/epic/models.py
+++ b/src/orchestrator/platform/epic/models.py
@@ -38,3 +38,4 @@ class EpicLibraryItem:
     namespace: str
     catalog_item_id: str
     title: str
+    build_version: str | None = None

--- a/src/orchestrator/platform/steam/enumerate.py
+++ b/src/orchestrator/platform/steam/enumerate.py
@@ -25,6 +25,7 @@ Two SEV-2 bugs from UAT-6 (issues #107 and #109) are addressed here:
 
 from __future__ import annotations
 
+import hashlib
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -140,7 +141,14 @@ def _extract_app_metadata(
             key_str = str(depot_key)
             if key_str.isdigit():
                 depot_ids.append(int(key_str))
-        out.append({"app_id": int(app_id), "name": name, "depots": depot_ids})
+        out.append(
+            {
+                "app_id": int(app_id),
+                "name": name,
+                "depots": depot_ids,
+                "version": _app_version_token(depots_dict),
+            }
+        )
     return out
 
 
@@ -226,3 +234,22 @@ def manifest_gids_for_app(depots: Any, branch: str = "public") -> list[tuple[int
             continue
         out.append((int(key), gid))
     return out
+
+
+def _app_version_token(depots: Any) -> str | None:
+    """A stable per-app version string for change detection (F8).
+
+    Prefers the public-branch ``buildid`` (changes on every app update); falls
+    back to a SHA-256 of the sorted ``(depot_id, manifest_gid)`` pairs so any
+    depot manifest change shifts the token. Returns ``None`` when neither is
+    available — the game is then treated as needing a prefill.
+    """
+    if isinstance(depots, dict):
+        buildid = ((depots.get("branches") or {}).get("public") or {}).get("buildid")
+        if buildid is not None and str(buildid):
+            return str(buildid)
+    pairs = manifest_gids_for_app(depots, "public")
+    if not pairs:
+        return None
+    joined = ",".join(f"{d}:{g}" for d, g in sorted(pairs))
+    return hashlib.sha256(joined.encode()).hexdigest()

--- a/src/orchestrator/scheduler/jobs.py
+++ b/src/orchestrator/scheduler/jobs.py
@@ -86,3 +86,42 @@ async def enqueue_validation_sweep(pool: Pool) -> int:
             reason=str(e)[:200],
         )
         return 0
+
+
+async def enqueue_scheduled_prefill(pool: Pool) -> int:
+    """Enqueue 'prefill' jobs for owned games that are new, version-diverged, or
+    validation_failed — and not block-listed (F8 scheduled prefill driver).
+
+    One bulk INSERT...SELECT. `ON CONFLICT DO NOTHING` + the migration-0006
+    in-flight UNIQUE index dedups against a prefill already queued/running for a
+    game. The `cached_version IS NULL` disjunct makes the `<>` comparison
+    NULL-safe (a never-cached game is caught by the IS NULL arm). Returns the
+    number of rows enqueued. Never raises — a failing scheduler tick must not
+    degrade APScheduler.
+    """
+    try:
+        inserted = await pool.execute_write(
+            "INSERT INTO jobs (kind, game_id, platform, state, source) "
+            "SELECT 'prefill', g.id, g.platform, 'queued', 'scheduler' "
+            "FROM games g "
+            "WHERE g.owned = 1 "
+            "  AND (g.cached_version IS NULL "
+            "       OR g.cached_version <> g.current_version "
+            "       OR g.status = 'validation_failed') "
+            "  AND NOT EXISTS ("
+            "      SELECT 1 FROM block_list b "
+            "      WHERE b.platform = g.platform AND b.app_id = g.app_id) "
+            "ON CONFLICT DO NOTHING"
+        )
+        _log.info("scheduler.scheduled_prefill.enqueued", count=inserted)
+        return inserted
+    except PoolError as e:
+        _log.error("scheduler.scheduled_prefill.db_error", reason=str(e)[:200])
+        return 0
+    except Exception as e:
+        _log.error(
+            "scheduler.scheduled_prefill.unexpected_error",
+            error=type(e).__name__,
+            reason=str(e)[:200],
+        )
+        return 0

--- a/src/orchestrator/scheduler/manager.py
+++ b/src/orchestrator/scheduler/manager.py
@@ -22,7 +22,11 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 
-from orchestrator.scheduler.jobs import enqueue_library_sync, enqueue_validation_sweep
+from orchestrator.scheduler.jobs import (
+    enqueue_library_sync,
+    enqueue_scheduled_prefill,
+    enqueue_validation_sweep,
+)
 
 if TYPE_CHECKING:
     from apscheduler.job import Job
@@ -37,6 +41,7 @@ _log = structlog.get_logger(__name__)
 # orphan jobs if the in-memory store ever gets persisted in a future BL.
 LIBRARY_SYNC_JOB_ID = "library_sync_steam"
 VALIDATION_SWEEP_JOB_ID = "validation_sweep"
+SCHEDULED_PREFILL_JOB_ID = "scheduled_prefill"
 
 
 class SchedulerManager:
@@ -56,12 +61,14 @@ class SchedulerManager:
         library_sync_interval_sec: int,
         validation_sweep_enabled: bool = True,
         validation_sweep_cron: str = "0 3 * * 0",
+        scheduled_prefill_enabled: bool = True,
     ) -> None:
         self._pool = pool
         self._enabled = enabled
         self._library_sync_interval_sec = library_sync_interval_sec
         self._validation_sweep_enabled = validation_sweep_enabled
         self._validation_sweep_cron = validation_sweep_cron
+        self._scheduled_prefill_enabled = scheduled_prefill_enabled
         self._scheduler: AsyncIOScheduler | None = None
         # Serializes start()/shutdown() so the lifecycle stays atomic even if
         # they are ever called concurrently (e.g. a future restart endpoint).
@@ -124,6 +131,20 @@ class SchedulerManager:
                     args=(self._pool,),
                     id=VALIDATION_SWEEP_JOB_ID,
                     name="Enqueue validation sweep",
+                    replace_existing=True,
+                )
+
+            if self._scheduled_prefill_enabled:
+                # F8: same cadence as library sync, independent of it (no
+                # completion-chaining) — eventually consistent: a fresh patch is
+                # enqueued once both the next sync (refreshing current_version)
+                # and the next prefill diff have run.
+                scheduler.add_job(
+                    enqueue_scheduled_prefill,
+                    trigger=IntervalTrigger(seconds=self._library_sync_interval_sec),
+                    args=(self._pool,),
+                    id=SCHEDULED_PREFILL_JOB_ID,
+                    name="Enqueue scheduled prefill (version-diff)",
                     replace_existing=True,
                 )
 

--- a/tests/api/test_block_list_router.py
+++ b/tests/api/test_block_list_router.py
@@ -1,0 +1,88 @@
+"""Tests for the block-list REST resource (F8): GET / POST / DELETE."""
+
+from __future__ import annotations
+
+VALID_TOKEN = "a" * 32
+AUTH = {"Authorization": f"Bearer {VALID_TOKEN}"}
+
+
+class TestBlockListPost:
+    async def test_post_creates_returns_201(self, client, populated_pool):
+        r = await client.post(
+            "/api/v1/block-list",
+            json={"platform": "steam", "app_id": "730", "reason": "no"},
+            headers=AUTH,
+        )
+        assert r.status_code == 201
+        body = r.json()
+        assert body["platform"] == "steam" and body["app_id"] == "730"
+        assert body["reason"] == "no" and body["source"] == "api"
+        assert set(body) == {"id", "platform", "app_id", "reason", "source", "blocked_at"}
+
+    async def test_post_idempotent_returns_200(self, client, populated_pool):
+        await client.post(
+            "/api/v1/block-list", json={"platform": "steam", "app_id": "730"}, headers=AUTH
+        )
+        r = await client.post(
+            "/api/v1/block-list", json={"platform": "steam", "app_id": "730"}, headers=AUTH
+        )
+        assert r.status_code == 200
+
+    async def test_post_accepts_unknown_app_id_preblock(self, client, populated_pool):
+        r = await client.post(
+            "/api/v1/block-list", json={"platform": "epic", "app_id": "never-seen"}, headers=AUTH
+        )
+        assert r.status_code == 201
+
+    async def test_post_rejects_extra_field_400(self, client, populated_pool):
+        # app remaps FastAPI's default 422 -> 400 (F9 convention)
+        r = await client.post(
+            "/api/v1/block-list",
+            json={"platform": "steam", "app_id": "1", "nope": 1},
+            headers=AUTH,
+        )
+        assert r.status_code == 400
+
+    async def test_post_rejects_bad_platform_400(self, client, populated_pool):
+        r = await client.post(
+            "/api/v1/block-list", json={"platform": "gog", "app_id": "1"}, headers=AUTH
+        )
+        assert r.status_code == 400
+
+    async def test_post_requires_auth_401(self, client, populated_pool):
+        r = await client.post("/api/v1/block-list", json={"platform": "steam", "app_id": "1"})
+        assert r.status_code == 401
+
+
+class TestBlockListGet:
+    async def test_get_empty_envelope(self, client, populated_pool):
+        async with populated_pool.write_transaction() as tx:
+            await tx.execute("DELETE FROM block_list")
+        r = await client.get("/api/v1/block-list", headers=AUTH)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["block_list"] == [] and body["meta"]["total"] == 0
+
+    async def test_get_filter_by_platform(self, client, populated_pool):
+        for p, a in [("steam", "1"), ("epic", "2")]:
+            await client.post("/api/v1/block-list", json={"platform": p, "app_id": a}, headers=AUTH)
+        r = await client.get("/api/v1/block-list?platform=steam", headers=AUTH)
+        rows = r.json()["block_list"]
+        assert [x["platform"] for x in rows] == ["steam"]
+
+    async def test_get_rejects_unknown_filter_400(self, client, populated_pool):
+        r = await client.get("/api/v1/block-list?bogus=1", headers=AUTH)
+        assert r.status_code == 400
+
+
+class TestBlockListDelete:
+    async def test_delete_present_removes_1(self, client, populated_pool):
+        await client.post(
+            "/api/v1/block-list", json={"platform": "steam", "app_id": "9"}, headers=AUTH
+        )
+        r = await client.delete("/api/v1/block-list/steam/9", headers=AUTH)
+        assert r.status_code == 200 and r.json() == {"removed": 1}
+
+    async def test_delete_absent_idempotent_removes_0(self, client, populated_pool):
+        r = await client.delete("/api/v1/block-list/steam/absent", headers=AUTH)
+        assert r.status_code == 200 and r.json() == {"removed": 0}

--- a/tests/api/test_games_router.py
+++ b/tests/api/test_games_router.py
@@ -87,6 +87,7 @@ class TestGamesHappyPath:
                 "last_prefilled_at",
                 "last_error",
                 "metadata",
+                "blocked",
             }
 
 
@@ -543,6 +544,7 @@ class TestGamesMetadata:
                     "last_prefilled_at": None,
                     "last_error": None,
                     "metadata": {"already-decoded": True},  # non-buffer type
+                    "blocked": 0,
                 }
             ]
 
@@ -581,6 +583,7 @@ class TestGamesMetadata:
                     "last_prefilled_at": None,
                     "last_error": None,
                     "metadata": None,
+                    "blocked": 0,
                 },
                 {
                     "id": 2,
@@ -596,6 +599,7 @@ class TestGamesMetadata:
                     "last_prefilled_at": None,
                     "last_error": None,
                     "metadata": None,
+                    "blocked": 0,
                 },
             ]
 
@@ -644,3 +648,18 @@ class TestGamesLastErrorTruncation:
         )
         game = next(g for g in r.json()["games"] if g["id"] == 1)
         assert len(game["last_error"]) == 200
+
+
+class TestGamesBlockedField:
+    async def test_blocked_true_when_in_block_list(self, client, populated_pool):
+        auth = {"Authorization": f"Bearer {'a' * 32}"}
+        first = (await client.get("/api/v1/games", headers=auth)).json()["games"][0]
+        await populated_pool.execute_write(
+            "INSERT INTO block_list (platform, app_id, source) VALUES (?, ?, 'api')",
+            (first["platform"], first["app_id"]),
+        )
+        body = (await client.get("/api/v1/games", headers=auth)).json()
+        match = next(x for x in body["games"] if x["id"] == first["id"])
+        assert match["blocked"] is True
+        others = [x for x in body["games"] if x["id"] != first["id"]]
+        assert all(x["blocked"] is False for x in others)

--- a/tests/cli/test_cmd_game.py
+++ b/tests/cli/test_cmd_game.py
@@ -79,3 +79,129 @@ def test_show_rejects_non_positive_id(cli_invoke):
     r = cli_invoke(["game", "show", "0"])
     assert r.exit_code == 2
     assert "positive" in (r.output + (r.stderr or "")).lower()
+
+
+def test_game_block_resolves_and_posts(mock):
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/api/v1/games":
+            return httpx.Response(
+                200,
+                json={
+                    "games": [
+                        {
+                            "id": 5,
+                            "platform": "steam",
+                            "app_id": "730",
+                            "title": "CS",
+                            "status": "up_to_date",
+                            "blocked": False,
+                        }
+                    ],
+                    "meta": {},
+                },
+            )
+        assert req.method == "POST" and req.url.path == "/api/v1/block-list"
+        import json as _j
+
+        assert _j.loads(req.content) == {
+            "platform": "steam",
+            "app_id": "730",
+            "reason": "x",
+            "source": "cli",
+        }
+        return httpx.Response(
+            201,
+            json={
+                "id": 1,
+                "platform": "steam",
+                "app_id": "730",
+                "reason": "x",
+                "source": "cli",
+                "blocked_at": "t",
+            },
+        )
+
+    r = mock(["game", "block", "5", "--reason", "x"], handler)
+    assert r.exit_code == 0 and "730" in r.output
+
+
+def test_game_block_unknown_id_exit_1(mock):
+    r = mock(
+        ["game", "block", "999"], lambda req: httpx.Response(200, json={"games": [], "meta": {}})
+    )
+    assert r.exit_code == 1
+
+
+def test_game_unblock_resolves_and_deletes(mock):
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/api/v1/games":
+            return httpx.Response(
+                200,
+                json={
+                    "games": [
+                        {
+                            "id": 5,
+                            "platform": "steam",
+                            "app_id": "730",
+                            "title": "CS",
+                            "status": "up_to_date",
+                            "blocked": True,
+                        }
+                    ],
+                    "meta": {},
+                },
+            )
+        assert req.method == "DELETE" and req.url.path == "/api/v1/block-list/steam/730"
+        return httpx.Response(200, json={"removed": 1})
+
+    r = mock(["game", "unblock", "5"], handler)
+    assert r.exit_code == 0
+
+
+def test_game_list_shows_blocked_column(mock):
+    games = {
+        "games": [
+            {
+                "id": 5,
+                "platform": "steam",
+                "app_id": "730",
+                "title": "CS",
+                "status": "up_to_date",
+                "blocked": True,
+            }
+        ],
+        "meta": {},
+    }
+    r = mock(["game", "list"], lambda req: httpx.Response(200, json=games))
+    assert r.exit_code == 0 and "BLOCKED" in r.output
+
+
+def test_game_unblock_url_encodes_app_id(mock):
+    """An app_id with a slash (Epic appName) must be percent-encoded so it stays
+    a single path segment and doesn't mis-route (SEV-4 adversarial finding)."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/api/v1/games":
+            return httpx.Response(
+                200,
+                json={
+                    "games": [
+                        {
+                            "id": 5,
+                            "platform": "epic",
+                            "app_id": "a/b",
+                            "title": "X",
+                            "status": "unknown",
+                            "blocked": True,
+                        }
+                    ],
+                    "meta": {},
+                },
+            )
+        raw = req.url.raw_path.decode()
+        assert "%2F" in raw.upper(), raw
+        assert "/epic/a/b" not in raw
+        return httpx.Response(200, json={"removed": 1})
+
+    r = mock(["game", "unblock", "5"], handler)
+    assert r.exit_code == 0

--- a/tests/db/test_pool_property.py
+++ b/tests/db/test_pool_property.py
@@ -129,7 +129,10 @@ class TestShape:
             # (unlikely but possible for the literal string "int", "str", etc.)
             # we tolerate that collision. Otherwise raw values must not appear.
             v_str = str(v)
-            if v_str in {"int", "str", "bool", "float", "bytes", "NoneType"}:
+            # "None" is a substring of the legitimately-emitted "NoneType", so a
+            # string value "None" is indistinguishable from the type name and
+            # must be tolerated alongside exact type-name collisions.
+            if v_str in {"int", "str", "bool", "float", "bytes", "NoneType", "None"}:
                 continue
             # Numeric values: their str form might appear in a type name like
             # "int" — guard against that too. But since type names don't

--- a/tests/jobs/test_epic_handlers.py
+++ b/tests/jobs/test_epic_handlers.py
@@ -166,3 +166,32 @@ async def test_epic_prefill_requires_client(pool):
         await prefill_handler(
             _job("prefill", gid), Deps(pool=pool, steam_client=None, epic_client=None)
         )
+
+
+async def test_epic_library_sync_writes_current_version(pool):
+    stub = _StubEpic(items=[EpicLibraryItem("AppA", "ns", "cat", "Game A", build_version="bv-1")])
+    await library_sync_handler(
+        _job("library_sync"), Deps(pool=pool, steam_client=None, epic_client=stub)
+    )
+    row = await pool.read_one("SELECT current_version FROM games WHERE platform='epic'")
+    assert row["current_version"] == "bv-1"
+
+
+async def test_epic_prefill_sets_cached_version(pool, monkeypatch):
+    gid = await _seed_epic_game(pool)
+    await pool.execute_write("UPDATE games SET current_version='bv-1' WHERE id=?", (gid,))
+    stub = _StubEpic(manifest=_manifest())
+
+    async def fake_prefill(paths, host, base, settings, **kw):
+        return EpicPrefillResult(len(paths), len(paths), 0)
+
+    async def fake_verify(paths, host, base, settings, **kw):
+        return 1.0
+
+    monkeypatch.setattr(ph, "epic_prefill_chunks", fake_prefill)
+    monkeypatch.setattr(ph, "epic_verify_cached", fake_verify)
+    await prefill_handler(
+        _job("prefill", gid), Deps(pool=pool, steam_client=None, epic_client=stub)
+    )
+    g = await pool.read_one("SELECT cached_version FROM games WHERE id=?", (gid,))
+    assert g["cached_version"] == "bv-1"

--- a/tests/jobs/test_library_sync_handler.py
+++ b/tests/jobs/test_library_sync_handler.py
@@ -241,3 +241,30 @@ class TestErrorPropagation:
             await library_sync_handler(_job(), Deps(pool=pool, steam_client=stub))
         rows = await pool.read_all("SELECT id FROM games")
         assert rows == []
+
+
+class TestCurrentVersion:
+    async def test_steam_sync_writes_current_version(self, pool):
+        stub = _StubSteam(
+            result={"apps": [{"app_id": 730, "name": "CS2", "depots": [731], "version": "42"}]}
+        )
+        await library_sync_handler(_job(), Deps(pool=pool, steam_client=stub))
+        row = await pool.read_one("SELECT current_version FROM games WHERE app_id='730'")
+        assert row["current_version"] == "42"
+
+    async def test_steam_sync_preserves_cached_version_and_status(self, pool):
+        await pool.execute_write(
+            "INSERT INTO games "
+            "(platform, app_id, title, owned, status, cached_version, current_version)"
+            " VALUES ('steam','730','Old',1,'up_to_date','99','99')"
+        )
+        stub = _StubSteam(
+            result={"apps": [{"app_id": 730, "name": "CS2", "depots": [731], "version": "42"}]}
+        )
+        await library_sync_handler(_job(), Deps(pool=pool, steam_client=stub))
+        row = await pool.read_one(
+            "SELECT status, cached_version, current_version FROM games WHERE app_id='730'"
+        )
+        assert row["status"] == "up_to_date"  # untouched
+        assert row["cached_version"] == "99"  # untouched
+        assert row["current_version"] == "42"  # updated

--- a/tests/jobs/test_prefill_handler.py
+++ b/tests/jobs/test_prefill_handler.py
@@ -179,3 +179,75 @@ async def test_chunk_failure_last_error_includes_reason(pool, monkeypatch):
         await prefill_handler(_job(game_id), Deps(pool=pool, steam_client=_StubSteam()))
     g = await pool.read_one("SELECT last_error FROM games WHERE id=?", (game_id,))
     assert "http 403" in g["last_error"]
+
+
+async def test_full_success_sets_cached_version(pool, monkeypatch):
+    game_id = await _seed_game(pool)
+    await _seed_manifest(pool, game_id)
+    await pool.execute_write(
+        "UPDATE games SET current_version='42', status='downloading' WHERE id=?", (game_id,)
+    )
+
+    async def fake_prefill(uris, settings, *, on_progress=None):
+        return PrefillResult(len(uris), len(uris), 0)
+
+    monkeypatch.setattr("orchestrator.jobs.handlers.prefill.prefill_chunks", fake_prefill)
+    await prefill_handler(_job(game_id), Deps(pool=pool, steam_client=_StubSteam()))
+    row = await pool.read_one(
+        "SELECT cached_version, last_prefilled_at FROM games WHERE id=?", (game_id,)
+    )
+    assert row["cached_version"] == "42"
+    assert row["last_prefilled_at"] is not None
+
+
+async def test_partial_failure_leaves_cached_version_stale(pool, monkeypatch):
+    game_id = await _seed_game(pool)
+    await _seed_manifest(pool, game_id)
+    await pool.execute_write(
+        "UPDATE games SET current_version='42', cached_version='OLD' WHERE id=?", (game_id,)
+    )
+
+    async def fake_prefill(uris, settings, *, on_progress=None):
+        return PrefillResult(len(uris), 0, len(uris), [("/depot/731/chunk/x", "http 500")])
+
+    monkeypatch.setattr("orchestrator.jobs.handlers.prefill.prefill_chunks", fake_prefill)
+    with pytest.raises(RuntimeError):
+        await prefill_handler(_job(game_id), Deps(pool=pool, steam_client=_StubSteam()))
+    row = await pool.read_one("SELECT cached_version FROM games WHERE id=?", (game_id,))
+    assert row["cached_version"] == "OLD"
+
+
+async def test_diverged_game_refetches_manifest(pool, monkeypatch):
+    """S2-2: a version-diverged game (cached != current) must re-fetch a fresh
+    manifest even though stale manifests exist, so it caches current content."""
+    game_id = await _seed_game(pool)
+    await _seed_manifest(pool, game_id)  # stale manifest already present
+    await pool.execute_write(
+        "UPDATE games SET cached_version='41', current_version='42' WHERE id=?", (game_id,)
+    )
+    stub = _StubSteam()
+
+    async def fake_prefill(uris, settings, *, on_progress=None):
+        return PrefillResult(len(uris), len(uris), 0)
+
+    monkeypatch.setattr("orchestrator.jobs.handlers.prefill.prefill_chunks", fake_prefill)
+    await prefill_handler(_job(game_id), Deps(pool=pool, steam_client=stub))
+    assert stub.fetch_calls == 1  # refetched despite the existing manifest
+
+
+async def test_up_to_date_reprefill_reuses_manifest(pool, monkeypatch):
+    """A redundant re-prefill of an up-to-date game (cached == current) reuses the
+    existing manifest — no wasted fetch."""
+    game_id = await _seed_game(pool)
+    await _seed_manifest(pool, game_id)
+    await pool.execute_write(
+        "UPDATE games SET cached_version='42', current_version='42' WHERE id=?", (game_id,)
+    )
+    stub = _StubSteam()
+
+    async def fake_prefill(uris, settings, *, on_progress=None):
+        return PrefillResult(len(uris), len(uris), 0)
+
+    monkeypatch.setattr("orchestrator.jobs.handlers.prefill.prefill_chunks", fake_prefill)
+    await prefill_handler(_job(game_id), Deps(pool=pool, steam_client=stub))
+    assert stub.fetch_calls == 0  # reused

--- a/tests/jobs/test_validate_handler.py
+++ b/tests/jobs/test_validate_handler.py
@@ -188,3 +188,28 @@ async def test_validate_handler_registered():
 
     _register_builtin_handlers()
     assert "validate" in HANDLERS
+
+
+async def test_validate_never_writes_cached_version(pool, monkeypatch):
+    """F8 prefill-sole-writer: validate updates status but NEVER cached_version,
+    even on a clean outcome (a standalone sweep may validate a stale manifest)."""
+    from orchestrator.core.settings import get_settings
+    from orchestrator.jobs.handlers.validate import validate_one_game
+    from orchestrator.validator.disk_stat import ValidationResult
+
+    game_id = await _seed_game(pool)
+    await pool.execute_write(
+        "UPDATE games SET current_version='42', cached_version='OLD', status='unknown' WHERE id=?",
+        (game_id,),
+    )
+
+    async def fake_validate(p, d, gid, s):
+        return ValidationResult(3, 3, 0, "cached", "42")
+
+    monkeypatch.setattr("orchestrator.jobs.handlers.validate.validate_game", fake_validate)
+    await validate_one_game(
+        pool, Deps(pool=pool, steam_client=_StubSteam(None)), game_id, get_settings()
+    )
+    row = await pool.read_one("SELECT status, cached_version FROM games WHERE id=?", (game_id,))
+    assert row["status"] == "up_to_date"  # status still updates
+    assert row["cached_version"] == "OLD"  # cached_version untouched by validate

--- a/tests/platform/epic/test_library.py
+++ b/tests/platform/epic/test_library.py
@@ -60,3 +60,22 @@ async def test_enumerate_error_raises(monkeypatch):
     )
     with pytest.raises(ep_lib.EpicLibraryError):
         await ep_lib.enumerate_library("TOK", _settings())
+
+
+async def test_to_item_carries_build_version():
+    item = ep_lib._to_item(
+        {
+            "appName": "Fortnite",
+            "namespace": "fn",
+            "catalogItemId": "abc",
+            "buildVersion": "++Fortnite-29.00",
+        }
+    )
+    assert item is not None
+    assert item.build_version == "++Fortnite-29.00"
+
+
+async def test_to_item_build_version_optional():
+    item = ep_lib._to_item({"appName": "X", "namespace": "n", "catalogItemId": "c"})
+    assert item is not None
+    assert item.build_version is None

--- a/tests/platform/steam/test_enumerate.py
+++ b/tests/platform/steam/test_enumerate.py
@@ -206,12 +206,14 @@ class TestExtractAppMetadata:
             }
         }
         out = _extract_app_metadata(resp, [730])
-        assert out == [{"app_id": 730, "name": "Counter-Strike 2", "depots": [731, 734]}]
+        assert out == [
+            {"app_id": 730, "name": "Counter-Strike 2", "depots": [731, 734], "version": None}
+        ]
 
     def test_falls_back_to_string_key(self):
         resp = {"apps": {"730": {"common": {"name": "CS2"}, "depots": {}}}}
         out = _extract_app_metadata(resp, [730])
-        assert out == [{"app_id": 730, "name": "CS2", "depots": []}]
+        assert out == [{"app_id": 730, "name": "CS2", "depots": [], "version": None}]
 
     def test_skips_missing_common_name(self):
         """Better than synthesizing placeholder names that pollute games table."""
@@ -252,7 +254,9 @@ class TestEnumerateApps:
             ],
         )
         out = enumerate_apps(c)
-        assert out == [{"app_id": 730, "name": "Counter-Strike 2", "depots": [731, 734]}]
+        assert out == [
+            {"app_id": 730, "name": "Counter-Strike 2", "depots": [731, 734], "version": None}
+        ]
         # Verify the package call passes access token and auto_access_tokens=False
         pkg_call = next(kwargs for op, kwargs in c.calls if "packages" in kwargs)
         assert pkg_call["packages"] == [{"packageid": 730, "access_token": 42}]
@@ -403,3 +407,46 @@ class TestManifestGidExtraction:
 
         assert manifest_gids_for_app(None) == []
         assert manifest_gids_for_app([]) == []
+
+
+class TestAppVersionToken:
+    def test_prefers_public_branch_buildid(self):
+        from orchestrator.platform.steam.enumerate import _app_version_token
+
+        depots = {"branches": {"public": {"buildid": "1788499"}}, "1234": {"manifests": {}}}
+        assert _app_version_token(depots) == "1788499"
+
+    def test_composite_when_no_buildid(self):
+        from orchestrator.platform.steam.enumerate import _app_version_token
+
+        depots = {
+            "1234": {"manifests": {"public": {"gid": "555"}}},
+            "1200": {"manifests": {"public": {"gid": "777"}}},
+        }
+        tok = _app_version_token(depots)
+        # order-independent: same pairs -> same token
+        assert tok == _app_version_token(
+            {
+                "1200": {"manifests": {"public": {"gid": "777"}}},
+                "1234": {"manifests": {"public": {"gid": "555"}}},
+            }
+        )
+        assert tok is not None and tok != "1788499"
+
+    def test_none_when_no_version_info(self):
+        from orchestrator.platform.steam.enumerate import _app_version_token
+
+        assert _app_version_token({"branches": {"public": {}}}) is None
+        assert _app_version_token(None) is None
+
+    def test_extract_app_metadata_includes_version(self):
+        apps_response = {
+            "apps": {
+                "10": {
+                    "common": {"name": "Game"},
+                    "depots": {"branches": {"public": {"buildid": "42"}}, "11": {"manifests": {}}},
+                }
+            }
+        }
+        out = _extract_app_metadata(apps_response, [10])
+        assert out == [{"app_id": 10, "name": "Game", "depots": [11], "version": "42"}]

--- a/tests/scheduler/test_jobs.py
+++ b/tests/scheduler/test_jobs.py
@@ -144,3 +144,70 @@ class TestEnqueueValidationSweep:
 
         pool.execute_write = AsyncMock(side_effect=PoolError("simulated"))
         assert await enqueue_validation_sweep(pool) == 0  # never raises
+
+
+async def _seed_game(
+    pool, app_id, *, owned=1, current="42", cached=None, status="up_to_date", platform="steam"
+):
+    await pool.execute_write(
+        "INSERT INTO games "
+        "(platform, app_id, title, owned, current_version, cached_version, status)"
+        " VALUES (?, ?, 'G', ?, ?, ?, ?)",
+        (platform, app_id, owned, current, cached, status),
+    )
+
+
+class TestEnqueueScheduledPrefill:
+    async def test_enqueues_never_cached(self, pool):
+        from orchestrator.scheduler.jobs import enqueue_scheduled_prefill
+
+        await _seed_game(pool, "1", current="42", cached=None)
+        n = await enqueue_scheduled_prefill(pool)
+        assert n == 1
+        row = await pool.read_one("SELECT kind, platform, state, source FROM jobs LIMIT 1")
+        assert (row["kind"], row["state"], row["source"]) == ("prefill", "queued", "scheduler")
+
+    async def test_enqueues_when_version_diverged(self, pool):
+        from orchestrator.scheduler.jobs import enqueue_scheduled_prefill
+
+        await _seed_game(pool, "1", current="42", cached="41")
+        assert await enqueue_scheduled_prefill(pool) == 1
+
+    async def test_enqueues_validation_failed(self, pool):
+        from orchestrator.scheduler.jobs import enqueue_scheduled_prefill
+
+        await _seed_game(pool, "1", current="42", cached="42", status="validation_failed")
+        assert await enqueue_scheduled_prefill(pool) == 1
+
+    async def test_skips_up_to_date(self, pool):
+        from orchestrator.scheduler.jobs import enqueue_scheduled_prefill
+
+        await _seed_game(pool, "1", current="42", cached="42", status="up_to_date")
+        assert await enqueue_scheduled_prefill(pool) == 0
+
+    async def test_skips_unowned(self, pool):
+        from orchestrator.scheduler.jobs import enqueue_scheduled_prefill
+
+        await _seed_game(pool, "1", owned=0, current="42", cached=None)
+        assert await enqueue_scheduled_prefill(pool) == 0
+
+    async def test_skips_blocked(self, pool):
+        from orchestrator.scheduler.jobs import enqueue_scheduled_prefill
+
+        await _seed_game(pool, "1", current="42", cached=None)
+        await pool.execute_write(
+            "INSERT INTO block_list (platform, app_id, source) VALUES ('steam','1','api')"
+        )
+        assert await enqueue_scheduled_prefill(pool) == 0
+
+    async def test_dedups_inflight_prefill(self, pool):
+        from orchestrator.scheduler.jobs import enqueue_scheduled_prefill
+
+        await _seed_game(pool, "1", current="42", cached=None)
+        gid = (await pool.read_one("SELECT id FROM games LIMIT 1"))["id"]
+        await pool.execute_write(
+            "INSERT INTO jobs (kind, game_id, platform, state, source)"
+            " VALUES ('prefill', ?, 'steam', 'queued', 'api')",
+            (gid,),
+        )
+        assert await enqueue_scheduled_prefill(pool) == 0

--- a/tests/scheduler/test_manager.py
+++ b/tests/scheduler/test_manager.py
@@ -277,3 +277,37 @@ class TestSchedulerManager:
             assert running[0] is mgr._scheduler
         finally:
             await mgr.shutdown()
+
+
+class TestScheduledPrefillRegistration:
+    async def test_registers_scheduled_prefill_job(self, pool):
+        from orchestrator.scheduler.manager import SCHEDULED_PREFILL_JOB_ID
+
+        mgr = SchedulerManager(
+            pool=pool,
+            enabled=True,
+            library_sync_interval_sec=21600,
+            validation_sweep_enabled=False,
+            scheduled_prefill_enabled=True,
+        )
+        await mgr.start()
+        try:
+            assert SCHEDULED_PREFILL_JOB_ID in mgr.get_registered_job_ids()
+        finally:
+            await mgr.shutdown()
+
+    async def test_scheduled_prefill_disabled_not_registered(self, pool):
+        from orchestrator.scheduler.manager import SCHEDULED_PREFILL_JOB_ID
+
+        mgr = SchedulerManager(
+            pool=pool,
+            enabled=True,
+            library_sync_interval_sec=21600,
+            validation_sweep_enabled=False,
+            scheduled_prefill_enabled=False,
+        )
+        await mgr.start()
+        try:
+            assert SCHEDULED_PREFILL_JOB_ID not in mgr.get_registered_job_ids()
+        finally:
+            await mgr.shutdown()


### PR DESCRIPTION
## F8 — Block List + Scheduled Prefill Driver

The last orchestrator-repo MVP feature before the Game_shelf integration (F14–F17). Makes the orchestrator the **automatic Steam+Epic prefill driver** (completes F12's "diff enqueues prefills"): a scheduled 6h cycle prefills only games that are new, version-diverged, or `validation_failed`, with an operator block-list to exclude games. **No DB migration** — `block_list` and the `current_version`/`cached_version` columns already shipped in `0001_initial.sql`.

### What's in it
- **Block-list REST resource** `GET/POST/DELETE /api/v1/block-list` — paginated F9 envelope + allow-list filters; idempotent POST (`201`/`200`, pre-block of unknown `app_id` OK); idempotent DELETE `{removed}`. Single source of truth (never mutates `games.status`).
- **CLI** `game block <id> [--reason]` / `game unblock <id>` (+ `BLOCKED` column on `game list`); `OrchClient.delete`.
- **`games.blocked`** flag via a correlated `EXISTS` subquery (no JOIN → no filter ambiguity).
- **`enqueue_scheduled_prefill`** — the version-diff insert, registered on the library-sync interval (`scheduled_prefill_enabled`).
- **Version tracking** — `library_sync` writes `current_version` (steam buildid / depot-gid composite; epic buildVersion); prefill is the sole `cached_version` writer and steam prefill re-fetches a fresh manifest when version-diverged so patches cache current content.

### Quality
- **Adversarial review** caught and we fixed test-first: two SEV-2 correctness defects (Epic infinite re-prefill; steam stale-manifest false version-stamp) + one SEV-4 (CLI `unblock` URL-encoding). Security audit: `docs/security-audits/f8-block-list-security-audit.md`.
- Full suite **1253 pass**; `ruff` / `mypy --strict` / `semgrep` / `gitleaks` clean.
- Second commit (`test(pool): …`) is an **unrelated** pre-existing Hypothesis flake fix (fails on `main` too), kept separate from the feature.

### Notes for review
- **Cold-start adoption** is a WAN-free prefill pass (all cache HITs), not stat-only — a game cached by external tools has no orchestrator manifest to validate against. A chunk-level disk-stat skip is a clean future optimization.
- **Scheduled Steam prefill needs a valid session**; **live UAT pending** (needs a Steam 2FA login to prove the full driver cycle).
- Orchestrator role = **driver**, intended to retire the host Steam/Epic prefill cron after a live parallel-run (GOG + chmod-heal cron stay).

Spec: `docs/superpowers/specs/2026-06-17-f8-block-list-design.md` · Plan: `docs/superpowers/plans/2026-06-17-f8-block-list.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)