### PR TITLE
fix(steam): give steam_validate a 300s timeout for large games (③a gate fix)

### DIFF
--- a/src/orchestrator/clients/agent_client.py
+++ b/src/orchestrator/clients/agent_client.py
@@ -86,7 +86,15 @@ class AgentClient:
         return result
 
     async def steam_validate(self, app_id: int) -> dict[str, Any]:
-        resp = await self._request("POST", "/v1/steam/validate", json={"app_id": app_id})
+        # A big game (tens of thousands of chunks) stat's many cache files over
+        # NFS and can take well over the default 30s timeout — use a generous
+        # per-call timeout so validate doesn't AgentError on large apps.
+        resp = await self._request(
+            "POST",
+            "/v1/steam/validate",
+            json={"app_id": app_id},
+            timeout=httpx.Timeout(300.0, connect=10.0),
+        )
         result: dict[str, Any] = resp.json()
         return result
 

--- a/tests/clients/test_agent_client.py
+++ b/tests/clients/test_agent_client.py
@@ -129,3 +129,28 @@ async def test_steam_validate_unreachable_raises():
     client = _client(handler)
     with pytest.raises(AgentError):
         await client.steam_validate(1018130)
+
+
+async def test_steam_validate_uses_long_timeout():
+    # A large validate (tens of thousands of chunks) stat's many files over NFS
+    # and can take well over the default 30s; steam_validate must use a generous
+    # per-call timeout so it doesn't AgentError on big games.
+    seen = {}
+
+    def handler(request):
+        seen["timeout"] = request.extensions.get("timeout")
+        return httpx.Response(
+            200,
+            json={
+                "chunks_total": 1,
+                "chunks_cached": 1,
+                "chunks_missing": 0,
+                "outcome": "cached",
+                "versions": "",
+                "error": None,
+            },
+        )
+
+    client = _client(handler)
+    await client.steam_validate(1)
+    assert seen["timeout"]["read"] == 300.0


### PR DESCRIPTION
## Summary

Second fix found by the **③a live gate**. A large game (e.g. 51,192 chunks) takes **~30s of NFS stat** on the agent, which hits the `AgentClient`'s default 30s read timeout and fails with `AgentError` (worse under concurrent load — the worker validate of game 1719 timed out at exactly 30036ms while the agent was still processing).

## Fix

`AgentClient.steam_validate` now uses a generous **300s per-call timeout** (validate is a background job, not latency-sensitive; the biggest games ~163k chunks stat in ~90s). The global 30s default stays for latency-sensitive calls (e.g. the `/health` agent-reachability probe), so a down agent is still detected fast.

## Testing

New test asserts the 300s read timeout is applied to the steam_validate request (via `request.extensions["timeout"]`). 10 client tests pass; mypy + ruff clean.

Unblocks the ③a live re-gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)