### PR TITLE
fix(steam): source validate manifests from the .bin cache, not the json (③a gate fix)

### DIFF
--- a/src/orchestrator/agent/manifest_locator.py
+++ b/src/orchestrator/agent/manifest_locator.py
@@ -1,35 +1,36 @@
 """Locate an app's current manifest .bin files in SteamPrefill's cache.
 
-SteamPrefill records what it prefilled in Config/successfullyDownloadedDepots.json
-({app_id_str: [manifest_gid_ints]}) and caches each manifest as
-<cache_root>/v1/{app}_{app}_{depot}_{gid}.bin. We pick the .bin for each gid the
-app prefilled (the current per-depot manifests).
+SteamPrefill caches each depot manifest as
+<cache_root>/v1/{app}_{app}_{depot}_{gid}.bin. For an app we take the NEWEST
+.bin (by mtime) per depot — the most recently fetched manifest, which tracks
+what is currently prefilled into lancache.
+
+This deliberately does NOT use Config/successfullyDownloadedDepots.json: that
+file proved unreliable as a manifest index (it omits apps that have cached
+manifests and lists only a subset of an app's depot gids — found live during
+the ③a gate). The .bin cache itself is the source of truth.
 """
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 
-def locate_manifest_bins(app_id: int, *, cache_root: Path, config_dir: Path) -> list[Path]:
-    downloaded_path = config_dir / "successfullyDownloadedDepots.json"
-    if not downloaded_path.exists():
-        return []
-    try:
-        downloaded = json.loads(downloaded_path.read_text())
-    except (json.JSONDecodeError, OSError):
-        return []
-    gids = downloaded.get(str(app_id))
-    if not gids:
-        return []
+def locate_manifest_bins(app_id: int, *, cache_root: Path) -> list[Path]:
+    """Return the newest manifest .bin per depot for ``app_id`` (empty if none)."""
     v1 = cache_root / "v1"
-    found: list[Path] = []
-    for gid in gids:
-        # filename is {app}_{app}_{depot}_{gid}.bin; depot is unknown here, glob by gid.
-        matches = list(v1.glob(f"{app_id}_{app_id}_*_{gid}.bin"))
-        found.extend(matches)
-    return found
+    if not v1.is_dir():
+        return []
+    newest_per_depot: dict[str, Path] = {}
+    for path in v1.glob(f"{app_id}_{app_id}_*.bin"):
+        parts = path.stem.split("_")
+        if len(parts) != 4:
+            continue
+        depot = parts[2]
+        current = newest_per_depot.get(depot)
+        if current is None or path.stat().st_mtime > current.stat().st_mtime:
+            newest_per_depot[depot] = path
+    return list(newest_per_depot.values())

--- a/src/orchestrator/agent/routers/steam.py
+++ b/src/orchestrator/agent/routers/steam.py
@@ -98,10 +98,9 @@ def _classify(total: int, cached: int) -> str:
 async def steam_validate(body: SteamValidateRequest, request: Request) -> dict[str, Any]:
     settings = request.app.state.settings
     cache_root = Path(settings.lancache_nginx_cache_path)
-    config_dir = Path(settings.steam_prefill_config_dir)
     manifest_cache = Path(settings.steam_manifest_cache_dir)
 
