### PR TITLE
feat(api): LAN-bind source-IP allowlist + fail-closed bind guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Security — LAN-bind source-IP allowlist + fail-closed boot guard — 2026-06-18
+
+- Source-IP allowlist (`SourceAllowlistMiddleware`) gates all API paths to loopback + `ORCH_ALLOWED_SOURCE_IPS` when bound off-loopback; defense-in-depth over the bearer token for LAN exposure.
+- Fail-closed boot guard: a non-loopback bind with no `ORCH_ALLOWED_SOURCE_IPS` refuses to start.
+
+### Added — `ORCH_ALLOWED_SOURCE_IPS` source-IP allowlist setting — 2026-06-18
+
+- `ORCH_ALLOWED_SOURCE_IPS` setting (comma-separated IPs/CIDRs) + `Settings.allowed_source_networks`.
+
+### Infrastructure — LAN-exposure deploy recipe documented — 2026-06-18
+
+- Documented LAN-exposure deploy recipe (LAN-scoped docker publish + host nftables rule) in README.
+
 ### Added — F8 block list + scheduled prefill driver (version-diff) — 2026-06-17
 
 The orchestrator becomes the automatic **Steam+Epic prefill driver** (completes F12's "diff enqueues prefills"): a 6h cycle prefills only the games that actually changed, with an operator block-list to exclude games.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1261,4 +1261,49 @@ plan `docs/superpowers/plans/2026-06-17-f8-block-list.md`.
 
 ---
 
+## Feature 23: LAN-Bind Source-IP Allowlist
+
+**Phase Built:** 2 (Milestone B / Game_shelf integration enabler)
+**Status:** Complete (2026-06-18)
+
+**Summary:** Lets the orchestrator be safely exposed off-loopback (e.g. for the
+Game_shelf backend on another host) by gating every API path to loopback plus an
+explicit source-IP allowlist. Adds the `ORCH_ALLOWED_SOURCE_IPS` setting
+(comma-separated IPs/CIDRs, default empty), a `SourceAllowlistMiddleware` that
+403s any non-loopback, non-allowlisted source on every path, and a fail-closed
+boot guard that refuses to start when bound off-loopback with an empty allowlist.
+Defense-in-depth over the bearer token. The OQ2 loopback-only surfaces
+(credential-intake `POST /platforms/{name}/auth`, 2FA-submit, OpenAPI schema,
+Swagger / ReDoc) are unchanged — an allowlisted-but-remote host still gets 403 on
+those. **No DB migration.**
+
+**Key Interfaces:**
+  - `src/orchestrator/core/settings.py` — `ORCH_ALLOWED_SOURCE_IPS` /
+    `Settings.allowed_source_networks` (parsed IP/CIDR networks)
+  - `src/orchestrator/api/middleware.py::SourceAllowlistMiddleware` — per-request
+    source gate (pure no-op when the allowlist is empty)
+  - `src/orchestrator/api/main.py` — middleware registration + the fail-closed
+    boot guard (`api.boot.lan_bind_without_allowlist` + `SystemExit`)
+
+**Locked decisions:**
+  - **Loopback is always allowed**; the allowlist only adds remote sources.
+  - **Fail-closed:** off-loopback bind + empty allowlist refuses to start (no
+    accidental open-to-the-world exposure).
+  - **OQ2 surfaces stay loopback-only** regardless of the allowlist.
+  - **No reverse proxy:** OQ2 + the allowlist read `scope["client"]` directly, so
+    uvicorn is bound directly (a proxy would mask the true source IP).
+
+**Test Coverage:** middleware allow/deny (loopback, allowlisted IP/CIDR, denied
+source, empty-allowlist no-op), boot-guard refusal, and OQ2 loopback-only paths
+still 403 a remote allowlisted host.
+
+**Related docs:** README "Running the API (BL5+)" LAN-exposure recipe
+(LAN-scoped docker publish + host nftables rule).
+
+**Known Limitations:**
+  - **Source IP must be the real client** — reading `scope["client"]` means a
+    reverse proxy or NAT in front would collapse all sources to one address.
+
+---
+
 <!-- Copy the section above for each new feature. Number sequentially. -->

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ The bearer token (`orchestrator_token`) is the only required field. Every other 
 | Env var | Type | Default | Notes |
 |---|---|---|---|
 | `ORCH_TOKEN` *(or secrets file `orchestrator_token`)* | string ≥32 chars | **required** | API bearer; whitespace stripped |
-| `ORCH_API_HOST` | string | `127.0.0.1` | Warns if not loopback |
+| `ORCH_API_HOST` | string | `127.0.0.1` | Off-loopback requires `ORCH_ALLOWED_SOURCE_IPS` (else refuses to start) |
+| `ORCH_ALLOWED_SOURCE_IPS` | comma-separated IPs/CIDRs | `[]` | Source-IP allowlist for LAN exposure. **Required** (non-empty) when `ORCH_API_HOST` is non-loopback. Loopback always allowed. |
 | `ORCH_API_PORT` | int (1..65535) | `8765` | |
 | `ORCH_CORS_ORIGINS` | JSON list | `[]` | Warns on `"*"` |
 | `ORCH_LOG_LEVEL` | DEBUG / INFO / WARNING / ERROR / CRITICAL | `INFO` | |
@@ -135,7 +136,25 @@ uvicorn orchestrator.api.main:create_app --factory --host 127.0.0.1 --port 8765
 
 The lifespan runs migrations + initializes the BL4 DB pool on startup; closes the pool with a 30 s hard timeout on shutdown.
 
-**Loopback restriction:** the OpenAPI schema (`/api/v1/openapi.json`) and the Swagger / ReDoc UIs (`/api/v1/docs`, `/api/v1/redoc`) are loopback-only. Browsing them on a non-loopback bind returns 403. If you bind the orchestrator to a non-loopback interface, expect a `api.boot.non_loopback_bind_warning` log line at startup — and note that **OQ2 loopback enforcement reads `scope["client"]` directly**, so a reverse proxy in front of the app silently disables OQ2. Either bind to a unix socket the proxy alone can reach, or enforce the equivalent gate at the proxy layer.
+**LAN exposure (e.g. for Game_shelf).** To reach the API from another host, bind off-loopback AND declare the allowed source(s):
+
+```bash
+# Container binds all interfaces in its namespace; the host publish is scoped
+# to the LAN NIC so the port is not exposed on other host interfaces.
+docker run -e ORCH_API_HOST=0.0.0.0 \
+           -e ORCH_ALLOWED_SOURCE_IPS=10.100.23.102 \
+           -p 192.168.1.40:8765:8765 ...
+```
+
+The `SourceAllowlistMiddleware` returns 403 for any source that is not loopback or in `ORCH_ALLOWED_SOURCE_IPS`, on every path. A non-loopback bind with an empty allowlist **refuses to start** (`api.boot.lan_bind_without_allowlist`). As an outer layer, also restrict the port at the host firewall, e.g. nftables:
+
+```
+# allow only Game_shelf to reach the orchestrator port; drop the rest
+nft add rule inet filter input ip saddr 10.100.23.102 tcp dport 8765 accept
+nft add rule inet filter input tcp dport 8765 drop
+```
+
+**Loopback restriction:** the OpenAPI schema (`/api/v1/openapi.json`), the Swagger / ReDoc UIs (`/api/v1/docs`, `/api/v1/redoc`), and the credential-intake endpoints (`POST /api/v1/platforms/{name}/auth` + 2FA-submit) are loopback-only. An allowlisted-but-remote host still receives 403 on those paths — they are never reachable over the LAN regardless of `ORCH_ALLOWED_SOURCE_IPS`. **OQ2 enforcement reads `scope["client"]` directly**, so a reverse proxy in front of the app would make every request appear to originate from the proxy and silently defeat both OQ2 and the source-IP allowlist. This design binds uvicorn directly — do **not** place a reverse proxy in front of it.
 
 **BL5 health-check note:** `GET /api/v1/health` returns **HTTP 503** until BL6+ ships the scheduler, Lancache self-test, and validator subsystems. The body still contains the 7-field response so operators can see exactly which subsystems are unhealthy. Container `HEALTHCHECK` and k8s liveness probes should expect 503 during this transition window. The unauth response truncates `git_sha` to 8 chars; full SHA is reserved for authenticated/internal observability surfaces. See [ADR-0012](docs/ADR%20documentation/0012-fastapi-skeleton-architecture.md) for the design rationale.
 

--- a/docs/superpowers/plans/2026-06-18-lan-bind-allowlist.md
+++ b/docs/superpowers/plans/2026-06-18-lan-bind-allowlist.md
@@ -1,0 +1,817 @@
+# Orchestrator LAN-bind + Source-IP Allowlist Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the orchestrator API be bound to the LAN for Game_shelf while a fail-closed, application-level source-IP allowlist guarantees only declared sources can connect — and an off-loopback bind without an allowlist refuses to start.
+
+**Architecture:** The bind itself is already env-driven (`ORCH_API_HOST` → uvicorn `--host`). This plan adds (1) an `allowed_source_ips` setting, (2) a dedicated `SourceAllowlistMiddleware` that 403s non-allowlisted sources on every path but is a pure no-op when the allowlist is empty, and (3) a fail-closed boot guard. OQ2's existing loopback-only gate (credential/2FA/schema endpoints) is untouched and keeps those endpoints unreachable from the LAN automatically.
+
+**Tech Stack:** Python 3.12, FastAPI, pure-ASGI middleware, pydantic-settings v2, pytest + pytest-asyncio + httpx ASGITransport. Spec: `docs/superpowers/specs/2026-06-18-lan-bind-allowlist-design.md` (committed 84e4c91).
+
+---
+
+## Context the engineer needs (read before starting)
+
+- **Branch:** `feat/lan-bind-allowlist` (already checked out, off `main`).
+- **Framework hooks are active** in this repo. Per the build loop, this plan uses **no per-task commits** — all tasks are implemented TDD-style, then a SINGLE `feat` commit at the end (Task 7) after presenting A/B/C commit-structure options. The framework process-checklist may gate the commit; follow its prompts.
+- **enforce-context7:** editing `core/settings.py` introduces `pydantic_settings.NoDecode`. If the hook blocks the edit, run `resolve-library-id` for the exact package `pydantic-settings`, then `query-docs` "NoDecode comma-separated env list field" before retrying. (Other edited files import already-used libs.)
+- **Run tests:** `python -m pytest <path> -q` from the repo root. The full suite is `python -m pytest -q`.
+- **Existing security machinery (do NOT change):**
+  - OQ2 loopback gate lives in `BearerAuthMiddleware.__call__` (`api/middleware.py:225`), reading `scope["client"][0]` against `LOOPBACK_HOSTS` (`api/dependencies.py:75` = `{"127.0.0.1","::1","::ffff:127.0.0.1"}`).
+  - `settings.py` emits a `config.api_bound_non_loopback` **warning** (model-validator `_emit_config_warnings`, `settings.py:352`) — keep it; it coexists with the new boot guard. `Settings(api_host="0.0.0.0")` must remain constructible (policy is enforced at boot, not config-load).
+- **Test fixtures (httpx ASGITransport) already exist** in `tests/api/conftest.py`:
+  - `client` → default transport, client host `127.0.0.1` (loopback).
+  - `loopback_client` → `client=("127.0.0.1", 12345)`.
+  - `external_client` → `client=("192.168.1.100", 54321)` (non-loopback).
+  - `unit_app` → `create_app()` with pool dep overridden, no lifespan; its settings have an **empty** allowlist (no env set), so the new middleware is a no-op there and the whole existing suite stays green.
+- **Settings override pattern:** `get_settings()` is `@lru_cache`d; tests do `monkeypatch.setenv("ORCH_…", …)` then `get_settings.cache_clear()`. A valid token for constructing `Settings` directly is any 32-char string, e.g. `"t" * 32`.
+
+## File Structure
+
+- **Modify** `src/orchestrator/core/settings.py` — add `allowed_source_ips` field (NoDecode + comma-split before-validator + CIDR after-validator) and an `allowed_source_networks` property.
+- **Modify** `src/orchestrator/api/middleware.py` — add `import ipaddress`, the pure `_is_source_allowed` helper, and `SourceAllowlistMiddleware`.
+- **Modify** `src/orchestrator/api/main.py` — import + register `SourceAllowlistMiddleware`; add `_enforce_lan_bind_policy(settings)`; call it at the top of `_lifespan`; remove the old non-loopback warning block.
+- **Create** `tests/api/test_source_allowlist.py` — pure-matcher + middleware + boot-guard tests.
+- **Modify** `tests/core/test_settings.py` — `allowed_source_ips` parsing/validation tests.
+- **Modify** `README.md` — env-table row + LAN-exposure run section; update the stale warning paragraph.
+- **Modify** `CHANGELOG.md`, `FEATURES.md` — record the feature.
+
+---
+
+### Task 1: `allowed_source_ips` setting + parsing + validation
+
+**Files:**
+- Modify: `src/orchestrator/core/settings.py`
+- Test: `tests/core/test_settings.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/core/test_settings.py` (it already imports `Settings` and uses a `VALID_TOKEN` 32-char constant — reuse them; if `VALID_TOKEN` isn't in scope in your class, use `"t" * 32`):
+
+```python
+class TestAllowedSourceIps:
+    def test_default_is_empty(self):
+        s = Settings(orchestrator_token="t" * 32)
+        assert s.allowed_source_ips == []
+        assert s.allowed_source_networks == []
+
+    def test_comma_separated_string_parses_to_list(self, monkeypatch):
+        monkeypatch.setenv("ORCH_TOKEN", "t" * 32)
+        monkeypatch.setenv("ORCH_ALLOWED_SOURCE_IPS", " 10.100.23.102 , 10.0.0.0/24 ")
+        from orchestrator.core.settings import get_settings
+        get_settings.cache_clear()
+        s = get_settings()
+        assert s.allowed_source_ips == ["10.100.23.102", "10.0.0.0/24"]
+        get_settings.cache_clear()
+
+    def test_list_input_passes_through(self):
+        s = Settings(orchestrator_token="t" * 32, allowed_source_ips=["10.100.23.102"])
+        assert s.allowed_source_ips == ["10.100.23.102"]
+
+    def test_allowed_source_networks_parses_entries(self):
+        s = Settings(orchestrator_token="t" * 32, allowed_source_ips=["10.100.23.102", "10.0.0.0/24"])
+        import ipaddress
+        nets = s.allowed_source_networks
+        assert ipaddress.ip_address("10.100.23.102") in nets[0]
+        assert ipaddress.ip_address("10.0.0.55") in nets[1]
+
+    def test_invalid_cidr_rejected_at_construction(self):
+        import pytest
+        with pytest.raises(Exception):  # pydantic ValidationError
+            Settings(orchestrator_token="t" * 32, allowed_source_ips=["10.0.0.0/99"])
+
+    def test_invalid_ip_rejected_at_construction(self):
+        import pytest
+        with pytest.raises(Exception):
+            Settings(orchestrator_token="t" * 32, allowed_source_ips=["not-an-ip"])
+
+    def test_allow_any_entry_is_accepted(self):
+        s = Settings(orchestrator_token="t" * 32, allowed_source_ips=["0.0.0.0/0"])
+        import ipaddress
+        assert ipaddress.ip_address("8.8.8.8") in s.allowed_source_networks[0]
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `python -m pytest tests/core/test_settings.py::TestAllowedSourceIps -q`
+Expected: FAIL — `AttributeError: 'Settings' object has no attribute 'allowed_source_ips'`.
+
+- [ ] **Step 3: Implement the field, validators, and property**
+
+In `src/orchestrator/core/settings.py`:
+
+1. Add imports near the top (with the other stdlib / typing imports):
+
+```python
+import ipaddress
+from functools import cached_property
+from typing import Annotated
+```
+
+(`from functools import lru_cache` is already present; add `cached_property` alongside or on its own line. `Any` is already imported; add `Annotated`.)
+
+2. Import `NoDecode` from pydantic-settings — extend the existing import:
+
+```python
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
+```
+
+3. Add the field next to `cors_origins` (around `settings.py:72`):
+
+```python
+    # Source-IP allowlist for LAN exposure. Empty => no extra sources beyond
+    # loopback (and the SourceAllowlistMiddleware is a pure no-op). Comma-
+    # separated IPs/CIDRs in env; NoDecode keeps pydantic-settings from trying
+    # to JSON-decode the value before our before-validator splits it.
+    allowed_source_ips: Annotated[list[str], NoDecode] = Field(default_factory=list)
+```
+
+4. Add the validators (place them near `_reject_empty_cors_origin`, ~`settings.py:220`):
+
+```python
+    @field_validator("allowed_source_ips", mode="before")
+    @classmethod
+    def _split_allowed_source_ips(cls, v: Any) -> Any:
+        """Accept a comma-separated env string or a real list. A bare env
+        string like '10.100.23.102,10.0.0.0/24' is split + trimmed; empty
+        segments are dropped."""
+        if v is None:
+            return []
+        if isinstance(v, str):
+            return [s.strip() for s in v.split(",") if s.strip()]
+        return v
+
+    @field_validator("allowed_source_ips", mode="after")
+    @classmethod
+    def _validate_allowed_source_ips(cls, v: list[str]) -> list[str]:
+        """Each entry must parse as an IP network (a bare IP becomes /32 or
+        /128). Fail fast at construction on a malformed entry."""
+        for entry in v:
+            try:
+                ipaddress.ip_network(entry, strict=False)
+            except ValueError as e:
+                raise ValueError(f"invalid allowed_source_ips entry {entry!r}: {e}") from e
+        return v
+```
+
+5. Add the parsed-networks property (place it after the validators, as a normal method on the class):
+
+```python
+    @cached_property
+    def allowed_source_networks(
+        self,
+    ) -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
+        """Parsed allowlist networks, consumed by SourceAllowlistMiddleware.
+        Entries are pre-validated by _validate_allowed_source_ips."""
+        return [ipaddress.ip_network(e, strict=False) for e in self.allowed_source_ips]
+```
+
+> NOTE: pydantic v2 supports `functools.cached_property` on models (it is treated as a non-field attribute). If construction raises specifically about `cached_property` assignment, fall back to a plain `@property` with the same body — the parse is O(1–2 entries), so per-call cost is negligible.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `python -m pytest tests/core/test_settings.py::TestAllowedSourceIps -q`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Confirm no settings regressions**
+
+Run: `python -m pytest tests/core/test_settings.py -q`
+Expected: PASS (existing + new). In particular `test_non_loopback_host_warning_fires` still passes (unchanged).
+
+---
+
+### Task 2: Pure `_is_source_allowed` matcher
+
+**Files:**
+- Modify: `src/orchestrator/api/middleware.py`
+- Test: `tests/api/test_source_allowlist.py` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/api/test_source_allowlist.py`:
+
+```python
+import ipaddress
+
+import pytest
+
+from orchestrator.api.middleware import _is_source_allowed
+
+
+def _nets(*entries):
+    return [ipaddress.ip_network(e, strict=False) for e in entries]
+
+
+class TestIsSourceAllowed:
+    def test_loopback_always_allowed(self):
+        nets = _nets("10.100.23.102")
+        assert _is_source_allowed("127.0.0.1", nets) is True
+        assert _is_source_allowed("::1", nets) is True
+        assert _is_source_allowed("::ffff:127.0.0.1", nets) is True
+
+    def test_exact_ip_match(self):
+        nets = _nets("10.100.23.102")
+        assert _is_source_allowed("10.100.23.102", nets) is True
+        assert _is_source_allowed("10.100.23.103", nets) is False
+
+    def test_cidr_range(self):
+        nets = _nets("10.0.0.0/24")
+        assert _is_source_allowed("10.0.0.55", nets) is True
+        assert _is_source_allowed("10.0.1.1", nets) is False
+
+    def test_ipv4_mapped_ipv6_matches_ipv4_entry(self):
+        nets = _nets("10.100.23.102")
+        assert _is_source_allowed("::ffff:10.100.23.102", nets) is True
+
+    def test_allow_any(self):
+        nets = _nets("0.0.0.0/0")
+        assert _is_source_allowed("8.8.8.8", nets) is True
+
+    def test_none_client_rejected(self):
+        nets = _nets("10.100.23.102")
+        assert _is_source_allowed(None, nets) is False
+
+    def test_unparseable_client_rejected(self):
+        nets = _nets("10.100.23.102")
+        assert _is_source_allowed("not-an-ip", nets) is False
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `python -m pytest tests/api/test_source_allowlist.py::TestIsSourceAllowed -q`
+Expected: FAIL — `ImportError: cannot import name '_is_source_allowed'`.
+
+- [ ] **Step 3: Implement the helper**
+
+In `src/orchestrator/api/middleware.py`:
+
+1. Add `import ipaddress` to the imports (top of file, with the other stdlib imports like `hashlib`, `hmac`).
+
+2. Add the helper near the top (after the imports / module constants, before the middleware classes):
+
+```python
+def _is_source_allowed(
+    client_host: str | None,
+    allowed_networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network],
+) -> bool:
+    """True if client_host is a loopback form, or its IP is contained in any
+    allowed network. None/unparseable -> False (fail closed). Callers invoke
+    this only when allowed_networks is non-empty (the enforcement switch lives
+    in SourceAllowlistMiddleware)."""
+    if client_host in LOOPBACK_HOSTS:
+        return True
+    if client_host is None:
+        return False
+    try:
+        ip: ipaddress.IPv4Address | ipaddress.IPv6Address = ipaddress.ip_address(client_host)
+    except ValueError:
+        return False
+    # Normalize IPv4-mapped IPv6 (::ffff:a.b.c.d) so it matches IPv4 entries.
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    return any(ip in net for net in allowed_networks)
+```
+
+(`LOOPBACK_HOSTS` is already imported at `middleware.py:25`.)
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `python -m pytest tests/api/test_source_allowlist.py::TestIsSourceAllowed -q`
+Expected: PASS (7 tests).
+
+---
+
+### Task 3: `SourceAllowlistMiddleware`
+
+**Files:**
+- Modify: `src/orchestrator/api/middleware.py`
+- Test: `tests/api/test_source_allowlist.py`
+
+- [ ] **Step 1: Write the failing tests (synthetic ASGI scope, driven directly)**
+
+Append to `tests/api/test_source_allowlist.py`:
+
+```python
+import pytest
+
+from orchestrator.api.middleware import SourceAllowlistMiddleware
+
+
+async def _collect(messages, send_list):
+    async def send(msg):
+        send_list.append(msg)
+    return send
+
+
+def _make_scope(client):
+    return {"type": "http", "method": "GET", "path": "/api/v1/games",
+            "headers": [], "client": client}
+
+
+class _Settings:
+    """Minimal settings stand-in for the middleware's get_settings() call."""
+    def __init__(self, networks):
+        self.allowed_source_networks = networks
+
+
+@pytest.mark.asyncio
+class TestSourceAllowlistMiddleware:
+    async def _run(self, monkeypatch, networks, client):
+        import orchestrator.api.middleware as mw
+        monkeypatch.setattr(mw, "get_settings", lambda: _Settings(networks))
+        reached = {"v": False}
+
+        async def downstream(scope, receive, send):
+            reached["v"] = True
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"ok"})
+
+        sent = []
+
+        async def send(msg):
+            sent.append(msg)
+
+        async def receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        await SourceAllowlistMiddleware(downstream)(_make_scope(client), receive, send)
+        return reached["v"], sent
+
+    async def test_empty_allowlist_is_noop_allows_any_source(self, monkeypatch):
+        reached, sent = await self._run(monkeypatch, [], ("203.0.113.9", 5000))
+        assert reached is True
+        assert sent[0]["status"] == 200
+
+    async def test_enforcing_rejects_unlisted_source_403(self, monkeypatch):
+        import ipaddress
+        nets = [ipaddress.ip_network("10.100.23.102")]
+        reached, sent = await self._run(monkeypatch, nets, ("203.0.113.9", 5000))
+        assert reached is False
+        assert sent[0]["status"] == 403
+
+    async def test_enforcing_allows_listed_source(self, monkeypatch):
+        import ipaddress
+        nets = [ipaddress.ip_network("10.100.23.102")]
+        reached, sent = await self._run(monkeypatch, nets, ("10.100.23.102", 5000))
+        assert reached is True
+        assert sent[0]["status"] == 200
+
+    async def test_enforcing_allows_loopback(self, monkeypatch):
+        import ipaddress
+        nets = [ipaddress.ip_network("10.100.23.102")]
+        reached, sent = await self._run(monkeypatch, nets, ("127.0.0.1", 5000))
+        assert reached is True
+
+    async def test_enforcing_none_client_rejected(self, monkeypatch):
+        import ipaddress
+        nets = [ipaddress.ip_network("10.100.23.102")]
+        reached, sent = await self._run(monkeypatch, nets, None)
+        assert reached is False
+        assert sent[0]["status"] == 403
+
+    async def test_non_http_scope_passes_through(self, monkeypatch):
+        import orchestrator.api.middleware as mw
+        monkeypatch.setattr(mw, "get_settings", lambda: _Settings([]))
+        reached = {"v": False}
+
+        async def downstream(scope, receive, send):
+            reached["v"] = True
+
+        async def send(msg):
+            pass
+
+        async def receive():
+            return {}
+
+        await SourceAllowlistMiddleware(downstream)({"type": "lifespan"}, receive, send)
+        assert reached["v"] is True
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `python -m pytest tests/api/test_source_allowlist.py::TestSourceAllowlistMiddleware -q`
+Expected: FAIL — `ImportError: cannot import name 'SourceAllowlistMiddleware'`.
+
+- [ ] **Step 3: Implement the middleware**
+
+In `src/orchestrator/api/middleware.py`, add after `_is_source_allowed` (and after the `BearerAuthMiddleware` class is fine too — place it logically near the other middlewares; it needs `get_settings`, already imported at `middleware.py:29`):
+
+```python
+# ----------------------------------------------------------------------
+# SourceAllowlistMiddleware — LAN-exposure source-IP gate
+# ----------------------------------------------------------------------
+
+
+class SourceAllowlistMiddleware:
+    """Reject connections whose peer IP is not loopback and not in
+    settings.allowed_source_networks. Pure no-op when the allowlist is empty
+    (the boot guard guarantees an empty allowlist only coincides with a
+    loopback-only bind). Reads scope["client"] directly — no X-Forwarded-For
+    trust, since the app is bound without a reverse proxy."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        allowed = get_settings().allowed_source_networks
+        if allowed:  # enforcement switch: empty list => passthrough
+            client_info = scope.get("client")
+            client_host = client_info[0] if client_info else None
+            if not _is_source_allowed(client_host, allowed):
+                _log.warning(
+                    "api.source.rejected",
+                    reason="source_not_allowed",
+                    path=scope["path"],
+                    client_host=client_host,
+                )
+                await self._send_403(send)
+                return
+
+        await self.app(scope, receive, send)
+
+    @staticmethod
+    async def _send_403(send: Send) -> None:
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 403,
+                "headers": [(b"content-type", b"application/json")],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": b'{"detail":"forbidden: source not allowed"}',
+            }
+        )
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `python -m pytest tests/api/test_source_allowlist.py::TestSourceAllowlistMiddleware -q`
+Expected: PASS (6 tests).
+
+---
+
+### Task 4: Register the middleware in the app stack
+
+**Files:**
+- Modify: `src/orchestrator/api/main.py`
+- Test: `tests/api/test_source_allowlist.py`
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Append to `tests/api/test_source_allowlist.py`. These build an app whose settings carry a non-empty allowlist and drive it through the full middleware stack:
+
+```python
+import time
+
+import httpx
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def enforcing_app(populated_pool, monkeypatch):
+    """App whose settings allow only 10.100.23.102 (+ loopback)."""
+    from orchestrator.api.dependencies import get_pool_dep
+    from orchestrator.api.main import create_app
+    from orchestrator.core.settings import get_settings
+
+    monkeypatch.setenv("ORCH_TOKEN", "t" * 32)
+    monkeypatch.setenv("ORCH_ALLOWED_SOURCE_IPS", "10.100.23.102")
+    get_settings.cache_clear()
+    app = create_app()
+    app.dependency_overrides[get_pool_dep] = lambda: populated_pool
+    app.state.boot_time = time.monotonic()
+    app.state.git_sha = "test-sha-deadbeef"
+    yield app
+    get_settings.cache_clear()
+
+
+def _client(app, host):
+    transport = httpx.ASGITransport(app=app, client=(host, 5000))
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.mark.asyncio
+class TestSourceAllowlistIntegration:
+    async def test_unlisted_source_403_on_health(self, enforcing_app):
+        async with _client(enforcing_app, "203.0.113.9") as c:
+            r = await c.get("/api/v1/health")
+        assert r.status_code == 403
+        assert r.json()["detail"] == "forbidden: source not allowed"
+
+    async def test_unlisted_source_403_on_games(self, enforcing_app):
+        async with _client(enforcing_app, "203.0.113.9") as c:
+            r = await c.get("/api/v1/games", headers={"Authorization": "Bearer " + "t" * 32})
+        assert r.status_code == 403
+
+    async def test_listed_source_without_token_401(self, enforcing_app):
+        async with _client(enforcing_app, "10.100.23.102") as c:
+            r = await c.get("/api/v1/games")
+        assert r.status_code == 401
+
+    async def test_listed_source_with_token_200(self, enforcing_app):
+        async with _client(enforcing_app, "10.100.23.102") as c:
+            r = await c.get("/api/v1/games", headers={"Authorization": "Bearer " + "t" * 32})
+        assert r.status_code == 200
+
+    async def test_listed_nonloopback_still_blocked_from_oq2_auth(self, enforcing_app):
+        # Passes the source gate but OQ2 still requires loopback for /auth.
+        async with _client(enforcing_app, "10.100.23.102") as c:
+            r = await c.post(
+                "/api/v1/platforms/steam/auth",
+                headers={"Authorization": "Bearer " + "t" * 32},
+                json={},
+            )
+        assert r.status_code == 403
+
+    async def test_rejected_source_still_gets_correlation_id(self, enforcing_app):
+        async with _client(enforcing_app, "203.0.113.9") as c:
+            r = await c.get("/api/v1/health")
+        assert r.status_code == 403
+        assert "x-correlation-id" in {k.lower() for k in r.headers}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `python -m pytest tests/api/test_source_allowlist.py::TestSourceAllowlistIntegration -q`
+Expected: FAIL — the middleware isn't in the stack yet, so the unlisted source is NOT 403'd (`test_unlisted_source_403_on_health` returns 200/503, and `test_rejected_source_still_gets_correlation_id` fails on the status assertion).
+
+- [ ] **Step 3: Register the middleware**
+
+In `src/orchestrator/api/main.py`:
+
+1. Extend the middleware import (around `main.py:24`):
+
+```python
+from orchestrator.api.middleware import (
+    BearerAuthMiddleware,
+    BodySizeCapMiddleware,
+    CorrelationIdMiddleware,
+    SourceAllowlistMiddleware,
+)
+```
+
+2. Add the registration between `BodySizeCapMiddleware` and `CorrelationIdMiddleware` (around `main.py:326-328`). `add_middleware` prepends, so this places SourceAllowlist just inside CorrelationId at request time:
+
+```python
+    app.add_middleware(BearerAuthMiddleware)
+    app.add_middleware(BodySizeCapMiddleware)
+    app.add_middleware(SourceAllowlistMiddleware)
+    app.add_middleware(CorrelationIdMiddleware)
+    app.add_middleware(
+        CORSMiddleware,
+        ...
+    )
+```
+
+Update the order comment above the block to read: `CORS → CorrelationId → SourceAllowlist → BodySizeCap → BearerAuth`.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `python -m pytest tests/api/test_source_allowlist.py::TestSourceAllowlistIntegration -q`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Confirm the existing API suite stays green**
+
+Run: `python -m pytest tests/api -q`
+Expected: PASS. (unit_app has an empty allowlist → middleware no-op; `external_client`-based OQ2 tests still 403 via OQ2.)
+
+---
+
+### Task 5: Fail-closed boot guard
+
+**Files:**
+- Modify: `src/orchestrator/api/main.py`
+- Test: `tests/api/test_source_allowlist.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/api/test_source_allowlist.py`:
+
+```python
+from orchestrator.api.main import _enforce_lan_bind_policy
+from orchestrator.core.settings import Settings
+
+
+class TestLanBindGuard:
+    def test_loopback_bind_empty_allowlist_ok(self):
+        s = Settings(orchestrator_token="t" * 32, api_host="127.0.0.1")
+        _enforce_lan_bind_policy(s)  # no raise
+
+    def test_non_loopback_bind_without_allowlist_systemexit(self):
+        import pytest
+        s = Settings(orchestrator_token="t" * 32, api_host="0.0.0.0")  # noqa: S104
+        with pytest.raises(SystemExit):
+            _enforce_lan_bind_policy(s)
+
+    def test_non_loopback_bind_with_allowlist_ok(self):
+        s = Settings(
+            orchestrator_token="t" * 32,
+            api_host="0.0.0.0",  # noqa: S104
+            allowed_source_ips=["10.100.23.102"],
+        )
+        _enforce_lan_bind_policy(s)  # no raise
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `python -m pytest tests/api/test_source_allowlist.py::TestLanBindGuard -q`
+Expected: FAIL — `ImportError: cannot import name '_enforce_lan_bind_policy'`.
+
+- [ ] **Step 3: Add the guard function and call it; remove the old warning block**
+
+In `src/orchestrator/api/main.py`:
+
+1. Add the guard function near `_detect_non_loopback_bind` (around `main.py:90`):
+
+```python
+def _enforce_lan_bind_policy(settings: Settings) -> None:
+    """Fail-closed LAN-bind guard (security priority #1). A non-loopback bind
+    MUST declare ORCH_ALLOWED_SOURCE_IPS; otherwise refuse to start. A loopback
+    bind is always fine. Called at the top of the lifespan, before migrations,
+    so a misconfiguration fails fast."""
+    log = structlog.get_logger()
+    bind_signal = _detect_non_loopback_bind(settings.api_host)
+    if bind_signal is None:
+        return
+    if not settings.allowed_source_ips:
+        log.critical(
+            "api.boot.lan_bind_without_allowlist",
+            api_host=bind_signal,
+            hint=(
+                "Set ORCH_ALLOWED_SOURCE_IPS to the permitted source(s) before "
+                "binding off-loopback. Refusing to start."
+            ),
+        )
+        raise SystemExit(1)
+    log.info(
+        "api.boot.lan_bind_gated",
+        api_host=bind_signal,
+        allowed_source_ips=settings.allowed_source_ips,
+        note="auth/2fa/schema remain loopback-only (OQ2)",
+    )
+```
+
+(`Settings` is the type from `orchestrator.core.settings`; import it for the annotation if not already imported — add `from orchestrator.core.settings import Settings, get_settings` or extend the existing settings import. If a circular-import risk appears, annotate as `"Settings"` under `TYPE_CHECKING` and keep the runtime import inside the function.)
+
+2. Call it at the very top of `_lifespan`, right after `settings = get_settings()` (around `main.py:95`):
+
+```python
+    settings = get_settings()
+    log = structlog.get_logger()
+
+    # 0. Fail-closed LAN-bind guard — before any startup work.
+    _enforce_lan_bind_policy(settings)
+```
+
+3. **Remove** the now-redundant warning block (the `bind_signal = _detect_non_loopback_bind(settings.api_host)` + `log.warning("api.boot.non_loopback_bind_warning", ...)` block around `main.py:233-248`). The new guard supersedes it (it logs `lan_bind_gated` on the allowed path).
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `python -m pytest tests/api/test_source_allowlist.py::TestLanBindGuard -q`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Confirm lifespan/boot tests still pass**
+
+Run: `python -m pytest tests/api -q -k "lifespan or boot or main or middleware or source"`
+Expected: PASS. If any existing test asserted the old `api.boot.non_loopback_bind_warning` event, update it to expect `api.boot.lan_bind_gated` (with an allowlist) or `api.boot.lan_bind_without_allowlist` + SystemExit (without). Search: `grep -rn "non_loopback_bind_warning" tests/`.
+
+---
+
+### Task 6: Documentation
+
+**Files:**
+- Modify: `README.md`, `CHANGELOG.md`, `FEATURES.md`
+
+- [ ] **Step 1: README — env table row**
+
+In `README.md`, add a row under `ORCH_CORS_ORIGINS` in the env table (~line 41):
+
+```markdown
+| `ORCH_ALLOWED_SOURCE_IPS` | comma-separated IPs/CIDRs | `[]` | Source-IP allowlist for LAN exposure. **Required** (non-empty) when `ORCH_API_HOST` is non-loopback, or the app refuses to start. Loopback is always allowed. |
+```
+
+- [ ] **Step 2: README — LAN-exposure run section + fix the stale warning paragraph**
+
+In `README.md`, replace the "Loopback restriction" paragraph (~line 138) so it reflects the new fail-closed behavior, and add a LAN-exposure subsection after the run commands (~line 134):
+
+```markdown
+**LAN exposure (e.g. for Game_shelf).** To reach the API from another host, bind off-loopback AND declare the allowed source(s):
+
+​```bash
+# Container binds all interfaces in its namespace; the host publish is scoped
+# to the LAN NIC so the port is not exposed on other host interfaces.
+docker run -e ORCH_API_HOST=0.0.0.0 \
+           -e ORCH_ALLOWED_SOURCE_IPS=10.100.23.102 \
+           -p 192.168.1.40:8765:8765 ...
+​```
+
+The `SourceAllowlistMiddleware` 403s any source that is not loopback or in `ORCH_ALLOWED_SOURCE_IPS`, on every path. A non-loopback bind with an empty allowlist **refuses to start** (`api.boot.lan_bind_without_allowlist`). As an outer layer, also restrict the port at the host firewall, e.g. nftables:
+
+​```
+# allow only Game_shelf to reach the orchestrator port; drop the rest
+nft add rule inet filter input ip saddr 10.100.23.102 tcp dport 8765 accept
+nft add rule inet filter input tcp dport 8765 drop
+​```
+
+**Loopback restriction (unchanged):** the OpenAPI schema and Swagger/ReDoc UIs, plus credential-intake (`POST /platforms/{name}/auth`) and 2FA-submit, remain loopback-only — an allowlisted-but-remote host still gets 403 on those. Note OQ2 reads `scope["client"]` directly, so do **not** place a reverse proxy in front of the app (it would make every client look like loopback). This design binds uvicorn directly, no proxy.
+```
+
+(The `​` zero-width marks above are just to escape the nested fences in this plan — in the actual README use plain triple-backtick fences.)
+
+- [ ] **Step 3: CHANGELOG**
+
+In `CHANGELOG.md`, under the current unreleased section, add entries:
+
+```markdown
+### Security
+- Source-IP allowlist (`SourceAllowlistMiddleware`) gates all API paths to loopback + `ORCH_ALLOWED_SOURCE_IPS` when the API is bound off-loopback; defense-in-depth over the bearer token for LAN exposure.
+- Fail-closed boot guard: a non-loopback bind with no `ORCH_ALLOWED_SOURCE_IPS` refuses to start.
+
+### Added
+- `ORCH_ALLOWED_SOURCE_IPS` setting (comma-separated IPs/CIDRs) + `Settings.allowed_source_networks`.
+
+### Infrastructure
+- Documented LAN-exposure deploy recipe (LAN-scoped docker publish + host nftables rule) in README.
+```
+
+- [ ] **Step 4: FEATURES**
+
+In `FEATURES.md`, add a line recording the LAN-bind + source-IP allowlist capability (match the file's existing row/section format).
+
+- [ ] **Step 5: Sanity-check docs build/links**
+
+Run: `grep -n "ORCH_ALLOWED_SOURCE_IPS" README.md CHANGELOG.md`
+Expected: matches in both files.
+
+---
+
+### Task 7: Full verification + single commit + push + PR
+
+- [ ] **Step 1: Full test suite**
+
+Run: `python -m pytest -q 2>&1 | tail -20`
+Expected: all green (no new failures vs. `main`). Investigate any failure before proceeding.
+
+- [ ] **Step 2: Lint / type gates (match repo CI)**
+
+Run the repo's configured checks (e.g. `ruff check src tests` and any mypy/pyright config). Expected: clean. Fix anything introduced by this change (e.g. the `# noqa: S104` markers on intentional `0.0.0.0` test binds are already included).
+
+- [ ] **Step 3: Present commit-structure options, then commit**
+
+Bring A/B/C commit-structure options to the user and WAIT for an explicit pick before committing (a Stop-hook relay is NOT approval). Recommended default — single `feat` commit:
+
+```bash
+git add src/orchestrator/core/settings.py \
+        src/orchestrator/api/middleware.py \
+        src/orchestrator/api/main.py \
+        tests/api/test_source_allowlist.py \
+        tests/core/test_settings.py \
+        README.md CHANGELOG.md FEATURES.md \
+        docs/superpowers/plans/2026-06-18-lan-bind-allowlist.md
+git commit -m "feat(api): LAN-bind source-IP allowlist + fail-closed bind guard
+
+- ORCH_ALLOWED_SOURCE_IPS setting (comma-separated IPs/CIDRs) + parsed
+  allowed_source_networks
+- SourceAllowlistMiddleware: 403s non-loopback, non-allowlisted sources on
+  every path; pure no-op when the allowlist is empty
+- fail-closed boot guard: off-loopback bind without an allowlist refuses to
+  start (api.boot.lan_bind_without_allowlist)
+- OQ2 loopback-only endpoints unchanged; README/CHANGELOG/FEATURES updated
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 4: Push (Claude pushes; user merges)**
+
+```bash
+git push -u origin feat/lan-bind-allowlist
+```
+
+(The branch is already off `main`, so the branch-safety hook allows the push.)
+
+- [ ] **Step 5: Open the PR (do NOT merge)**
+
+```bash
+gh pr create --title "feat(api): LAN-bind source-IP allowlist + fail-closed bind guard" --body "<summary: what/why, the two locked decisions (plaintext+allowlist, documented firewall), test counts, and the note that this unblocks live Game_shelf F14-F17 verification>"
+```
+
+- [ ] **Step 6: Report**
+
+Report the PR URL. Note that this unblocks **live** Game_shelf F14–F17 verification (set `ORCH_API_URL=http://192.168.1.40:8765` on the Game_shelf backend once deployed) and that the host nftables rule is a manual sudo step on `192.168.1.40`.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §4.1 setting → Task 1; §4.3 middleware + enforcement switch → Tasks 2–4; §4.4 boot guard → Task 5; §5 "stays safe" (OQ2 untouched, bearer untouched) → verified by Task 4 `test_listed_nonloopback_still_blocked_from_oq2_auth` + Task 4 Step 5; §6 deploy recipe → Task 6; §7 test matrix → Tasks 1–5 (every listed case mapped); §8 YAGNI (no TLS/proxy/XFF/reload) → nothing added beyond scope.
+- **Placeholder scan:** none — every code/test step is complete. The only conditional is the cached_property fallback note (a real pydantic-v2 nuance), which still gives exact code.
+- **Type/name consistency:** `allowed_source_ips` (list[str]) and `allowed_source_networks` (list of ip_network) are used identically in settings, the middleware, and tests; `_is_source_allowed(client_host, allowed_networks)` signature matches all call sites; `SourceAllowlistMiddleware` registration name matches the import; `_enforce_lan_bind_policy(settings)` matches its tests.
+- **Stack order:** registration `BearerAuth, BodySizeCap, SourceAllowlist, CorrelationId, CORS` (prepend semantics) ⇒ request-time `CORS → CorrelationId → SourceAllowlist → BodySizeCap → BearerAuth`, consistent across Task 4 and the spec.
+- **Suite safety:** empty-allowlist no-op (Task 3) + httpx ASGITransport default client = loopback ⇒ the existing suite is unaffected; the one place to double-check is any test asserting `non_loopback_bind_warning` (Task 5 Step 5 handles it).

