### PR TITLE
fix(steam): enumerate library from .bin app_ids, not depot keys

### DIFF
--- a/src/orchestrator/agent/manifest_locator.py
+++ b/src/orchestrator/agent/manifest_locator.py
@@ -19,6 +19,24 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+def list_prefilled_app_ids(*, cache_root: Path) -> list[int]:
+    """Distinct app_ids that have a cached manifest .bin (sorted ascending).
+
+    The .bin filename is {app}_{app}_{depot}_{gid}.bin, so the first field is
+    the app_id. These are the prefilled GAMES (real app_ids), unlike
+    successfullyDownloadedDepots.json whose keys are depot_ids.
+    """
+    v1 = cache_root / "v1"
+    if not v1.is_dir():
+        return []
+    apps: set[int] = set()
+    for path in v1.glob("*.bin"):
+        first = path.stem.split("_", 1)[0]
+        if first.isdigit():
+            apps.add(int(first))
+    return sorted(apps)
+
+
 def locate_manifest_bins(app_id: int, *, cache_root: Path) -> list[Path]:
     """Return the newest manifest .bin per depot for ``app_id`` (empty if none)."""
     v1 = cache_root / "v1"

--- a/src/orchestrator/agent/routers/steam.py
+++ b/src/orchestrator/agent/routers/steam.py
@@ -9,7 +9,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel, ConfigDict, Field
 