-    bins = locate_manifest_bins(body.app_id, cache_root=manifest_cache, config_dir=config_dir)
+    bins = locate_manifest_bins(body.app_id, cache_root=manifest_cache)
     if not bins:
         return {
             "chunks_total": 0,

--- a/tests/agent/test_manifest_locator.py
+++ b/tests/agent/test_manifest_locator.py
@@ -1,8 +1,8 @@
-"""Tests for locating an app's current manifest .bin files."""
+"""Tests for locating an app's current manifest .bin files (cache-based)."""
 
 from __future__ import annotations
 
-import json
+import os
 from typing import TYPE_CHECKING
 
 from orchestrator.agent.manifest_locator import locate_manifest_bins
@@ -11,42 +11,35 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-def _setup(tmp_path: Path, downloaded: dict, bin_names: list[str]) -> tuple[Path, Path]:
-    cache = tmp_path / "cache" / "v1"
-    cache.mkdir(parents=True)
-    for name in bin_names:
-        (cache / name).write_bytes(b"x")
-    cfg = tmp_path / "Config"
-    cfg.mkdir()
-    (cfg / "successfullyDownloadedDepots.json").write_text(json.dumps(downloaded))
-    return cache.parent, cfg
+def _write(cache_root: Path, name: str, mtime: int) -> Path:
+    v1 = cache_root / "v1"
+    v1.mkdir(parents=True, exist_ok=True)
+    p = v1 / name
+    p.write_bytes(b"x")
+    os.utime(p, (mtime, mtime))
+    return p
 
 
-def test_locates_bins_for_app(tmp_path):
-    cache_root, cfg = _setup(
-        tmp_path,
-        {"440": [111, 222]},
-        ["440_440_4401_111.bin", "440_440_4402_222.bin", "570_570_5701_999.bin"],
-    )
-    found = locate_manifest_bins(440, cache_root=cache_root, config_dir=cfg)
-    names = sorted(p.name for p in found)
-    assert names == ["440_440_4401_111.bin", "440_440_4402_222.bin"]
+def test_locates_newest_bin_per_depot(tmp_path):
+    # app 440, depots 440 and 441. Depot 441 has two gids -> newest mtime wins.
+    _write(tmp_path, "440_440_440_111.bin", 1000)
+    _write(tmp_path, "440_440_441_222.bin", 1000)
+    _write(tmp_path, "440_440_441_333.bin", 2000)  # newer for depot 441
+    _write(tmp_path, "570_570_5701_999.bin", 1000)  # other app
+    found = sorted(p.name for p in locate_manifest_bins(440, cache_root=tmp_path))
+    assert found == ["440_440_440_111.bin", "440_440_441_333.bin"]
 
 
-def test_app_not_prefilled_returns_empty(tmp_path):
-    cache_root, cfg = _setup(tmp_path, {"440": [111]}, ["440_440_4401_111.bin"])
-    assert locate_manifest_bins(999, cache_root=cache_root, config_dir=cfg) == []
+def test_app_with_no_bins_returns_empty(tmp_path):
+    _write(tmp_path, "440_440_440_111.bin", 1000)
+    assert locate_manifest_bins(999, cache_root=tmp_path) == []
 
 
-def test_missing_bin_for_gid_skipped(tmp_path):
-    cache_root, cfg = _setup(tmp_path, {"440": [111, 222]}, ["440_440_4401_111.bin"])
-    found = locate_manifest_bins(440, cache_root=cache_root, config_dir=cfg)
-    assert [p.name for p in found] == ["440_440_4401_111.bin"]
+def test_no_cache_dir_returns_empty(tmp_path):
+    assert locate_manifest_bins(440, cache_root=tmp_path / "missing") == []
 
 
-def test_no_downloaded_file_returns_empty(tmp_path):
-    cache = tmp_path / "cache" / "v1"
-    cache.mkdir(parents=True)
-    cfg = tmp_path / "Config"
-    cfg.mkdir()
-    assert locate_manifest_bins(440, cache_root=cache.parent, config_dir=cfg) == []
+def test_single_depot_single_gid(tmp_path):
+    _write(tmp_path, "1182900_1182900_1182901_3367036266289852265.bin", 1000)
+    found = locate_manifest_bins(1182900, cache_root=tmp_path)
+    assert [p.name for p in found] == ["1182900_1182900_1182901_3367036266289852265.bin"]


### PR DESCRIPTION
## Summary

Fix found by the **③a live gate** (PR #180). The agent's `/v1/steam/validate` located manifests via `successfullyDownloadedDepots.json`, but that file is an **unreliable manifest index** on the live box:
- It **omits apps that have cached manifests** (e.g. Terraria 105600 → `None`, despite 7 cached `.bin`s).
- It lists only a **subset of an app's depot gids** (e.g. TF2 440 had depot 440 but not depot 441).

So the json-based locator returned no/partial manifests for the vast majority of apps (only 3 of 2248 apps had a json-gid that matched a cached `.bin`).

## Fix

`locate_manifest_bins` now uses the **`.bin` cache itself** as the source of truth: glob `{app}_{app}_{depot}_{gid}.bin` and take the **newest (by mtime) per depot** — the most recently fetched manifest, which tracks what's currently prefilled into lancache. The `config_dir` / json dependency is dropped from both the locator and the `/v1/steam/validate` endpoint.

Verified live: e.g. app 1182900 has one `.bin` (depot 1182901, gid 3367036266289852265) matching the DB manifest's 51,192 chunks.

## Testing

`tests/agent/test_manifest_locator.py` rewritten (newest-per-depot, multi-depot, no-bins, no-cache-dir). 1361 passed (lone failure = pre-existing pip-licenses); mypy + ruff clean.

This unblocks the ③a live flip; once merged I re-run Gate A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)