### PR TITLE
fix(steam): run SteamPrefill from config_dir.parent so it resolves ./Config

### DIFF
--- a/src/orchestrator/platform/steam/prefill_driver.py
+++ b/src/orchestrator/platform/steam/prefill_driver.py
@@ -40,8 +40,14 @@ class SteamPrefillDriver:
         self._selection_path.write_text(json.dumps([int(a) for a in app_ids]))
         try:
             args = [str(self._binary), "prefill", "--no-ansi", *(["--force"] if force else [])]
+            # SteamPrefill resolves its Config/ dir RELATIVE TO the working
+            # directory (./Config), not the binary path. Run it from the parent
+            # of our config_dir so ./Config maps to exactly config_dir —
+            # otherwise it finds no account.config and login fails (the failure
+            # is masked by a Spectre.Console crash; see the 2026-06-21 flip).
             proc = await asyncio.create_subprocess_exec(
                 *args,
+                cwd=str(self._config_dir.parent),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
             )

--- a/tests/platform/steam/test_prefill_driver.py
+++ b/tests/platform/steam/test_prefill_driver.py
@@ -1,5 +1,6 @@
 import json
 import stat
+from pathlib import Path
 
 import pytest
 
@@ -32,6 +33,22 @@ async def test_prefill_apps_restores_prior_selection(tmp_path):
     await d.prefill_apps([730], force=False)
     # the operator's prior selection is restored after the run
     assert json.loads((cfg / "selectedAppsToPrefill.json").read_text()) == [111, 222]
+
+
+@pytest.mark.asyncio
+async def test_prefill_apps_runs_from_config_parent_cwd(tmp_path):
+    # SteamPrefill resolves its Config/ dir RELATIVE TO the working directory
+    # (./Config), not the binary path, so the driver must run it from
+    # config_dir.parent — otherwise it finds no account.config and login fails.
+    cfg = tmp_path / "Config"
+    cfg.mkdir()
+    marker = tmp_path / "cwd.txt"
+    bin_path = tmp_path / "FakeSteamPrefill"
+    bin_path.write_text(f'#!/bin/sh\npwd > "{marker}"\nexit 0\n')
+    bin_path.chmod(bin_path.stat().st_mode | stat.S_IEXEC)
+    d = SteamPrefillDriver(binary=bin_path, config_dir=cfg)
+    await d.prefill_apps([730])
+    assert Path(marker.read_text().strip()).resolve() == tmp_path.resolve()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`SteamPrefill` resolves its `Config/` directory **relative to the working directory** (`./Config`), not relative to the binary path. `SteamPrefillDriver.prefill_apps` invoked the binary without a `cwd`, so when the process CWD wasn't the install dir, SteamPrefill found no `account.config` → login failed ("Already disconnected from Steam"), with the real error masked by a Spectre.Console crash.

This was **diagnosed live during the re-architecture ② flip** (the agent container ran SteamPrefill from the wrong CWD), where it was worked around with a `-w /SteamPrefill` container workdir. This is the proper code fix.

## Change

Pass `cwd=config_dir.parent` to `create_subprocess_exec`, so `./Config` maps to exactly the configured `config_dir` regardless of the container/process CWD — removing the need for the workdir hack.

## Testing

- New regression test (`test_prefill_apps_runs_from_config_parent_cwd`): a fake binary records `pwd`; asserts it ran from `config_dir.parent`. Red without the fix, green with it.
- `tests/platform/steam` + `tests/jobs/test_prefill_handler.py`: **117 passed**. mypy + ruff clean.

## Follow-up (deploy)

Once merged + the image rebuilt, the agent's `-w /SteamPrefill` workdir flag in `/home/karl/deploy-agent.sh` becomes redundant (harmless to keep). The other agent env (`HOME=/tmp`, `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1`, the Config `chmod 666`, the `/SteamPrefill` mount) are still required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)