-from orchestrator.agent.manifest_locator import locate_manifest_bins
+from orchestrator.agent.manifest_locator import list_prefilled_app_ids, locate_manifest_bins
 from orchestrator.agent.manifest_parser import parse_chunk_shas
 from orchestrator.validator.cache_key import (
     cache_key,
@@ -74,6 +74,14 @@ async def downloaded_state(request: Request) -> dict[str, list[int]]:
 async def auth_status(request: Request) -> dict[str, Any]:
     st = request.app.state.prefill_driver.auth_status()
     return {"ok": st.ok, "reason": st.reason}
+
+
+@router.get("/v1/steam/prefilled-apps")
+async def prefilled_apps(request: Request) -> dict[str, list[int]]:
+    """Distinct app_ids with a cached manifest (real game app_ids from the .bin
+    filenames) — the enumeration source for library_sync."""
+    manifest_cache = Path(request.app.state.settings.steam_manifest_cache_dir)
+    return {"app_ids": list_prefilled_app_ids(cache_root=manifest_cache)}
 
 
 class SteamValidateRequest(BaseModel):

--- a/src/orchestrator/clients/agent_client.py
+++ b/src/orchestrator/clients/agent_client.py
@@ -98,6 +98,11 @@ class AgentClient:
         result: dict[str, Any] = resp.json()
         return result
 
+    async def prefilled_apps(self) -> list[int]:
+        resp = await self._request("GET", "/v1/steam/prefilled-apps")
+        result: list[int] = resp.json()["app_ids"]
+        return result
+
     async def downloaded_state(self) -> dict[str, list[int]]:
         resp = await self._request("GET", "/v1/steam/downloaded-state")
         result: dict[str, list[int]] = resp.json()

--- a/src/orchestrator/jobs/handlers/library_sync.py
+++ b/src/orchestrator/jobs/handlers/library_sync.py
@@ -69,21 +69,21 @@ async def library_sync_handler(job: dict[str, Any], deps: Deps) -> None:
 async def _steam_library_sync_via_prefill(job: dict[str, Any], deps: Deps) -> None:
     """Enumerate the Steam library from SteamPrefill's prefilled apps (re-arch
     ③b). SteamPrefill lives on the lancache host (agent side), so this reads the
-    agent's downloaded-state ({app_id: [gids]}) rather than the orchestrator's
-    driver (the control plane has no /SteamPrefill mount).
+    agent's prefilled-apps — the distinct app_ids from the manifest .bin cache
+    filenames (real game app_ids), NOT successfullyDownloadedDepots.json (whose
+    keys are depot_ids with no store page).
 
-    The prefilled app_ids include Valve tools, dedicated servers and DLC — not
-    just games. To upsert only actual games (with their real names) we look each
-    uncached app up via the public Steam store appdetails API (no auth) for its
-    {type, name}, cache the result in steam_app_info, and upsert only
-    type=='game'. The store API is rate-limited (~200/5min) so each run is bound
-    by steam_store_fetch_budget; the rest fill on later scheduled syncs."""
+    Some prefilled app_ids may still be DLC; to upsert only actual games (with
+    their real names) we look each uncached app up via the public Steam store
+    appdetails API (no auth) for its {type, name}, cache the result in
+    steam_app_info, and upsert only type=='game'. The store API is rate-limited
+    (~200/5min) so each run is bound by steam_store_fetch_budget; the rest fill
+    on later scheduled syncs."""
     if deps.agent_client is None:
         raise RuntimeError("agent_client is required when steam_enumerate_via_prefill")
     settings = get_settings()
     job_id = job.get("id")
-    state = await deps.agent_client.downloaded_state()
-    app_ids = [str(a) for a in state]
+    app_ids = [str(a) for a in await deps.agent_client.prefilled_apps()]
     _log.info("library_sync.prefill.enumerate.returned", job_id=job_id, app_count=len(app_ids))
 
     cache: dict[str, dict[str, str]] = {

--- a/tests/agent/test_manifest_locator.py
+++ b/tests/agent/test_manifest_locator.py
@@ -43,3 +43,18 @@ def test_single_depot_single_gid(tmp_path):
     _write(tmp_path, "1182900_1182900_1182901_3367036266289852265.bin", 1000)
     found = locate_manifest_bins(1182900, cache_root=tmp_path)
     assert [p.name for p in found] == ["1182900_1182900_1182901_3367036266289852265.bin"]
+
+
+def test_list_prefilled_app_ids(tmp_path):
+    from orchestrator.agent.manifest_locator import list_prefilled_app_ids
+
+    _write(tmp_path, "440_440_440_111.bin", 1000)
+    _write(tmp_path, "440_440_441_222.bin", 1000)  # same app, diff depot
+    _write(tmp_path, "730_730_731_333.bin", 1000)
+    assert list_prefilled_app_ids(cache_root=tmp_path) == [440, 730]
+
+
+def test_list_prefilled_app_ids_no_cache(tmp_path):
+    from orchestrator.agent.manifest_locator import list_prefilled_app_ids
+
+    assert list_prefilled_app_ids(cache_root=tmp_path / "missing") == []

--- a/tests/agent/test_steam.py
+++ b/tests/agent/test_steam.py
@@ -62,3 +62,18 @@ def test_steam_prefill_rejects_negative_app_id():
     client = _client(_FakeDriver())
     resp = client.post("/v1/steam/prefill", json={"app_ids": [-5], "force": False})
     assert resp.status_code == 422
+
+
+def test_prefilled_apps_lists_distinct_app_ids(tmp_path):
+    v1 = tmp_path / "v1"
+    v1.mkdir()
+    for name in ("440_440_441_1.bin", "440_440_442_2.bin", "730_730_731_3.bin"):
+        (v1 / name).write_bytes(b"")
+    app = create_agent_app(
+        settings=Settings(orchestrator_token="a" * 32, steam_manifest_cache_dir=tmp_path)
+    )
+    app.state.prefill_driver = _FakeDriver()
+    client = TestClient(app, headers={"Authorization": "Bearer " + "a" * 32})
+    resp = client.get("/v1/steam/prefilled-apps")
+    assert resp.status_code == 200
+    assert resp.json() == {"app_ids": [440, 730]}

--- a/tests/clients/test_agent_client.py
+++ b/tests/clients/test_agent_client.py
@@ -64,6 +64,16 @@ async def test_stat_single_call():
     assert await client.stat(["a" * 32]) == {"cached": 3, "missing": 1}
 
 
+async def test_prefilled_apps_single_call():
+    def handler(request):
+        assert request.method == "GET"
+        assert request.url.path == "/v1/steam/prefilled-apps"
+        return httpx.Response(200, json={"app_ids": [440, 570, 730]})
+
+    client = _client(handler)
+    assert await client.prefilled_apps() == [440, 570, 730]
+
+
 async def test_auth_status_single_call():
     def handler(request):
         return httpx.Response(200, json={"ok": True, "reason": ""})

--- a/tests/jobs/test_library_sync_handler.py
+++ b/tests/jobs/test_library_sync_handler.py
@@ -271,11 +271,11 @@ class TestCurrentVersion:
 
 
 class _StubAgent:
-    def __init__(self, state):
-        self._state = state
+    def __init__(self, app_ids):
+        self._app_ids = app_ids
 
-    async def downloaded_state(self):
-        return self._state
+    async def prefilled_apps(self):
+        return self._app_ids
 
 
 class TestEnumerateViaPrefill:
@@ -306,7 +306,7 @@ class TestEnumerateViaPrefill:
             return {"type": "dlc", "name": "Some DLC"}
 
         monkeypatch.setattr("orchestrator.jobs.handlers.library_sync.fetch_app_info", fake_fetch)
-        agent = _StubAgent({"440": [1], "570": [2]})
+        agent = _StubAgent([440, 570])
         await library_sync_handler(_job(), Deps(pool=pool, steam_client=None, agent_client=agent))
 
         games = await pool.read_all(
@@ -333,7 +333,7 @@ class TestEnumerateViaPrefill:
             raise AssertionError("fetch_app_info must not be called on a cache hit")
 
         monkeypatch.setattr("orchestrator.jobs.handlers.library_sync.fetch_app_info", boom)
-        agent = _StubAgent({"440": [1]})
+        agent = _StubAgent([440])
         await library_sync_handler(_job(), Deps(pool=pool, steam_client=None, agent_client=agent))
 
         row = await pool.read_one("SELECT title, owned FROM games WHERE app_id='440'")
@@ -351,7 +351,7 @@ class TestEnumerateViaPrefill:
         monkeypatch.setattr(
             "orchestrator.jobs.handlers.library_sync.fetch_app_info", counting_fetch
         )
-        agent = _StubAgent({"1": [1], "2": [2], "3": [3]})
+        agent = _StubAgent([1, 2, 3])
         await library_sync_handler(_job(), Deps(pool=pool, steam_client=None, agent_client=agent))
 
         # Budget=1 → only one uncached app is looked up this run; the rest defer.
@@ -367,7 +367,7 @@ class TestEnumerateViaPrefill:
             return {"type": "game", "name": "Team Fortress 2"}
 
         monkeypatch.setattr("orchestrator.jobs.handlers.library_sync.fetch_app_info", fake_fetch)
-        agent = _StubAgent({"440": [1]})
+        agent = _StubAgent([440])
         await library_sync_handler(_job(), Deps(pool=pool, steam_client=None, agent_client=agent))
 
         row = await pool.read_one("SELECT title, owned FROM games WHERE app_id='440'")


### PR DESCRIPTION
## Gate B fix (re-arch ③b)

**Bug found live during Gate B:** `_steam_library_sync_via_prefill` sourced its app list from `successfullyDownloadedDepots.json`, whose keys are **depot IDs, not app IDs**. Depot IDs have no Steam store page, so every `appdetails` lookup returned NO_STORE_PAGE and **zero games were upserted**.

**Fix:** enumerate distinct app_ids from the manifest `.bin` filenames (`{app}_{app}_{depot}_{gid}.bin` → first field is the app_id), which are the real game app_ids (440=TF2, 570=Dota2, 730=CS2, …).

### Changes
- `manifest_locator.list_prefilled_app_ids(cache_root)` — distinct app_ids from the `.bin` cache
- `GET /v1/steam/prefilled-apps` agent endpoint
- `AgentClient.prefilled_apps()`
- `_steam_library_sync_via_prefill` sources from `prefilled_apps()` instead of `downloaded_state()`

### Verification
- Full suite: `1378 passed` (only pre-existing `test_licenses.py` / `pip-licenses` not installed)
- `mypy src/orchestrator`: clean
- `ruff format` + `ruff check`: clean
- New tests: `list_prefilled_app_ids` (locator), `/v1/steam/prefilled-apps` (router), `prefilled_apps()` (client)

### Next (operator gate)
After merge: rebuild the agent image, re-run **Gate B** — flip `ORCH_STEAM_ENUMERATE_VIA_PREFILL=true`, run `library_sync`, confirm only named games are added (no depot-id clutter) and titles are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)