--- a/docs/superpowers/specs/2026-06-18-lan-bind-allowlist-design.md
+++ b/docs/superpowers/specs/2026-06-18-lan-bind-allowlist-design.md
@@ -1,0 +1,154 @@
+# Orchestrator LAN-bind + Source-IP Allowlist — Design
+
+**Date:** 2026-06-18
+**Status:** Approved (design)
+**Branch:** `feat/lan-bind-allowlist`
+**Driver:** Game_shelf (F14–F17, merged) consumes the orchestrator API from a different host (LXC1102 @ `10.100.23.102`). The orchestrator runs dockerized on the lancache host (`192.168.1.40`) and is currently loopback-only. It must be reachable from Game_shelf without weakening any existing protection.
+
+---
+
+## 1. Goal
+
+Allow the orchestrator API to be bound to the LAN so Game_shelf can reach it, while guaranteeing — at the application layer, fail-closed — that only declared source IPs can connect. Security is priority #1: the change must not weaken the bearer-token gate or the OQ2 loopback gate, and it must be impossible to LAN-expose the API by accident.
+
+## 2. Decisions (locked during brainstorming)
+
+- **Transport: plaintext HTTP + source allowlist.** The VLAN between the two Proxmox guests is treated as a trusted segment. The bearer token plus a fail-closed source-IP allowlist are the gates; no TLS, no reverse proxy. (A reverse proxy would also silently defeat OQ2/allowlist, which read `scope["client"]` directly.)
+- **Firewall: in-repo app allowlist + documented host firewall.** The application-level allowlist is the in-repo, tested deliverable. The host nftables/iptables rule is documented in the deploy recipe for the operator to apply with sudo (host sudo is password-gated; it stays a manual step).
+
+## 3. What already exists (no change needed)
+
+- **Bind is env-driven.** The Dockerfile entrypoint runs `python -m uvicorn … --host "${ORCH_API_HOST:-127.0.0.1}" --port "${ORCH_API_PORT:-8765}"`. Setting `ORCH_API_HOST` is all that's needed to bind to the LAN. No code change for the bind itself.
+- **OQ2 loopback gate** (`api/middleware.py` `BearerAuthMiddleware`, `LOOPBACK_ONLY_PATTERNS` in `api/dependencies.py`) restricts credential-intake (`POST /platforms/{name}/auth`), 2FA-submit (`/platforms/{name}/auth/{challenge_id}`, except `/auth/status`), and schema endpoints (`openapi.json`, `docs`, `redoc`) to loopback by reading `scope["client"][0]`. A LAN bind therefore keeps these unreachable from Game_shelf automatically. Game_shelf only ever reaches the bearer-gated data/action endpoints + `/auth/status` it proxies in F14.
+- **Bearer auth** (`BearerAuthMiddleware`) gates every non-exempt `/api/v1/*` path with a constant-time token compare.
+- **Non-loopback bind warning** (`api/main.py` lifespan, via `_detect_non_loopback_bind()`) already detects a non-loopback bind from settings / `UVICORN_HOST` / `--host` argv. This design upgrades that warning into a fail-closed guard.
+
+## 4. The deliverable: fail-closed source-IP allowlist
+
+A thin defense-in-depth layer **outside** the bearer token — the "trust-list of proxy IPs" the code flags as Phase-3 backlog (`api/dependencies.py:58`). It restricts which source IPs may open a connection to the API at all, on **every** path (including the unauthenticated `/health` and the schema endpoints), before any auth or body processing.
+
+### 4.1 New setting (`core/settings.py`)
+
+```
+allowed_source_ips: list[str] = []   # env ORCH_ALLOWED_SOURCE_IPS
+```
+
+- **Env parsing:** accept either a comma-separated string (`10.100.23.102,10.0.0.0/24`) or a JSON array, via a `field_validator(mode="before")` that splits on comma + strips whitespace + drops empties. (Mirrors how `cors_origins` is fed; the planning step confirms and reuses the existing mechanism.)
+- **Validation:** a `field_validator(mode="after")` parses each entry with `ipaddress.ip_network(entry, strict=False)`. An invalid entry raises a `ValidationError` at boot (fail fast). Parsed networks are exposed via a cached property `allowed_source_networks -> list[IPv4Network | IPv6Network]` so the middleware doesn't re-parse per request.
+- **Default `[]`** = no extra sources beyond loopback. For the default loopback-only deployment this is a no-op.
+- **Allow-any is explicit and auditable:** `ORCH_ALLOWED_SOURCE_IPS=0.0.0.0/0` (and/or `::/0`) opts into "any source," a deliberate choice visible in config and logged at boot.
+
+### 4.2 Always-allowed loopback
+
+Loopback (`127.0.0.1`, `::1`, `::ffff:127.0.0.1`) is **always** allowed, independent of the configured list — the CLI, the docker healthcheck, the F10 status page, and the OQ2 loopback endpoints all originate from loopback. The allowlist is **additive** to loopback. Reuse `LOOPBACK_HOSTS` from `api/dependencies.py`.
+
+### 4.3 New `SourceAllowlistMiddleware` (`api/middleware.py`)
+
+A dedicated single-responsibility ASGI middleware (not folded into `BearerAuthMiddleware`), with a pure, independently-testable matching helper:
+
+```
+def _is_source_allowed(client_host: str | None,
+                       allowed_networks: list[IPv4Network | IPv6Network]) -> bool:
+    # True if client_host is a loopback form, or parses to an IP contained
+    # in any allowed network. False on None/unparseable, or no match (fail closed).
+```
+
+- **Enforcement switch (critical):** the middleware enforces **only when `allowed_source_networks` is non-empty**. With an empty list it is a pure passthrough (allow-all). This is safe and required:
+  - The §4.4 boot guard guarantees an empty allowlist can only coincide with a loopback-only bind, where the only possible clients are loopback anyway.
+  - It keeps the default/dev/test posture unchanged: the existing test suite hits endpoints via Starlette `TestClient` whose client host is `"testclient"` (neither loopback nor allowlisted); an always-rejecting middleware would 403 the entire suite. Empty-list-is-no-op avoids that. Enforcement tests set a non-empty allowlist explicitly and control the client host.
+- When enforcing, reads `scope["client"][0]` directly. **No `X-Forwarded-For` trust** — uvicorn is bound directly with no reverse proxy, so the peer IP is authentic.
+- Loopback forms (`LOOPBACK_HOSTS`) are always allowed when enforcing. Normalizes IPv4-mapped IPv6 (`::ffff:a.b.c.d`) before matching so a mapped client still matches an IPv4 network entry.
+- On a disallowed source (only possible while enforcing): log `api.source.rejected` (reason, client_host, path) and return **403** `{"detail":"forbidden: source not allowed"}` before any downstream work. Reuse the existing `_send_403`-style helper shape.
+- A `None`/missing client while enforcing is treated as **not allowed** — fail closed.
+
+**Stack placement.** `add_middleware` prepends, so the registration becomes (innermost → outermost):
+
+```
+BearerAuthMiddleware           # innermost
+BodySizeCapMiddleware
+SourceAllowlistMiddleware      # NEW
+CorrelationIdMiddleware
+CORSMiddleware                 # outermost
+```
+
+giving request-time order **CORS → CorrelationId → SourceAllowlist → BodySizeCap → BearerAuth**. Rationale: the source gate sits *inside* CorrelationId (so a rejected source still gets a correlation-id and the `request.received`/`completed` log lines for ops visibility) but *outside* body-size and auth processing (an unknown source is dropped before we read its body or touch the token). CORS remains outermost; a non-allowlisted host's OPTIONS preflight is answered by CORS with no data exposure (and `cors_origins` is empty by default), while its actual GET/POST is 403'd by the source gate.
+
+The middleware is **always registered**; with an empty allowlist and loopback clients it is a no-op.
+
+### 4.4 Fail-closed boot guard (`api/main.py` lifespan)
+
+Move the non-loopback-bind check to the **top** of lifespan (right after `settings = get_settings()`, before migrations) so a misconfiguration fails fast without spinning up the pool/worker/scheduler. Replace today's warning-only behavior:
+
+```
+bind_signal = _detect_non_loopback_bind(settings.api_host)
+if bind_signal is not None:
+    if not settings.allowed_source_ips:
+        log.critical("api.boot.lan_bind_without_allowlist",
+                     api_host=bind_signal,
+                     hint="Set ORCH_ALLOWED_SOURCE_IPS to the permitted source(s) "
+                          "before binding off-loopback. Refusing to start.")
+        raise SystemExit(1)
+    log.info("api.boot.lan_bind_gated",
+             api_host=bind_signal,
+             allowed_source_ips=settings.allowed_source_ips,
+             loopback_only_endpoints="auth/2fa/schema remain loopback-only (OQ2)")
+```
+
+`raise SystemExit(1)` aborts startup the same way the existing migration/pool-init failures do. You cannot bind off-loopback without declaring who's allowed.
+
+## 5. What stays safe automatically
+
+- **OQ2 is unchanged and still loopback-only.** An allowlisted Game_shelf is *not* loopback, so it still cannot reach credential-intake, 2FA-submit, or schema endpoints. The allowlist grants connection eligibility, **not** loopback-equivalence.
+- **Bearer auth is unchanged.** Allowlisted sources still need a valid token for `/api/v1/*`; `/health` and `/auth/status` remain the only LAN-reachable unauthenticated/low-sensitivity reads, exactly as F14 expects.
+- **No new trust of client-supplied headers.** Matching uses the transport peer IP only.
+
+## 6. Deploy recipe (documentation, not code)
+
+Update the deploy recipe / HANDOFF with the LAN-exposure configuration:
+
+- `ORCH_API_HOST=0.0.0.0` — the container binds all interfaces *inside its own network namespace*.
+- Docker publish **scoped to the LAN NIC**: `-p 192.168.1.40:8765:8765` — host-side exposure is limited to the LAN IP, not every host interface (e.g. not a separate management NIC).
+- `ORCH_ALLOWED_SOURCE_IPS=10.100.23.102` — Game_shelf LXC.
+- Outer-layer host firewall (operator applies with sudo), documented as an nftables rule allowing only `10.100.23.102 → tcp/8765` and dropping otherwise. This is belt-and-suspenders over the app allowlist.
+- Game_shelf side (already built): set `ORCH_API_URL=http://192.168.1.40:8765` in the Game_shelf backend env (the F14 proxy already injects the bearer server-side).
+
+## 7. Testing (test-first, QA-engineer mindset)
+
+**Pure matching (`_is_source_allowed`)** — exercised with a non-empty `allowed_networks`
+- loopback `127.0.0.1` / `::1` / `::ffff:127.0.0.1` allowed regardless of the entries
+- exact IP entry (`10.100.23.102`) allows that IP, rejects a neighbor (`10.100.23.103`)
+- CIDR entry (`10.0.0.0/24`) allows in-range, rejects out-of-range
+- IPv4-mapped IPv6 client (`::ffff:10.100.23.102`) matches an IPv4 entry
+- `0.0.0.0/0` allows an arbitrary IPv4 source
+- `None`/unparseable client → not allowed (fail closed)
+
+**Middleware integration (ASGI / TestClient)** — note the enforcement switch
+- **empty allowlist** + arbitrary source (`"testclient"`) → passthrough, normal behavior (proves the suite-safe no-op)
+- non-empty allowlist, non-allowlisted source → **403** on `/api/v1/health` *and* `/api/v1/games` (gated before auth)
+- non-empty allowlist, allowlisted source, no token → **401** on `/api/v1/games` (passes source gate, fails bearer)
+- non-empty allowlist, allowlisted source, valid token → **200** on `/api/v1/games`
+- non-empty allowlist, allowlisted-but-non-loopback source → **403** on `POST /api/v1/platforms/steam/auth` (OQ2 still bites)
+- non-empty allowlist, rejected source still receives an `X-Correlation-ID` (CorrelationId is outer)
+
+**Settings validation**
+- comma-separated env string parses to a list; surrounding whitespace trimmed; empty entries dropped
+- invalid CIDR (`10.0.0.0/99`, `not-an-ip`) → `ValidationError` at construction
+- `allowed_source_networks` returns parsed network objects
+
+**Boot guard (lifespan)**
+- non-loopback `api_host` + empty allowlist → `SystemExit(1)`, logs `lan_bind_without_allowlist`
+- non-loopback `api_host` + non-empty allowlist → boots, logs `lan_bind_gated`
+- loopback `api_host` + empty allowlist → boots normally (no guard trip)
+
+## 8. Scope boundary (YAGNI)
+
+Out of scope: TLS / HTTPS, reverse proxy, `X-Forwarded-For` parsing, dynamic/hot allowlist reload (env-at-boot only), a scripted host firewall (documented only), per-endpoint allowlists (single global list). These are explicitly excluded; revisit only if the threat model changes (e.g. an untrusted LAN segment → TLS).
+
+## 9. Files touched
+
+- `src/orchestrator/core/settings.py` — new `allowed_source_ips` field + validators + `allowed_source_networks` cached property.
+- `src/orchestrator/api/middleware.py` — new `_is_source_allowed` helper + `SourceAllowlistMiddleware`.
+- `src/orchestrator/api/main.py` — register the middleware in the stack; move + harden the bind guard into a fail-closed check at the top of lifespan.
+- `src/orchestrator/api/dependencies.py` — (reuse `LOOPBACK_HOSTS`; export if needed).
+- Tests: `tests/api/test_source_allowlist.py` (new), additions to settings + lifespan/boot tests.
+- Docs: deploy recipe / HANDOFF LAN-exposure section; `CHANGELOG.md` (Security + Added + Infrastructure), `FEATURES.md`.

