### PR TITLE
fix(steam): enumerate the library via the agent, not the control-plane driver (③b gate fix)

### DIFF
--- a/src/orchestrator/jobs/handlers/library_sync.py
+++ b/src/orchestrator/jobs/handlers/library_sync.py
@@ -59,18 +59,20 @@ async def library_sync_handler(job: dict[str, Any], deps: Deps) -> None:
 
 async def _steam_library_sync_via_prefill(job: dict[str, Any], deps: Deps) -> None:
     """Enumerate the Steam library from SteamPrefill's prefilled apps (re-arch
-    ③b). list_owned() gives app_ids only; the title-preserving upsert keeps any
-    existing name and uses the app_id as the placeholder title for new apps."""
-    if deps.prefill_driver is None:
-        raise RuntimeError("prefill_driver is required when steam_enumerate_via_prefill")
+    ③b). SteamPrefill lives on the lancache host (agent side), so this reads the
+    agent's downloaded-state ({app_id: [gids]}) rather than the orchestrator's
+    driver (the control plane has no /SteamPrefill mount). The keys are the
+    prefilled app_ids; the title-preserving upsert keeps any existing name and
+    uses the app_id as the placeholder title for new apps."""
+    if deps.agent_client is None:
+        raise RuntimeError("agent_client is required when steam_enumerate_via_prefill")
     job_id = job.get("id")
-    owned = deps.prefill_driver.list_owned()
-    _log.info("library_sync.prefill.enumerate.returned", job_id=job_id, app_count=len(owned))
-    for app in owned:
-        await deps.pool.execute_write(
-            _PREFILL_UPSERT_SQL, (str(app.app_id), app.name or str(app.app_id))
-        )
-    _log.info("library_sync.prefill.upserted", job_id=job_id, upserted=len(owned))
+    state = await deps.agent_client.downloaded_state()
+    app_ids = list(state)
+    _log.info("library_sync.prefill.enumerate.returned", job_id=job_id, app_count=len(app_ids))
+    for app_id in app_ids:
+        await deps.pool.execute_write(_PREFILL_UPSERT_SQL, (str(app_id), str(app_id)))
+    _log.info("library_sync.prefill.upserted", job_id=job_id, upserted=len(app_ids))
 
 
 async def _epic_library_sync(job: dict[str, Any], deps: Deps) -> None:

--- a/src/orchestrator/platform/steam/prefill_driver.py
+++ b/src/orchestrator/platform/steam/prefill_driver.py
@@ -24,12 +24,6 @@ class SteamAuthStatus:
     reason: str = ""
 
 
-@dataclass(frozen=True)
-class OwnedApp:
-    app_id: int
-    name: str = ""
-
-
 class SteamPrefillDriver:
     def __init__(self, *, binary: Path, config_dir: Path) -> None:
         self._binary = Path(binary)
@@ -71,21 +65,6 @@ class SteamPrefillDriver:
             return {}
         data = json.loads(p.read_text())
         return {int(k): [int(g) for g in v] for k, v in data.items()}
-
-    def list_owned(self) -> list[OwnedApp]:
-        """Owned/prefilled apps from successfullyDownloadedDepots.json keys.
-
-        SteamPrefill has no non-interactive owned-apps-with-names enumeration
-        (select-apps is a TTY-only picker), so this sources the prefilled apps
-        (the ones with cache to validate). Names are unknown here (empty) — the
-        library_sync upsert keeps existing names and uses the app_id as the
-        placeholder title for brand-new apps.
-        """
-        p = self._config_dir / "successfullyDownloadedDepots.json"
-        if not p.exists():
-            return []
-        data = json.loads(p.read_text())
-        return [OwnedApp(app_id=int(k)) for k in data]
 
     def auth_status(self) -> SteamAuthStatus:
         """account.config present => SteamPrefill is/was authed (its ~6-month token;

--- a/tests/jobs/test_library_sync_handler.py
+++ b/tests/jobs/test_library_sync_handler.py
@@ -270,18 +270,17 @@ class TestCurrentVersion:
         assert row["current_version"] == "42"  # updated
 
 
-class _StubDriver:
-    def __init__(self, owned):
-        self._owned = owned
+class _StubAgent:
+    def __init__(self, state):
+        self._state = state
 
-    def list_owned(self):
-        return self._owned
+    async def downloaded_state(self):
+        return self._state
 
 
 class TestEnumerateViaPrefill:
-    async def test_upserts_from_list_owned(self, pool, monkeypatch):
+    async def test_upserts_from_downloaded_state(self, pool, monkeypatch):
         from orchestrator.core import settings as settings_mod
-        from orchestrator.platform.steam.prefill_driver import OwnedApp
 
         monkeypatch.setattr(
             "orchestrator.jobs.handlers.library_sync.get_settings",
@@ -289,10 +288,8 @@ class TestEnumerateViaPrefill:
                 orchestrator_token="a" * 32, steam_enumerate_via_prefill=True
             ),
         )
