### PR TITLE
feat(steam): library enumerate via SteamPrefill + flag (re-arch ③b)

### DIFF
--- a/src/orchestrator/core/settings.py
+++ b/src/orchestrator/core/settings.py
@@ -111,6 +111,9 @@ class Settings(BaseSettings):
     # Flag: route Steam validate through the agent's /v1/steam/validate (parses
     # SteamPrefill manifests) instead of the legacy worker manifest_expand.
     steam_validate_via_agent: bool = False
+    # Flag: source the Steam library from SteamPrefill (prefilled apps) instead
+    # of the legacy worker library_enumerate.
+    steam_enumerate_via_prefill: bool = False
 
     # --- Lancache cache topology ------------------------------------
     lancache_nginx_cache_path: Path = Path("/data/cache/cache/")

--- a/src/orchestrator/jobs/handlers/library_sync.py
+++ b/src/orchestrator/jobs/handlers/library_sync.py
@@ -18,10 +18,21 @@ from typing import TYPE_CHECKING, Any
 
 import structlog
 
+from orchestrator.core.settings import get_settings
+
 if TYPE_CHECKING:
     from orchestrator.jobs.worker import Deps
 
 _log = structlog.get_logger(__name__)
+
+# Title-preserving upsert for the SteamPrefill-sourced enumeration: list_owned
+# gives app_ids without names, so a NEW app gets the app_id as its placeholder
+# title (set on INSERT), while an EXISTING app keeps its title — only `owned`
+# is updated on conflict.
+_PREFILL_UPSERT_SQL = (
+    "INSERT INTO games (platform, app_id, title) VALUES ('steam', ?, ?) "
+    "ON CONFLICT(platform, app_id) DO UPDATE SET owned = 1"
+)
 
 _UPSERT_SQL = (
     "INSERT INTO games (platform, app_id, title, owned, metadata, current_version) "
@@ -44,6 +55,22 @@ async def library_sync_handler(job: dict[str, Any], deps: Deps) -> None:
     if platform == "epic":
         return await _epic_library_sync(job, deps)
     raise ValueError(f"library_sync: unsupported platform {platform!r}")
+
+
+async def _steam_library_sync_via_prefill(job: dict[str, Any], deps: Deps) -> None:
+    """Enumerate the Steam library from SteamPrefill's prefilled apps (re-arch
+    ③b). list_owned() gives app_ids only; the title-preserving upsert keeps any
+    existing name and uses the app_id as the placeholder title for new apps."""
+    if deps.prefill_driver is None:
+        raise RuntimeError("prefill_driver is required when steam_enumerate_via_prefill")
+    job_id = job.get("id")
+    owned = deps.prefill_driver.list_owned()
+    _log.info("library_sync.prefill.enumerate.returned", job_id=job_id, app_count=len(owned))
+    for app in owned:
+        await deps.pool.execute_write(
+            _PREFILL_UPSERT_SQL, (str(app.app_id), app.name or str(app.app_id))
+        )
+    _log.info("library_sync.prefill.upserted", job_id=job_id, upserted=len(owned))
 
 
 async def _epic_library_sync(job: dict[str, Any], deps: Deps) -> None:
@@ -93,6 +120,9 @@ async def _steam_library_sync(job: dict[str, Any], deps: Deps) -> None:
             operator-facing /platforms surface matches reality before the
             re-raise marks the job failed (F-UAT6-3).
     """
+    if get_settings().steam_enumerate_via_prefill:
+        return await _steam_library_sync_via_prefill(job, deps)
+
     from orchestrator.platform.steam.client import SteamWorkerError
 
     if deps.steam_client is None:

--- a/src/orchestrator/platform/steam/prefill_driver.py
+++ b/src/orchestrator/platform/steam/prefill_driver.py
@@ -24,6 +24,12 @@ class SteamAuthStatus:
     reason: str = ""
 
 
+@dataclass(frozen=True)
+class OwnedApp:
+    app_id: int
+    name: str = ""
+
+
 class SteamPrefillDriver:
     def __init__(self, *, binary: Path, config_dir: Path) -> None:
         self._binary = Path(binary)
@@ -65,6 +71,21 @@ class SteamPrefillDriver:
             return {}
         data = json.loads(p.read_text())
         return {int(k): [int(g) for g in v] for k, v in data.items()}
+
+    def list_owned(self) -> list[OwnedApp]:
+        """Owned/prefilled apps from successfullyDownloadedDepots.json keys.
+
+        SteamPrefill has no non-interactive owned-apps-with-names enumeration
+        (select-apps is a TTY-only picker), so this sources the prefilled apps
+        (the ones with cache to validate). Names are unknown here (empty) — the
+        library_sync upsert keeps existing names and uses the app_id as the
+        placeholder title for brand-new apps.
+        """
+        p = self._config_dir / "successfullyDownloadedDepots.json"
+        if not p.exists():
+            return []
+        data = json.loads(p.read_text())
+        return [OwnedApp(app_id=int(k)) for k in data]
 
     def auth_status(self) -> SteamAuthStatus:
         """account.config present => SteamPrefill is/was authed (its ~6-month token;

--- a/tests/jobs/test_library_sync_handler.py
+++ b/tests/jobs/test_library_sync_handler.py
@@ -268,3 +268,54 @@ class TestCurrentVersion:
         assert row["status"] == "up_to_date"  # untouched
         assert row["cached_version"] == "99"  # untouched
         assert row["current_version"] == "42"  # updated
+
+
+class _StubDriver:
+    def __init__(self, owned):
+        self._owned = owned
+
+    def list_owned(self):
+        return self._owned
+
+
+class TestEnumerateViaPrefill:
+    async def test_upserts_from_list_owned(self, pool, monkeypatch):
+        from orchestrator.core import settings as settings_mod
+        from orchestrator.platform.steam.prefill_driver import OwnedApp
+
+        monkeypatch.setattr(
+            "orchestrator.jobs.handlers.library_sync.get_settings",
+            lambda: settings_mod.Settings(
+                orchestrator_token="a" * 32, steam_enumerate_via_prefill=True
+            ),
+        )
+        driver = _StubDriver([OwnedApp(440), OwnedApp(570)])
+        await library_sync_handler(
+            _job(), Deps(pool=pool, steam_client=None, prefill_driver=driver)
+        )
+        rows = await pool.read_all(
+            "SELECT app_id, title FROM games WHERE platform='steam' ORDER BY app_id"
+        )
+        assert [(r["app_id"], r["title"]) for r in rows] == [("440", "440"), ("570", "570")]
+
+    async def test_existing_title_preserved(self, pool, monkeypatch):
+        from orchestrator.core import settings as settings_mod
+        from orchestrator.platform.steam.prefill_driver import OwnedApp
+
+        await pool.execute_write(
+            "INSERT INTO games (platform, app_id, title, owned) "
+            "VALUES ('steam','440','Team Fortress 2',0)"
+        )
+        monkeypatch.setattr(
+            "orchestrator.jobs.handlers.library_sync.get_settings",
+            lambda: settings_mod.Settings(
+                orchestrator_token="a" * 32, steam_enumerate_via_prefill=True
+            ),
+        )
+        driver = _StubDriver([OwnedApp(440)])
+        await library_sync_handler(
+            _job(), Deps(pool=pool, steam_client=None, prefill_driver=driver)
+        )
+        row = await pool.read_one("SELECT title, owned FROM games WHERE app_id='440'")
+        assert row["title"] == "Team Fortress 2"  # existing name kept
+        assert row["owned"] == 1  # marked owned

--- a/tests/platform/steam/test_prefill_driver.py
+++ b/tests/platform/steam/test_prefill_driver.py
@@ -89,3 +89,20 @@ def test_auth_status_present_ok(tmp_path):
     (cfg / "account.config").write_bytes(b"\x0a\x05hello")
     d = SteamPrefillDriver(binary=tmp_path / "x", config_dir=cfg)
     assert d.auth_status().ok is True
+
+
+def test_list_owned_from_downloaded_depots(tmp_path):
+    cfg = tmp_path / "Config"
+    cfg.mkdir()
+    (cfg / "successfullyDownloadedDepots.json").write_text('{"440":[1],"570":[2,3]}')
+    d = SteamPrefillDriver(binary=tmp_path / "bin", config_dir=cfg)
+    owned = d.list_owned()
+    assert sorted(o.app_id for o in owned) == [440, 570]
+    assert all(o.name == "" for o in owned)
+
+
+def test_list_owned_missing_file_returns_empty(tmp_path):
+    cfg = tmp_path / "Config"
+    cfg.mkdir()
+    d = SteamPrefillDriver(binary=tmp_path / "bin", config_dir=cfg)
+    assert d.list_owned() == []


### PR DESCRIPTION
## Summary

**Phase ③b** of roadmap ③. The Steam library can now be sourced from **SteamPrefill's prefilled apps** instead of the worker's `library_enumerate` — behind a flag.

### The constraint (recon)
SteamPrefill has **no non-interactive owned-apps-with-names enumeration** (`select-apps` is a TTY-only picker). Quantified on the box: worker = 2485 owned (with names); `successfullyDownloadedDepots.json` = 2248 prefilled apps (90%, app_ids only); `selectedAppsToPrefill.json` = 1077 curated. Per the chosen direction, ③b sources the **prefilled apps** (the ones with cache to validate).

### What's in it
- `SteamPrefillDriver.list_owned()` → `list[OwnedApp{app_id, name=""}]` from `successfullyDownloadedDepots.json` keys.
- Steam `library_sync` → `list_owned` behind `steam_enumerate_via_prefill` (default **False** = existing worker path, unchanged — existing tests are the equivalence net).
- **Title-preserving upsert**: list_owned has no names, so a NEW app gets the app_id as its placeholder title (on INSERT), while an EXISTING app keeps its name and is just marked `owned` (on conflict). This avoids clobbering existing titles with placeholders.

### Trade-off (accepted)
Loses the ~237 un-prefilled owned games (nothing to validate anyway) and proper names for brand-new apps (placeholder = app_id until a name source exists).

## ③b live gate (after merge)
Flip `ORCH_STEAM_ENUMERATE_VIA_PREFILL=true`, run a `library_sync`, confirm `games` populates equivalently (existing names preserved, prefilled apps marked owned).

## Testing
1366 passed (lone failure = pre-existing pip-licenses); mypy + ruff clean. `list_owned` tested; library_sync flag-on tested (new app → placeholder title; existing title preserved + owned set); flag-off = existing tests unchanged.

## Next
③c: delete the worker stack + `manifest_fetch` + Steam auth + venv, collapse the `steam_validate_via_agent` + `steam_enumerate_via_prefill` flags, drop `manifests.raw`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)