--- a/src/orchestrator/api/main.py
+++ b/src/orchestrator/api/main.py
@@ -24,6 +24,7 @@ from orchestrator.api.middleware import (
     BearerAuthMiddleware,
     BodySizeCapMiddleware,
     CorrelationIdMiddleware,
+    SourceAllowlistMiddleware,
 )
 from orchestrator.api.routers.auth import router as auth_router
 from orchestrator.api.routers.auth import set_steam_client_singleton
@@ -40,7 +41,7 @@ from orchestrator.api.routers.prefill_trigger import router as prefill_trigger_r
 from orchestrator.api.routers.status import router as status_router
 from orchestrator.api.routers.sync import router as sync_router
 from orchestrator.api.routers.validate_trigger import router as validate_trigger_router
-from orchestrator.core.settings import get_settings
+from orchestrator.core.settings import Settings, get_settings
 from orchestrator.db import migrate
 from orchestrator.db.pool import (
     PoolError,
@@ -90,10 +91,40 @@ def _detect_non_loopback_bind(settings_api_host: str) -> str | None:
     return None
 
 
+def _enforce_lan_bind_policy(settings: Settings) -> None:
+    """Fail-closed LAN-bind guard (security priority #1). A non-loopback bind
+    MUST declare ORCH_ALLOWED_SOURCE_IPS; otherwise refuse to start. A loopback
+    bind is always fine. Called at the top of the lifespan, before migrations,
+    so a misconfiguration fails fast."""
+    log = structlog.get_logger()
+    bind_signal = _detect_non_loopback_bind(settings.api_host)
+    if bind_signal is None:
+        return
+    if not settings.allowed_source_ips:
+        log.critical(
+            "api.boot.lan_bind_without_allowlist",
+            api_host=bind_signal,
+            hint=(
+                "Set ORCH_ALLOWED_SOURCE_IPS to the permitted source(s) before "
+                "binding off-loopback. Refusing to start."
+            ),
+        )
+        raise SystemExit(1)
+    log.info(
+        "api.boot.lan_bind_gated",
+        api_host=bind_signal,
+        allowed_source_ips=settings.allowed_source_ips,
+        note="auth/2fa/schema remain loopback-only (OQ2)",
+    )
+
+
 @asynccontextmanager
 async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     settings = get_settings()
     log = structlog.get_logger()
+
+    # 0. Fail-closed LAN-bind guard — before any startup work.
+    _enforce_lan_bind_policy(settings)
 
     # 1. Migrations (sync; offload)
     log.info("api.boot.migrations_starting")
@@ -230,23 +261,6 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         app.state.boot_time = time.monotonic()
         app.state.git_sha = os.environ.get("GIT_SHA", "unknown")
 
-        # 7. Deployment-hardening warning: surface non-loopback bind at boot.
-        # UAT-3 S2-D: detect non-loopback from any of three signals so an
-        # operator running `uvicorn --host 0.0.0.0` from the CLI gets the
-        # warning even without ORCH_API_HOST set.
-        bind_signal = _detect_non_loopback_bind(settings.api_host)
-        if bind_signal is not None:
-            log.warning(
-                "api.boot.non_loopback_bind_warning",
-                api_host=bind_signal,
-                hint=(
-                    "Binding to a non-loopback interface exposes the API on "
-                    "the network. OQ2 loopback enforcement reads scope[client] "
-                    "directly — a reverse proxy in front of this app silently "
-                    "disables OQ2. Document deployment topology."
-                ),
-            )
-
         log.info("api.boot.complete")
         yield
     finally:
@@ -320,11 +334,14 @@ def create_app() -> FastAPI:
     #
     # add_middleware prepends to user_middleware, so the LAST add_middleware
     # call is the OUTERMOST layer at request time. Order applied (outermost
-    # → innermost): CORS → CorrelationId → BodySizeCap → BearerAuth.
+    # → innermost): CORS → CorrelationId → SourceAllowlist → BodySizeCap →
+    # BearerAuth. SourceAllowlist sits just inside CorrelationId so a rejected
+    # source still gets a correlation_id, but is gated before body-size/auth.
     # Registration order (innermost → outermost):
 
     app.add_middleware(BearerAuthMiddleware)
     app.add_middleware(BodySizeCapMiddleware)
+    app.add_middleware(SourceAllowlistMiddleware)
     app.add_middleware(CorrelationIdMiddleware)
     app.add_middleware(
         CORSMiddleware,

--- a/src/orchestrator/api/middleware.py
+++ b/src/orchestrator/api/middleware.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import ipaddress
 import re
 import time
 import uuid
@@ -51,6 +52,28 @@ _UUID4_RE = re.compile(
 # through attacker-controlled headers. 4096 is comfortably above realistic
 # bearer tokens (typical opaque tokens are 32-128 hex/base64 chars).
 _MAX_AUTH_HEADER_BYTES = 4096
+
+
+def _is_source_allowed(
+    client_host: str | None,
+    allowed_networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network],
+) -> bool:
+    """True if client_host is a loopback form, or its IP is contained in any
+    allowed network. None/unparseable -> False (fail closed). Callers invoke
+    this only when allowed_networks is non-empty (the enforcement switch lives
+    in SourceAllowlistMiddleware)."""
+    if client_host in LOOPBACK_HOSTS:
+        return True
+    if client_host is None:
+        return False
+    try:
+        ip: ipaddress.IPv4Address | ipaddress.IPv6Address = ipaddress.ip_address(client_host)
+    except ValueError:
+        return False
+    # Normalize IPv4-mapped IPv6 (::ffff:a.b.c.d) so it matches IPv4 entries.
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    return any(ip in net for net in allowed_networks)
 
 
 # ----------------------------------------------------------------------
@@ -354,5 +377,58 @@ class BearerAuthMiddleware:
             {
                 "type": "http.response.body",
                 "body": b'{"detail":"forbidden: loopback only"}',
+            }
+        )
+
+
+# ----------------------------------------------------------------------
+# SourceAllowlistMiddleware — LAN-exposure source-IP gate
+# ----------------------------------------------------------------------
+
+
+class SourceAllowlistMiddleware:
+    """Reject connections whose peer IP is not loopback and not in
+    settings.allowed_source_networks. Pure no-op when the allowlist is empty
+    (the boot guard guarantees an empty allowlist only coincides with a
+    loopback-only bind). Reads scope["client"] directly — no X-Forwarded-For
+    trust, since the app is bound without a reverse proxy."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        allowed = get_settings().allowed_source_networks
+        if allowed:  # enforcement switch: empty list => passthrough
+            client_info = scope.get("client")
+            client_host = client_info[0] if client_info else None
+            if not _is_source_allowed(client_host, allowed):
+                _log.warning(
+                    "api.source.rejected",
+                    reason="source_not_allowed",
+                    path=scope["path"],
+                    client_host=client_host,
+                )
+                await self._send_403(send)
+                return
+
+        await self.app(scope, receive, send)
+
+    @staticmethod
+    async def _send_403(send: Send) -> None:
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 403,
+                "headers": [(b"content-type", b"application/json")],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": b'{"detail":"forbidden: source not allowed"}',
             }
         )

--- a/src/orchestrator/core/settings.py
+++ b/src/orchestrator/core/settings.py
@@ -14,11 +14,12 @@ for the full design rationale.
 
 from __future__ import annotations
 
+import ipaddress
 import os
 import warnings
-from functools import lru_cache
+from functools import cached_property, lru_cache
 from pathlib import Path
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 import structlog
 from apscheduler.triggers.cron import CronTrigger
@@ -30,7 +31,7 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
 _SPIKE_F_CHUNK_CONCURRENCY = 32
@@ -70,6 +71,11 @@ class Settings(BaseSettings):
     api_host: str = Field(default="127.0.0.1", min_length=1)
     api_port: int = Field(default=8765, ge=1, le=65535)
     cors_origins: list[str] = Field(default_factory=list)
+    # Source-IP allowlist for LAN exposure. Empty => no extra sources beyond
+    # loopback (and the SourceAllowlistMiddleware is a pure no-op). Comma-
+    # separated IPs/CIDRs in env; NoDecode keeps pydantic-settings from trying
+    # to JSON-decode the value before our before-validator splits it.
+    allowed_source_ips: Annotated[list[str], NoDecode] = Field(default_factory=list)
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
 
     # --- Database & migrations --------------------------------------
@@ -218,6 +224,38 @@ class Settings(BaseSettings):
         if any(not o for o in v):
             raise ValueError("cors_origins must not contain empty strings")
         return v
+
+    @field_validator("allowed_source_ips", mode="before")
+    @classmethod
+    def _split_allowed_source_ips(cls, v: Any) -> Any:
+        """Accept a comma-separated env string or a real list. A bare env
+        string like '10.100.23.102,10.0.0.0/24' is split + trimmed; empty
+        segments are dropped."""
+        if v is None:
+            return []
+        if isinstance(v, str):
+            return [s.strip() for s in v.split(",") if s.strip()]
+        return v
+
+    @field_validator("allowed_source_ips", mode="after")
+    @classmethod
+    def _validate_allowed_source_ips(cls, v: list[str]) -> list[str]:
+        """Each entry must parse as an IP network (a bare IP becomes /32 or
+        /128). Fail fast at construction on a malformed entry."""
+        for entry in v:
+            try:
+                ipaddress.ip_network(entry, strict=False)
+            except ValueError as e:
+                raise ValueError(f"invalid allowed_source_ips entry {entry!r}: {e}") from e
+        return v
+
+    @cached_property
+    def allowed_source_networks(
+        self,
+    ) -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
+        """Parsed allowlist networks, consumed by SourceAllowlistMiddleware.
+        Entries are pre-validated by _validate_allowed_source_ips."""
+        return [ipaddress.ip_network(e, strict=False) for e in self.allowed_source_ips]
 
     @field_validator("cache_levels", mode="after")
     @classmethod

--- a/tests/api/test_source_allowlist.py
+++ b/tests/api/test_source_allowlist.py
@@ -1,0 +1,235 @@
+import ipaddress
+import time
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from orchestrator.api.main import _enforce_lan_bind_policy
+from orchestrator.api.middleware import (
+    SourceAllowlistMiddleware,
+    _is_source_allowed,
+)
+from orchestrator.core.settings import Settings
+
+
+def _nets(*entries):
+    return [ipaddress.ip_network(e, strict=False) for e in entries]
+
+
+class TestIsSourceAllowed:
+    def test_loopback_always_allowed(self):
+        nets = _nets("10.100.23.102")
+        assert _is_source_allowed("127.0.0.1", nets) is True
+        assert _is_source_allowed("::1", nets) is True
+        assert _is_source_allowed("::ffff:127.0.0.1", nets) is True
+
+    def test_exact_ip_match(self):
+        nets = _nets("10.100.23.102")
+        assert _is_source_allowed("10.100.23.102", nets) is True
+        assert _is_source_allowed("10.100.23.103", nets) is False
+
+    def test_cidr_range(self):
+        nets = _nets("10.0.0.0/24")
+        assert _is_source_allowed("10.0.0.55", nets) is True
+        assert _is_source_allowed("10.0.1.1", nets) is False
+
+    def test_ipv4_mapped_ipv6_matches_ipv4_entry(self):
+        nets = _nets("10.100.23.102")
+        assert _is_source_allowed("::ffff:10.100.23.102", nets) is True
+
+    def test_ipv4_mapped_ipv6_of_unlisted_addr_rejected(self):
+        # Regression guard: a mapped IPv6 of a NON-allowlisted address must
+        # still fail closed (the normalization must not accidentally allow it).
+        nets = _nets("10.100.23.102")
+        assert _is_source_allowed("::ffff:203.0.113.9", nets) is False
+
+    def test_allow_any(self):
+        nets = _nets("0.0.0.0/0")
+        assert _is_source_allowed("8.8.8.8", nets) is True
+
+    def test_none_client_rejected(self):
+        nets = _nets("10.100.23.102")
+        assert _is_source_allowed(None, nets) is False
+
+    def test_unparseable_client_rejected(self):
+        nets = _nets("10.100.23.102")
+        assert _is_source_allowed("not-an-ip", nets) is False
+
+
+def _make_scope(client):
+    return {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/v1/games",
+        "headers": [],
+        "client": client,
+    }
+
+
+class _Settings:
+    """Minimal settings stand-in for the middleware's get_settings() call."""
+
+    def __init__(self, networks):
+        self.allowed_source_networks = networks
+
+
+@pytest.mark.asyncio
+class TestSourceAllowlistMiddleware:
+    async def _run(self, monkeypatch, networks, client):
+        import orchestrator.api.middleware as mw
+
+        monkeypatch.setattr(mw, "get_settings", lambda: _Settings(networks))
+        reached = {"v": False}
+
+        async def downstream(scope, receive, send):
+            reached["v"] = True
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"ok"})
+
+        sent = []
+
+        async def send(msg):
+            sent.append(msg)
+
+        async def receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        await SourceAllowlistMiddleware(downstream)(_make_scope(client), receive, send)
+        return reached["v"], sent
+
+    async def test_empty_allowlist_is_noop_allows_any_source(self, monkeypatch):
+        reached, sent = await self._run(monkeypatch, [], ("203.0.113.9", 5000))
+        assert reached is True
+        assert sent[0]["status"] == 200
+
+    async def test_enforcing_rejects_unlisted_source_403(self, monkeypatch):
+        import ipaddress
+
+        nets = [ipaddress.ip_network("10.100.23.102")]
+        reached, sent = await self._run(monkeypatch, nets, ("203.0.113.9", 5000))
+        assert reached is False
+        assert sent[0]["status"] == 403
+
+    async def test_enforcing_allows_listed_source(self, monkeypatch):
+        import ipaddress
+
+        nets = [ipaddress.ip_network("10.100.23.102")]
+        reached, sent = await self._run(monkeypatch, nets, ("10.100.23.102", 5000))
+        assert reached is True
+        assert sent[0]["status"] == 200
+
+    async def test_enforcing_allows_loopback(self, monkeypatch):
+        import ipaddress
+
+        nets = [ipaddress.ip_network("10.100.23.102")]
+        reached, _sent = await self._run(monkeypatch, nets, ("127.0.0.1", 5000))
+        assert reached is True
+
+    async def test_enforcing_none_client_rejected(self, monkeypatch):
+        import ipaddress
+
+        nets = [ipaddress.ip_network("10.100.23.102")]
+        reached, sent = await self._run(monkeypatch, nets, None)
+        assert reached is False
+        assert sent[0]["status"] == 403
+
+    async def test_non_http_scope_passes_through(self, monkeypatch):
+        import orchestrator.api.middleware as mw
+
+        monkeypatch.setattr(mw, "get_settings", lambda: _Settings([]))
+        reached = {"v": False}
+
+        async def downstream(scope, receive, send):
+            reached["v"] = True
+
+        async def send(msg):
+            pass
+
+        async def receive():
+            return {}
+
+        await SourceAllowlistMiddleware(downstream)({"type": "lifespan"}, receive, send)
+        assert reached["v"] is True
+
+
+@pytest_asyncio.fixture
+async def enforcing_app(populated_pool, monkeypatch):
+    """App whose settings allow only 10.100.23.102 (+ loopback)."""
+    from orchestrator.api.dependencies import get_pool_dep
+    from orchestrator.api.main import create_app
+    from orchestrator.core.settings import get_settings
+
+    monkeypatch.setenv("ORCH_TOKEN", "t" * 32)
+    monkeypatch.setenv("ORCH_ALLOWED_SOURCE_IPS", "10.100.23.102")
+    get_settings.cache_clear()
+    app = create_app()
+    app.dependency_overrides[get_pool_dep] = lambda: populated_pool
+    app.state.boot_time = time.monotonic()
+    app.state.git_sha = "test-sha-deadbeef"
+    yield app
+    get_settings.cache_clear()
+
+
+def _client(app, host):
+    transport = httpx.ASGITransport(app=app, client=(host, 5000))
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.mark.asyncio
+class TestSourceAllowlistIntegration:
+    async def test_unlisted_source_403_on_health(self, enforcing_app):
+        async with _client(enforcing_app, "203.0.113.9") as c:
+            r = await c.get("/api/v1/health")
+        assert r.status_code == 403
+        assert r.json()["detail"] == "forbidden: source not allowed"
+
+    async def test_unlisted_source_403_on_games(self, enforcing_app):
+        async with _client(enforcing_app, "203.0.113.9") as c:
+            r = await c.get("/api/v1/games", headers={"Authorization": "Bearer " + "t" * 32})
+        assert r.status_code == 403
+
+    async def test_listed_source_without_token_401(self, enforcing_app):
+        async with _client(enforcing_app, "10.100.23.102") as c:
+            r = await c.get("/api/v1/games")
+        assert r.status_code == 401
+
+    async def test_listed_source_with_token_200(self, enforcing_app):
+        async with _client(enforcing_app, "10.100.23.102") as c:
+            r = await c.get("/api/v1/games", headers={"Authorization": "Bearer " + "t" * 32})
+        assert r.status_code == 200
+
+    async def test_listed_nonloopback_still_blocked_from_oq2_auth(self, enforcing_app):
+        # Passes the source gate but OQ2 still requires loopback for /auth.
+        async with _client(enforcing_app, "10.100.23.102") as c:
+            r = await c.post(
+                "/api/v1/platforms/steam/auth",
+                headers={"Authorization": "Bearer " + "t" * 32},
+                json={},
+            )
+        assert r.status_code == 403
+
+    async def test_rejected_source_still_gets_correlation_id(self, enforcing_app):
+        async with _client(enforcing_app, "203.0.113.9") as c:
+            r = await c.get("/api/v1/health")
+        assert r.status_code == 403
+        assert "x-correlation-id" in {k.lower() for k in r.headers}
+
+
+class TestLanBindGuard:
+    def test_loopback_bind_empty_allowlist_ok(self):
+        s = Settings(orchestrator_token="t" * 32, api_host="127.0.0.1")
+        _enforce_lan_bind_policy(s)  # no raise
+
+    def test_non_loopback_bind_without_allowlist_systemexit(self):
+        s = Settings(orchestrator_token="t" * 32, api_host="0.0.0.0")  # noqa: S104
+        with pytest.raises(SystemExit):
+            _enforce_lan_bind_policy(s)
+
+    def test_non_loopback_bind_with_allowlist_ok(self):
+        s = Settings(
+            orchestrator_token="t" * 32,
+            api_host="0.0.0.0",  # noqa: S104
+            allowed_source_ips=["10.100.23.102"],
+        )
+        _enforce_lan_bind_policy(s)  # no raise