-        driver = _StubDriver([OwnedApp(440), OwnedApp(570)])
-        await library_sync_handler(
-            _job(), Deps(pool=pool, steam_client=None, prefill_driver=driver)
-        )
+        agent = _StubAgent({"440": [1], "570": [2, 3]})
+        await library_sync_handler(_job(), Deps(pool=pool, steam_client=None, agent_client=agent))
         rows = await pool.read_all(
             "SELECT app_id, title FROM games WHERE platform='steam' ORDER BY app_id"
         )
@@ -300,7 +297,6 @@ class TestEnumerateViaPrefill:
 
     async def test_existing_title_preserved(self, pool, monkeypatch):
         from orchestrator.core import settings as settings_mod
-        from orchestrator.platform.steam.prefill_driver import OwnedApp
 
         await pool.execute_write(
             "INSERT INTO games (platform, app_id, title, owned) "
@@ -312,10 +308,8 @@ class TestEnumerateViaPrefill:
                 orchestrator_token="a" * 32, steam_enumerate_via_prefill=True
             ),
         )
-        driver = _StubDriver([OwnedApp(440)])
-        await library_sync_handler(
-            _job(), Deps(pool=pool, steam_client=None, prefill_driver=driver)
-        )
+        agent = _StubAgent({"440": [1]})
+        await library_sync_handler(_job(), Deps(pool=pool, steam_client=None, agent_client=agent))
         row = await pool.read_one("SELECT title, owned FROM games WHERE app_id='440'")
         assert row["title"] == "Team Fortress 2"  # existing name kept
         assert row["owned"] == 1  # marked owned

--- a/tests/platform/steam/test_prefill_driver.py
+++ b/tests/platform/steam/test_prefill_driver.py
@@ -89,20 +89,3 @@ def test_auth_status_present_ok(tmp_path):
     (cfg / "account.config").write_bytes(b"\x0a\x05hello")
     d = SteamPrefillDriver(binary=tmp_path / "x", config_dir=cfg)
     assert d.auth_status().ok is True
-
-
-def test_list_owned_from_downloaded_depots(tmp_path):
-    cfg = tmp_path / "Config"
-    cfg.mkdir()
-    (cfg / "successfullyDownloadedDepots.json").write_text('{"440":[1],"570":[2,3]}')
-    d = SteamPrefillDriver(binary=tmp_path / "bin", config_dir=cfg)
-    owned = d.list_owned()
-    assert sorted(o.app_id for o in owned) == [440, 570]
-    assert all(o.name == "" for o in owned)
-
-
-def test_list_owned_missing_file_returns_empty(tmp_path):
-    cfg = tmp_path / "Config"
-    cfg.mkdir()
-    d = SteamPrefillDriver(binary=tmp_path / "bin", config_dir=cfg)
-    assert d.list_owned() == []


### PR DESCRIPTION
## Summary

Fix found by the **③b live gate**. `library_sync` (control plane) called `deps.prefill_driver.list_owned()`, which reads `/SteamPrefill/Config/successfullyDownloadedDepots.json` — but the **orchestrator has no `/SteamPrefill` mount** (it was dropped in ③a when the agent took ownership of SteamPrefill). So it read a non-existent path and would enumerate **zero apps**.

## Fix

Route enumeration through the **agent**: `library_sync` now reads `deps.agent_client.downloaded_state()` (`{app_id: [gids]}`) — the agent already exposes `GET /v1/steam/downloaded-state` and has `/SteamPrefill` mounted. Its keys are the prefilled app_ids; the title-preserving upsert is unchanged. Removed the now-dead `SteamPrefillDriver.list_owned()` + `OwnedApp`.

This is consistent with ②/③a — **all SteamPrefill access goes through the agent**.

## Testing

library_sync flag-on tests rewired to a fake `agent_client.downloaded_state` (new app → placeholder title; existing title preserved + owned set); flag-off = existing worker tests unchanged. 1364 passed (lone failure = pre-existing pip-licenses); mypy + ruff clean.

Unblocks the ③b live re-gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)