--- a/tests/api/test_uat3_remediation.py
+++ b/tests/api/test_uat3_remediation.py
@@ -111,12 +111,44 @@ class TestS2CS3hLoopbackRestrictedSchema:
 
 
 # ---------------------------------------------------------------------------
-# S2-D: startup warning on non-loopback bind (deployment hardening hint)
+# S2-D: non-loopback bind boot policy (fail-closed LAN-bind guard).
+# Superseded the old `api.boot.non_loopback_bind_warning` hint: a non-loopback
+# bind now REFUSES to start unless ORCH_ALLOWED_SOURCE_IPS is declared, and
+# emits `api.boot.lan_bind_gated` when it is (feat/lan-bind-allowlist Task 5).
 # ---------------------------------------------------------------------------
 
 
 class TestS2DNonLoopbackStartupWarning:
-    async def test_lifespan_logs_warning_when_bound_to_0_0_0_0(self, db_path, monkeypatch, capsys):
+    async def test_lifespan_refuses_to_start_when_bound_to_0_0_0_0_no_allowlist(
+        self, db_path, monkeypatch, capsys
+    ):
+        from orchestrator.api.main import create_app
+        from orchestrator.core.logging import configure_logging
+        from orchestrator.core.settings import reload_settings
+
+        configure_logging()
+        monkeypatch.setenv("ORCH_DATABASE_PATH", str(db_path))
+        monkeypatch.setenv("ORCH_API_HOST", "0.0.0.0")  # noqa: S104
+        monkeypatch.delenv("ORCH_ALLOWED_SOURCE_IPS", raising=False)
+        reload_settings()
+
+        app = create_app()
+        # The guard raises SystemExit at the very top of the lifespan. We invoke
+        # FastAPI's lifespan_context directly (bypassing asgi-lifespan, which
+        # swallows SystemExit in its background task wrapper) — same pattern as
+        # the migration-failure test in test_lifespan.py.
+        with pytest.raises(SystemExit):
+            async with app.router.lifespan_context(app):
+                pass
+
+        out = capsys.readouterr().out
+        events = [json.loads(line) for line in out.splitlines() if line.strip()]
+        names = [e.get("event") for e in events]
+        assert "api.boot.lan_bind_without_allowlist" in names
+
+    async def test_lifespan_logs_gated_when_bound_to_0_0_0_0_with_allowlist(
+        self, db_path, monkeypatch, capsys
+    ):
         from asgi_lifespan import LifespanManager
 
         from orchestrator.api.main import create_app
@@ -126,6 +158,7 @@ class TestS2DNonLoopbackStartupWarning:
         configure_logging()
         monkeypatch.setenv("ORCH_DATABASE_PATH", str(db_path))
         monkeypatch.setenv("ORCH_API_HOST", "0.0.0.0")  # noqa: S104
+        monkeypatch.setenv("ORCH_ALLOWED_SOURCE_IPS", "10.100.23.102")
         reload_settings()
 
         app = create_app()
@@ -135,7 +168,7 @@ class TestS2DNonLoopbackStartupWarning:
         out = capsys.readouterr().out
         events = [json.loads(line) for line in out.splitlines() if line.strip()]
         names = [e.get("event") for e in events]
-        assert "api.boot.non_loopback_bind_warning" in names
+        assert "api.boot.lan_bind_gated" in names
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -13,6 +13,7 @@ Covers:
 
 from __future__ import annotations
 
+import ipaddress
 import json
 from pathlib import Path
 
@@ -729,3 +730,48 @@ class TestBL10SteamWorkerSettings:
         get_settings.cache_clear()
         with pytest.raises(ValueError, match=r"steam_worker_max_restart_attempts"):
             Settings()
+
+
+# ----------------------------------------------------------------------
+# 10. Source-IP allowlist
+# ----------------------------------------------------------------------
+
+
+class TestAllowedSourceIps:
+    def test_default_is_empty(self):
+        s = Settings(orchestrator_token="t" * 32)
+        assert s.allowed_source_ips == []
+        assert s.allowed_source_networks == []
+
+    def test_comma_separated_string_parses_to_list(self, monkeypatch):
+        monkeypatch.setenv("ORCH_TOKEN", "t" * 32)
+        monkeypatch.setenv("ORCH_ALLOWED_SOURCE_IPS", " 10.100.23.102 , 10.0.0.0/24 ")
+        get_settings.cache_clear()
+        s = get_settings()
+        assert s.allowed_source_ips == ["10.100.23.102", "10.0.0.0/24"]
+        get_settings.cache_clear()
+
+    def test_list_input_passes_through(self):
+        s = Settings(orchestrator_token="t" * 32, allowed_source_ips=["10.100.23.102"])
+        assert s.allowed_source_ips == ["10.100.23.102"]
+
+    def test_allowed_source_networks_parses_entries(self):
+        s = Settings(
+            orchestrator_token="t" * 32,
+            allowed_source_ips=["10.100.23.102", "10.0.0.0/24"],
+        )
+        nets = s.allowed_source_networks
+        assert ipaddress.ip_address("10.100.23.102") in nets[0]
+        assert ipaddress.ip_address("10.0.0.55") in nets[1]
+
+    def test_invalid_cidr_rejected_at_construction(self):
+        with pytest.raises(ValidationError):
+            Settings(orchestrator_token="t" * 32, allowed_source_ips=["10.0.0.0/99"])
+
+    def test_invalid_ip_rejected_at_construction(self):
+        with pytest.raises(ValidationError):
+            Settings(orchestrator_token="t" * 32, allowed_source_ips=["not-an-ip"])
+
+    def test_allow_any_entry_is_accepted(self):
+        s = Settings(orchestrator_token="t" * 32, allowed_source_ips=["0.0.0.0/0"])
+        assert ipaddress.ip_address("8.8.8.8") in s.allowed_source_networks[0]


### PR DESCRIPTION
## Orchestrator LAN-bind + source-IP allowlist

Lets the orchestrator API be bound to the LAN (so Game_shelf on `10.100.23.102` can reach it) while a fail-closed, application-level source-IP allowlist guarantees only declared sources can connect. **Unblocks live F14–F17 Game_shelf verification.**

Spec: `docs/superpowers/specs/2026-06-18-lan-bind-allowlist-design.md` · Plan: `docs/superpowers/plans/2026-06-18-lan-bind-allowlist.md`

### Locked decisions (from brainstorming)
- **Plaintext + source allowlist** — the inter-guest VLAN is treated as trusted; the bearer token + a fail-closed allowlist are the gates (no TLS/reverse proxy — a proxy would defeat OQ2/allowlist, which read `scope["client"]` directly).
- **In-repo app allowlist + documented host firewall** — the allowlist ships in code (tested); the host nftables rule is documented for manual `sudo` application.

### What
- **`ORCH_ALLOWED_SOURCE_IPS`** setting (comma-separated IPs/CIDRs, default empty) + parsed `Settings.allowed_source_networks`.
- **`SourceAllowlistMiddleware`** — 403s any source that is not loopback or in the allowlist, on **every** path (incl. `/health`), before any auth/body work; a **pure no-op when the allowlist is empty** (keeps the default/loopback deploy and the whole test suite unaffected).
- **Fail-closed boot guard** — a non-loopback bind (`ORCH_API_HOST`, `UVICORN_HOST`, or `--host` argv) with an empty allowlist **refuses to start** (`api.boot.lan_bind_without_allowlist` + `SystemExit`).
- **OQ2 unchanged** — credential-intake / 2FA-submit / schema endpoints stay loopback-only; an allowlisted-but-remote host still gets 403 on those (verified by test).

### Test
- 1283 passing locally; ruff clean. (The one local failure is `tests/test_licenses.py`, which shells out to the `pip-licenses` CLI that isn't installed in my env — unrelated; passes in CI.)
- New `tests/api/test_source_allowlist.py`: matcher (incl. IPv4-mapped-IPv6 fail-closed regression guard), middleware (no-op vs enforcing), full-stack integration (unlisted→403 on health+games, listed→401-without-token/200-with, OQ2 still 403s `/auth`, rejected source keeps correlation-id), boot guard.
- Built test-first via subagent-driven development with spec + code-quality review after each task.

### Deploy (docs in README)
`ORCH_API_HOST=0.0.0.0` + `ORCH_ALLOWED_SOURCE_IPS=10.100.23.102` + LAN-scoped publish `-p 192.168.1.40:8765:8765`, plus the documented host nftables rule (manual sudo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)