### PR TITLE
docs: re-arch ④ — control plane → Proxmox LXC (design + plan)

### DIFF
--- a/docs/superpowers/plans/2026-06-23-lxc-move.md
+++ b/docs/superpowers/plans/2026-06-23-lxc-move.md
@@ -1,0 +1,650 @@
+# Re-arch ④ — Control Plane to a Proxmox LXC: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement the CODE tasks task-by-task. Steps use checkbox (`- [ ]`) syntax. The **operator-collaborative cutover** (Phase C) is NOT subagent work — the controller runs it on the boxes.
+
+**Goal:** Move the orchestrator control plane (FastAPI brain + SQLite DB) onto a dedicated Proxmox LXC while the data-plane agent stays on the UGREEN NAS, with no prefill hairpin.
+
+**Architecture:** Three small, independent, test-first code PRs make the control plane safe to run off-host (validator health no longer depends on a local cache mount; the agent connection is reused; the agent process stops importing control-plane/DB code). Then an operator-collaborative parallel-bring-up → atomic-flip cutover moves the brain, keeping the old VM for rollback.
+
+**Tech Stack:** Python 3.12, FastAPI, httpx (async), aiosqlite pool, structlog. Same `orchestrator:dpa` Docker image, run on the LXC with Docker nesting.
+
+**Spec:** `docs/superpowers/specs/2026-06-23-lxc-move-design.md` (commit 4b3624f).
+
+**Conventions (apply to every code task):**
+- Run `.venv/bin/python -m pytest <path> -q -p no:cacheprovider` for a test; full suite `.venv/bin/python -m pytest -q --ignore=tests/scripts` (only acceptable failure: `tests/test_licenses.py` — pip-licenses not installed).
+- Before EACH commit: `.venv/bin/mypy src/orchestrator` (clean), `.venv/bin/ruff format src tests`, `.venv/bin/ruff check src tests` (clean). No `assert` in `src/` (ruff S101 → use `if x is None: raise`). Bare `dict` returns need `dict[str, Any]`.
+- `enforce-plan-tracking`: mark a plan task in_progress (TaskUpdate) before its source edits. `enforce-evaluate`: present an evaluation + run `bash .claude/framework/hooks/mark-evaluated.sh "<reason>"` before each commit. Present A/B/C commit-structure options before each commit and WAIT. Claude pushes branches; Karl merges PRs.
+- Each PHASE below (0, 3b-1, 3b-2) is its OWN branch + commit + PR.
+
+---
+
+## File Structure
+
+| File | Responsibility | Phase |
+|---|---|---|
+| `src/orchestrator/agent/routers/health.py` (modify) | agent liveness → enrich with `validator_healthy` (the agent owns the cache mount) | 0 |
+| `src/orchestrator/clients/agent_client.py` (modify) | add `agent_health()`; later, persistent client + `aclose()` | 0, 3b-1 |
+| `src/orchestrator/validator/self_test.py` (modify) | `validator_self_test` becomes agent-aware (probe agent when `agent_enabled`) | 0 |
+| `src/orchestrator/api/main.py` (modify) | boot gate passes `agent_client` to `validator_self_test`; lifespan closes the AgentClient | 0, 3b-1 |
+| `src/orchestrator/jobs/handlers/sweep.py` (modify) | sweep's validator gate passes `deps.agent_client` | 0 |
+| `src/orchestrator/core/net.py` (create) | neutral home for `detect_non_loopback_bind` + loopback constant | 3b-2 |
+| `src/orchestrator/api/_constants.py` (create) | neutral home for the pure middleware constants (no DB import) | 3b-2 |
+| `src/orchestrator/api/main.py`, `api/dependencies.py`, `api/middleware.py`, `agent/app.py` (modify) | import the moved symbols from their neutral homes | 3b-2 |
+| `deploy-orchestrator-lxc.sh`, nftables rule, rollback runbook (artifacts) | operator cutover | C |
+
+---
+
+## PHASE 0 — Validator health gate becomes agent-aware (own PR)
+
+**Why first / on the existing NAS host:** on the LXC there is no local lancache cache mount, so `validator_self_test`'s local `is_dir()`/`iterdir()` stat would fail → `validator_healthy=False` → `/health` 503 (Game_shelf reads cache offline) AND the F13 sweep would skip every game. When `agent_enabled`, validator health must instead reflect the **agent's** cache (the agent has the mount). Shipping + verifying this on the current co-located NAS orchestrator (which has both paths available) de-risks the move.
+
+**Branch:** `feat/lxc-validator-health-gate`
+
+### Task 1: Agent `/v1/health` reports `validator_healthy`
+
+**Files:**
+- Modify: `src/orchestrator/agent/routers/health.py`
+- Test: `tests/agent/test_health.py` (create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/agent/test_health.py
+"""Agent /v1/health enrichment (re-arch ④): the agent owns the cache mount, so
+its liveness endpoint also reports whether its local validator self-test passes."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from orchestrator.agent.app import create_agent_app
+from orchestrator.core.settings import Settings
+
+
+def _client(tmp_path, *, cache_exists: bool) -> TestClient:
+    cache = tmp_path / "cache"
+    if cache_exists:
+        (cache / "x").mkdir(parents=True)  # non-empty dir so the self-test passes
+    settings = Settings(orchestrator_token="a" * 32, lancache_nginx_cache_path=cache)
+    app = create_agent_app(settings=settings)
+    return TestClient(app)
+
+
+def test_agent_health_reports_validator_healthy_true(tmp_path):
+    r = _client(tmp_path, cache_exists=True).get("/v1/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert body["validator_healthy"] is True
+
+
+def test_agent_health_reports_validator_unhealthy_when_cache_missing(tmp_path):
+    r = _client(tmp_path, cache_exists=False).get("/v1/health")
+    assert r.status_code == 200  # liveness still 200; the field carries the signal
+    assert r.json()["validator_healthy"] is False
+```
+
+- [ ] **Step 2: Run → FAIL**
+
+Run: `.venv/bin/python -m pytest tests/agent/test_health.py -q -p no:cacheprovider`
+Expected: FAIL — `KeyError: 'validator_healthy'`.
+
+- [ ] **Step 3: Implement**
+
+```python
+# src/orchestrator/agent/routers/health.py
+"""Agent liveness + cache-health endpoint (auth-exempt)."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+from orchestrator.validator.self_test import validator_self_test
+
+router = APIRouter()
+
+
+@router.get("/v1/health")
+async def health(request: Request) -> dict[str, bool]:
+    # The agent owns the lancache cache mount, so it answers the authoritative
+    # validator-health question for the control plane (re-arch ④). Liveness is
+    # always 200; `validator_healthy` carries the cache signal.
+    settings = request.app.state.settings
+    healthy = await validator_self_test(settings)
+    return {"ok": True, "validator_healthy": healthy}
+```
+
+- [ ] **Step 4: Run → PASS**
+
+Run: `.venv/bin/python -m pytest tests/agent/test_health.py -q -p no:cacheprovider`
+Expected: PASS (2 passed). Also run `tests/agent/ -q` — the existing agent suite stays green.
+
+### Task 2: `AgentClient.agent_health()`
+
+**Files:**
+- Modify: `src/orchestrator/clients/agent_client.py`
+- Test: `tests/clients/test_agent_client.py`
+
+- [ ] **Step 1: Write the failing test** (append)
+
+```python
+async def test_agent_health_single_call():
+    def handler(request):
+        assert request.method == "GET"
+        assert request.url.path == "/v1/health"
+        return httpx.Response(200, json={"ok": True, "validator_healthy": True})
+
+    client = _client(handler)
+    res = await client.agent_health()
+    assert res["validator_healthy"] is True
+```
+
+- [ ] **Step 2: Run → FAIL**
+
+Run: `.venv/bin/python -m pytest tests/clients/test_agent_client.py::test_agent_health_single_call -q -p no:cacheprovider`
+Expected: FAIL — `AttributeError: ... has no attribute 'agent_health'`.
+
+- [ ] **Step 3: Implement** (add to `AgentClient`, after `auth_status`)
+
+```python
+    async def agent_health(self) -> dict[str, Any]:
+        resp = await self._request("GET", "/v1/health")
+        result: dict[str, Any] = resp.json()
+        return result
+```
+
+- [ ] **Step 4: Run → PASS**
+
+Run: `.venv/bin/python -m pytest tests/clients/test_agent_client.py -q -p no:cacheprovider`
+Expected: PASS.
+
+### Task 3: `validator_self_test` becomes agent-aware
+
+**Files:**
+- Modify: `src/orchestrator/validator/self_test.py`
+- Test: `tests/validator/test_self_test.py` (create if absent; check first)
+
+**Design:** add an optional `agent_client` parameter. When `settings.agent_enabled and agent_client is not None`, return the agent's `validator_healthy` (agent unreachable → `False`, reported not raised). Otherwise the existing local-path logic runs **byte-identical** (flag-off unchanged).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/validator/test_self_test.py
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.core.settings import Settings
+from orchestrator.validator.self_test import validator_self_test
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Agent:
+    def __init__(self, *, healthy=None, boom=False):
+        self._healthy = healthy
+        self._boom = boom
+
+    async def agent_health(self):
+        if self._boom:
+            raise RuntimeError("agent down")
+        return {"ok": True, "validator_healthy": self._healthy}
+
+
+def _agent_settings(tmp_path):
+    # agent_enabled True; local cache path does NOT exist (the LXC case).
+    return Settings(
+        orchestrator_token="a" * 32,
+        agent_enabled=True,
+        lancache_nginx_cache_path=tmp_path / "no-local-cache",
+    )
+
+
+async def test_agent_enabled_uses_agent_health_true(tmp_path):
+    s = _agent_settings(tmp_path)
+    assert await validator_self_test(s, agent_client=_Agent(healthy=True)) is True
+
+
+async def test_agent_enabled_uses_agent_health_false(tmp_path):
+    s = _agent_settings(tmp_path)
+    assert await validator_self_test(s, agent_client=_Agent(healthy=False)) is False
+
+
+async def test_agent_enabled_agent_down_is_unhealthy(tmp_path):
+    s = _agent_settings(tmp_path)
+    assert await validator_self_test(s, agent_client=_Agent(boom=True)) is False
+
+
+async def test_flag_off_keeps_local_path(tmp_path):
+    # agent_enabled defaults False → local stat path; a real, non-empty dir passes.
+    cache = tmp_path / "cache"
+    (cache / "x").mkdir(parents=True)
+    s = Settings(orchestrator_token="a" * 32, lancache_nginx_cache_path=cache)
+    assert await validator_self_test(s) is True
+```
+
+- [ ] **Step 2: Run → FAIL**
+
+Run: `.venv/bin/python -m pytest tests/validator/test_self_test.py -q -p no:cacheprovider`
+Expected: FAIL — `validator_self_test() got an unexpected keyword argument 'agent_client'`.
+
+- [ ] **Step 3: Implement** — change the `validator_self_test` signature + add the agent branch at the top. Keep the existing local body unchanged below the branch.
+
+```python
+# src/orchestrator/validator/self_test.py — signature + new branch
+async def validator_self_test(settings: Settings, *, agent_client: Any = None) -> bool:
+    """Return True iff the validator's cache is usable.
+
+    Re-arch ④: when the data-plane agent owns the cache (agent_enabled), the
+    agent is the authority — probe its /v1/health and use its validator_healthy
+    (an unreachable agent reports unhealthy, never raises). Flag-off keeps the
+    in-process local-cache stat below, byte-identical.
+    """
+    if settings.agent_enabled and agent_client is not None:
+        try:
+            body = await agent_client.agent_health()
+        except Exception as e:
+            _log.error("validator.self_test.agent_unreachable", reason=str(e)[:200])
+            return False
+        return bool(body.get("validator_healthy", False))
+
+    root = Path(settings.lancache_nginx_cache_path)
+    # ... existing local-stat body unchanged ...
+```
+
+Add `from typing import Any` to the imports if not present (and keep `Path`, `os` as-is).
+
+- [ ] **Step 4: Run → PASS**
+
+Run: `.venv/bin/python -m pytest tests/validator/test_self_test.py -q -p no:cacheprovider`
+Expected: PASS (4 passed). Run `tests/validator/ -q` — existing self-test/disk-stat tests stay green.
+
+### Task 4: Wire the agent_client into the boot gate + the sweep gate
+
+**Files:**
+- Modify: `src/orchestrator/api/main.py` (~line 281, the boot `validator_self_test` call)
+- Modify: `src/orchestrator/jobs/handlers/sweep.py` (the pre-flight `validator_self_test` call)
+- Test: `tests/jobs/test_sweep_handler.py` (existing — confirm it still passes; the sweep already builds an agent stub)
+
+- [ ] **Step 1: Update the boot gate** — `api/main.py` already constructs `agent_client` before the validator self-test (section 3d precedes 5b). Pass it:
+
+```python
+    # 5b. F7 validator self-test (re-arch ④: agent-aware when agent_enabled).
+    from orchestrator.validator.self_test import validator_self_test
+
+    app.state.validator_healthy = await validator_self_test(settings, agent_client=agent_client)
+    log.info("api.boot.validator_self_test", healthy=app.state.validator_healthy)
+```
+
+- [ ] **Step 2: Update the sweep gate** — `jobs/handlers/sweep.py`, the pre-flight check. Pass `deps.agent_client`:
+
+```python
+    if not await validator_self_test(settings, agent_client=deps.agent_client):
+        _log.info("sweep.skipped", job_id=job_id, reason="validator_unhealthy")
+        return
+```
+
+- [ ] **Step 3: Add a sweep test that proves the agent path gates it** — `tests/jobs/test_sweep_handler.py` (append). The sweep already has an `_Agent` stub with no `agent_health`; give it one returning unhealthy and assert skip.
+
+```python
+async def test_sweep_skips_when_agent_validator_unhealthy(pool, monkeypatch):
+    """Re-arch ④: with agent_enabled, an agent that reports validator_unhealthy
+    must skip the sweep (the LXC has no local cache to stat)."""
+    from orchestrator.core import settings as settings_mod
+
+    monkeypatch.setattr(
+        "orchestrator.jobs.handlers.sweep.get_settings",
+        lambda: settings_mod.Settings(orchestrator_token="a" * 32, agent_enabled=True),
+    )
+
+    class _UnhealthyAgent:
+        async def agent_health(self):
+            return {"ok": True, "validator_healthy": False}
+
+    await _seed(pool, status="up_to_date", app_id="1")
+    await sweep_handler(_job(), Deps(pool=pool, agent_client=_UnhealthyAgent()))
+    g = await pool.read_one("SELECT status FROM games WHERE app_id='1'")
+    assert g["status"] == "up_to_date"  # untouched — sweep skipped
+```
+
+(The existing sweep tests monkeypatch `validator_self_test` directly; those still pass — this new one exercises the real agent-aware path. Note the existing `_healthy(monkeypatch)` helper patches `validator_self_test`; this test does not, so the real one runs against the stub agent.)
+
+- [ ] **Step 4: Run → PASS**
+
+Run: `.venv/bin/python -m pytest tests/jobs/test_sweep_handler.py tests/validator/ tests/agent/ tests/clients/ -q -p no:cacheprovider`
+Expected: all PASS.
+
+### Task 5: Phase 0 — verify + commit + PR
+
+- [ ] Full suite + `mypy` + `ruff` clean (only `test_licenses` fails). Present evaluation; A/B/C (recommend A: single `feat` commit). `mark-evaluated.sh`. Commit:
+
+```
+feat(health): agent-aware validator health gate (re-arch ④ §3a)
+
+When agent_enabled, validator_self_test probes the agent's /v1/health (the agent
+owns the cache mount) instead of stat-ing a local cache path the LXC won't have.
+Agent /v1/health now reports validator_healthy; AgentClient.agent_health()
+fetches it; the boot gate and the F13 sweep pre-flight pass agent_client.
+Flag-off keeps the local-stat path byte-identical.
+```
+
+Push. PR. **Then verify on the existing NAS orchestrator:** deploy, confirm `/health.validator_healthy` is true via the agent path (agent_enabled is already ON live), and that a sweep still runs. This proves the path before the LXC has no cache.
+
+### ⛔ OPERATOR-COLLABORATIVE GATE — Phase 0 live-verify on the NAS (controller runs it)
+
+---
+
+## PHASE 3b-1 — AgentClient connection reuse (own PR)
+
+**Why:** `AgentClient` builds a fresh `httpx.AsyncClient` per `_request`; fine on loopback, wasteful once every call is a cross-host LAN round-trip. Hold one persistent client, created lazily and closed on lifespan shutdown.
+
+**Branch:** `feat/lxc-agentclient-reuse`
+
+### Task 6: Persistent AgentClient + `aclose()`
+
+**Files:**
+- Modify: `src/orchestrator/clients/agent_client.py`
+- Modify: `src/orchestrator/api/main.py` (close the client on lifespan shutdown)
+- Test: `tests/clients/test_agent_client.py`
+
+- [ ] **Step 1: Write the failing test** (append)
+
+```python
+async def test_reuses_single_client_across_calls():
+    """Re-arch ④ §3b-1: the cross-host client must be reused, not rebuilt per
+    request."""
+    seen = []
+
+    def handler(request):
+        return httpx.Response(200, json={"cached": 1, "missing": 0})
+
+    transport = httpx.MockTransport(handler)
+    client = AgentClient(base_url="http://agent:8780", token=TOKEN, transport=transport)
+    # Spy: count how many AsyncClient objects get built.
+    import orchestrator.clients.agent_client as mod
+
+    real_ctor = mod.httpx.AsyncClient
+
+    def counting_ctor(*a, **k):
+        c = real_ctor(*a, **k)
+        seen.append(c)
+        return c
+
+    mod.httpx.AsyncClient = counting_ctor  # type: ignore[assignment]
+    try:
+        await client.stat(["a" * 32])
+        await client.stat(["b" * 32])
+    finally:
+        mod.httpx.AsyncClient = real_ctor  # type: ignore[assignment]
+        await client.aclose()
+    assert len(seen) == 1  # one client built, reused for both calls
+
+
+async def test_aclose_closes_client():
+    client = AgentClient(base_url="http://agent:8780", token=TOKEN)
+    await client.aclose()  # idempotent + safe even if never used
+    await client.aclose()
+```
+
+- [ ] **Step 2: Run → FAIL**
+
+Run: `.venv/bin/python -m pytest tests/clients/test_agent_client.py::test_reuses_single_client_across_calls -q -p no:cacheprovider`
+Expected: FAIL — two clients built (one per `_request`), or `AttributeError: aclose`.
+
+- [ ] **Step 3: Implement** — replace per-request `_new_client()` with a lazily-created persistent `self._client`; route the per-call timeout override through the request, not the client.
+
+```python
+# in __init__: add
+        self._client: httpx.AsyncClient | None = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            kwargs: dict[str, Any] = {
+                "base_url": self._base_url,
+                "headers": self._headers,
+                "timeout": self._timeout,
+            }
+            if self._transport is not None:
+                kwargs["transport"] = self._transport
+            self._client = httpx.AsyncClient(**kwargs)
+        return self._client
+
+    async def _request(self, method: str, path: str, **kw: Any) -> httpx.Response:
+        try:
+            resp = await self._get_client().request(method, path, **kw)
+        except httpx.HTTPError as e:
+            raise AgentError(f"agent unreachable: {type(e).__name__}") from e
+        if resp.status_code >= 400:
+            raise AgentError(f"agent returned {resp.status_code} for {path}")
+        return resp
+
+    async def aclose(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+```
+
+The per-call 300s validate timeout still works: `steam_validate` passes `timeout=httpx.Timeout(...)` to `_request` → `client.request(timeout=...)` (httpx request-level override). Remove the now-unused `_new_client`.
+
+- [ ] **Step 4: Run → PASS**
+
+Run: `.venv/bin/python -m pytest tests/clients/test_agent_client.py -q -p no:cacheprovider`
+Expected: PASS (incl. the existing `test_steam_validate_uses_long_timeout` — the per-call override is preserved).
+
+- [ ] **Step 5: Close the client on lifespan shutdown** — `api/main.py` shutdown block (near the `close_pool()` teardown), add:
+
+```python
+        with contextlib.suppress(Exception):
+            await agent_client.aclose()
+```
+
+Run `tests/api/ -q` to confirm app startup/shutdown still passes.
+
+### Task 7: Phase 3b-1 — verify + commit + PR
+
+- [ ] Full suite + `mypy` + `ruff` clean. Evaluation; A/B/C (recommend A). `mark-evaluated.sh`. Commit `feat(agent-client): reuse one httpx client across calls (re-arch ④ §3b-1)`. Push. PR.
+
+---
+
+## PHASE 3b-2 — Decouple the agent process from control-plane/DB imports (own PR)
+
+**Why (ARCH-4):** `agent/app.py` imports `from orchestrator.api.middleware import ...` (→ `api.dependencies` → `db.pool`) and lazily `from orchestrator.api.main import _detect_non_loopback_bind` (→ routers + scheduler + pool). Once the agent is the only orchestrator code on the UGREEN, its import graph should not pull in control-plane/DB modules. Two moves fix it.
+
+**Branch:** `feat/lxc-agent-decouple`
+
+### Task 8: Move `detect_non_loopback_bind` to `core/net.py`
+
+**Files:**
+- Create: `src/orchestrator/core/net.py`
+- Modify: `src/orchestrator/api/main.py` (import from `core.net`; drop the local def + constant)
+- Modify: `src/orchestrator/agent/app.py` (import from `core.net`; drop the lazy `api.main` import)
+- Test: `tests/core/test_net.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/core/test_net.py
+from __future__ import annotations
+
+from orchestrator.core.net import detect_non_loopback_bind
+
+
+def test_loopback_returns_none(monkeypatch):
+    monkeypatch.delenv("UVICORN_HOST", raising=False)
+    monkeypatch.setattr("sys.argv", ["x"])
+    assert detect_non_loopback_bind("127.0.0.1") is None
+
+
+def test_non_loopback_setting_returned(monkeypatch):
+    monkeypatch.delenv("UVICORN_HOST", raising=False)
+    monkeypatch.setattr("sys.argv", ["x"])
+    assert detect_non_loopback_bind("0.0.0.0") == "0.0.0.0"
+```
+
+- [ ] **Step 2: Run → FAIL** (`ModuleNotFoundError: orchestrator.core.net`).
+
+- [ ] **Step 3: Create `core/net.py`** — move the body of `_detect_non_loopback_bind` + `_LOOPBACK_HOST_VALUES` from `api/main.py` verbatim, renamed public (drop the leading underscore):
+
+```python
+# src/orchestrator/core/net.py
+"""Network bind-detection helpers (neutral home so both the control-plane API
+and the data-plane agent can detect a non-loopback bind without importing each
+other). Pure stdlib — no DB, no routers."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+LOOPBACK_HOST_VALUES = frozenset({"127.0.0.1", "::1", "localhost"})
+
+
+def detect_non_loopback_bind(settings_host: str) -> str | None:
+    """Return the non-loopback host string if any signal indicates it, else None.
+    Covers the settings host, the UVICORN_HOST env var, and `--host` in argv."""
+    if settings_host not in LOOPBACK_HOST_VALUES:
+        return settings_host
+    uvicorn_host = os.environ.get("UVICORN_HOST")
+    if uvicorn_host and uvicorn_host not in LOOPBACK_HOST_VALUES:
+        return uvicorn_host
+    argv = sys.argv
+    for i, arg in enumerate(argv):
+        if arg == "--host" and i + 1 < len(argv):
+            value = argv[i + 1]
+            if value not in LOOPBACK_HOST_VALUES:
+                return value
+        elif arg.startswith("--host="):
+            value = arg.split("=", 1)[1]
+            if value not in LOOPBACK_HOST_VALUES:
+                return value
+    return None
+```
+
+- [ ] **Step 4:** In `api/main.py`, delete the local `_LOOPBACK_HOST_VALUES` + `_detect_non_loopback_bind`, add `from orchestrator.core.net import detect_non_loopback_bind`, and replace the call sites `_detect_non_loopback_bind(` → `detect_non_loopback_bind(`.
+
+- [ ] **Step 5:** In `agent/app.py`, replace the lazy `from orchestrator.api.main import _detect_non_loopback_bind` with a top-level `from orchestrator.core.net import detect_non_loopback_bind`, and update its call. Remove the now-stale comment about importing from `api.main`.
+
+- [ ] **Step 6: Run → PASS**
+
+Run: `.venv/bin/python -m pytest tests/core/test_net.py tests/agent/ tests/api/test_*lan*.py -q -p no:cacheprovider`
+Expected: PASS (the LAN-bind-policy tests for both API and agent still pass).
+
+### Task 9: Move the pure middleware constants out of `api/dependencies.py`
+
+**Files:**
+- Create: `src/orchestrator/api/_constants.py`
+- Modify: `src/orchestrator/api/dependencies.py` (re-export from `_constants` for back-compat, OR move + update importers)
+- Modify: `src/orchestrator/api/middleware.py` (import the 4 constants from `_constants`, not `dependencies`)
+- Test: covered by Task 10's import-graph guard + existing middleware tests
+
+- [ ] **Step 1:** Create `api/_constants.py` and move `AUTH_EXEMPT_PATHS`, `BODY_SIZE_CAP_BYTES`, `LOOPBACK_HOSTS`, `LOOPBACK_ONLY_PATTERNS` (the pure constants `middleware.py` imports) verbatim from `dependencies.py`. This module imports NOTHING from `db.pool`.
+
+```python
+# src/orchestrator/api/_constants.py
+"""Pure middleware/auth constants (no DB import) so the data-plane agent can
+import the middlewares without pulling in the control-plane DB pool (ARCH-4)."""
+
+from __future__ import annotations
+
+import re
+
+# ... move the four constants here verbatim (values copied from dependencies.py) ...
+```
+
+- [ ] **Step 2:** In `api/dependencies.py`, replace the moved literals with `from orchestrator.api._constants import (AUTH_EXEMPT_PATHS, BODY_SIZE_CAP_BYTES, LOOPBACK_HOSTS, LOOPBACK_ONLY_PATTERNS)` (back-compat re-export; existing importers of `dependencies.<const>` keep working).
+
+- [ ] **Step 3:** In `api/middleware.py`, change `from orchestrator.api.dependencies import (...)` → `from orchestrator.api._constants import (...)`. Now `middleware.py` no longer imports `dependencies` (→ `db.pool`).
+
+- [ ] **Step 4: Run → PASS**
+
+Run: `.venv/bin/python -m pytest tests/api/ -q -p no:cacheprovider`
+Expected: PASS (middleware behavior unchanged; constants identical).
+
+### Task 10: Import-graph guard — agent imports no control-plane/DB code
+
+**Files:**
+- Test: `tests/agent/test_import_isolation.py` (create)
+
+- [ ] **Step 1: Write the failing test** — run in a fresh subprocess so other tests' imports don't pollute `sys.modules`.
+
+```python
+# tests/agent/test_import_isolation.py
+"""ARCH-4 / re-arch ④: the data-plane agent process must not transitively import
+the control-plane API entrypoint or the DB pool."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_agent_app_does_not_import_api_main_or_pool():
+    code = (
+        "import orchestrator.agent.app as a\n"
+        "a.create_agent_app\n"
+        "import sys\n"
+        "bad = [m for m in ('orchestrator.api.main', 'orchestrator.db.pool') "
+        "if m in sys.modules]\n"
+        "print('BAD=' + ','.join(bad))\n"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True
+    ).stdout
+    assert "BAD=\n" in out or out.strip() == "BAD=", f"agent pulled in: {out.strip()}"
+```
+
+- [ ] **Step 2: Run → FAIL** (before Tasks 8–9 land it would list both; after, it passes — run it last to confirm the decoupling).
+
+Run: `.venv/bin/python -m pytest tests/agent/test_import_isolation.py -q -p no:cacheprovider`
+Expected: PASS after Tasks 8–9 (the agent imports `core.net` + `api.middleware`→`api._constants`, neither pulling `api.main`/`db.pool`).
+
+> If it still lists a module, grep the agent's import chain for the offender and move/neutralize it the same way.
+
+### Task 11: Phase 3b-2 — verify + commit + PR
+
+- [ ] Full suite + `mypy` + `ruff` clean. Evaluation; A/B/C (recommend A). `mark-evaluated.sh`. Commit `refactor(agent): decouple agent import graph from api.main + db.pool (re-arch ④ §3b-2/ARCH-4)`. Push. PR.
+
+---
+
+## PHASE C — Operator-collaborative cutover (NOT subagent work)
+
+> The controller runs these on the boxes per `[[feedback_run_deploys_yourself]]`; only the IP/sizing/go-ahead are Karl's. Each gate is live-verified before the next. Code PRs (Phase 0, 3b-1, 3b-2) must be merged + the image rebuilt first.
+
+### C1 — Provision the LXC (Karl decides IP + sizing; controller does the rest)
+- Create a dedicated LXC on the Proxmox cluster with `features: nesting=1`; assign `10.100.23.X` (OQ4-1); modest vCPU/RAM that beats the NAS VM's steal-bound share (OQ4-2). Install Docker.
+- Confirm the LXC can reach `192.168.1.40:8780` and `:80` (OQ4-3 — VLAN↔NAS reachability). If blocked, add the Proxmox firewall/route rule.
+- Build/load `orchestrator:dpa` on the LXC. Author **`/home/karl/deploy-orchestrator-lxc.sh`** (artifact): `docker run` with `--env-file /home/karl/orch-lxc.env`, the DB volume, NO cache mount, `API_HOST=0.0.0.0`. Author **`orch-lxc.env`**: same `ORCH_TOKEN`; `ORCH_AGENT_BASE_URL=http://192.168.1.40:8780`; `ORCH_LANCACHE_HEARTBEAT_URL=http://192.168.1.40/lancache-heartbeat`; `ORCH_ALLOWED_SOURCE_IPS=10.100.23.102`; `ORCH_AGENT_ENABLED=true`; `ORCH_SCHEDULED_PREFILL_ENABLED=false`.
+
+### C2 — Parallel bring-up + dual-reach (old VM still serving Game_shelf)
+- On the agent (NAS): set `ORCH_AGENT_BIND_HOST=0.0.0.0` + `ORCH_ALLOWED_SOURCE_IPS=10.100.23.X`; recreate the agent (the old orchestrator keeps reaching it via loopback — allowlist no-ops for loopback).
+- Copy a point-in-time `orchestrator.db` snapshot to the LXC volume. Start the LXC orchestrator.
+- **Smoke (LXC against the real agent):** `/health` healthy (agent-probe path), one validate of a known-cached game, one library_sync, one prefill — all green. Old VM untouched; no manual triggers on it during the window.
+
+### ⛔ GATE C2 — LXC proven against the live agent before the flip
+
+### C3 — Atomic flip (short maintenance window)
+1. Stop the old NAS orchestrator (WAL checkpoints).
+2. Final `rsync` of `orchestrator.db` (+ `-wal`/`-shm`) NAS → LXC (authoritative).
+3. Restart the LXC orchestrator on the final DB.
+4. Game_shelf: `ORCH_API_URL` → `http://10.100.23.X:8765`; redeploy (separate repo — park lancache_orchestrator on a non-main branch first so its branch-safety hook lets the Game_shelf push through, per `[[feedback_claude_pushes_branches]]`).
+5. NAS nftables: `:8780` accept only from `10.100.23.X` (artifact: the rule + where it's persisted).
+
+### C4 — Live verification (spec §5 table)
+- Run every row of the §5 acceptance table: LXC `/health`, cross-host validate vs baseline, prefill round-trip + auto-validate, library_sync, Game_shelf F14–F17 page, agent allowlist tightened (off-allowlist host refused), row-count parity LXC-DB vs the pre-flip snapshot.
+
+### ⛔ GATE C4 — all §5 rows pass → ④ accepted
+- **Rollback (any failure):** stop LXC orchestrator → restart old NAS orchestrator → revert Game_shelf `ORCH_API_URL` → `192.168.1.40:8765`. Keep the `orchestrator:pre-4` image + the old VM for a grace period. (Artifact: write the rollback runbook into `docs/` or alongside the deploy scripts.)
+
+---
+
+## Self-Review
+
+**1. Spec coverage:** §3a health gate → Tasks 1–4 (+ live-verify gate). §3b-1 AgentClient reuse → Task 6. §3b-2 import decoupling → Tasks 8–10. §3 config changes + §4 cutover + §5 verification → Phase C (C1–C4). §6 scope boundaries respected (no prefill/validate/enumerate behavior change). §7 open questions → C1 (IP/sizing) + C1 reachability check. ✓
+
+**2. Placeholder scan:** `10.100.23.X` is the deliberate OQ4-1 placeholder resolved at C1. The `core/net.py` and `_constants.py` bodies say "move verbatim" with the exact symbols named — the engineer copies the existing literals (shown by reference, not re-typed, to avoid drift). No "TODO/handle edge cases" gaps. ✓
+
+**3. Type consistency:** `validator_self_test(settings, *, agent_client=None) -> bool` (Task 3) is called with `agent_client=` in Task 4 (boot + sweep). `AgentClient.agent_health() -> dict[str, Any]` (Task 2) consumed by `validator_self_test` (Task 3) via `body.get("validator_healthy")` and matches the agent endpoint's `{"ok", "validator_healthy"}` (Task 1). `AgentClient.aclose()` (Task 6) called in lifespan (Task 6 step 5). `detect_non_loopback_bind` (Task 8) replaces `_detect_non_loopback_bind` at every call site (api.main + agent). ✓
+
+---
+
+**Plan complete.** Execution: subagent-driven for the code tasks (Phases 0, 3b-1, 3b-2); the Phase C cutover is operator-collaborative (controller runs it on the boxes, gated, not a subagent).

--- a/docs/superpowers/specs/2026-06-23-lxc-move-design.md
+++ b/docs/superpowers/specs/2026-06-23-lxc-move-design.md
@@ -1,0 +1,153 @@
+# Re-arch ④ — Move the control plane to a Proxmox LXC (design)
+
+**Status:** Approved (design), 2026-06-23
+**Parent north-star:** `docs/superpowers/specs/2026-06-19-re-architecture-design.md`
+**Predecessors (all complete + live):** ① SteamPrefill driver, ② data-plane agent, ③ delete legacy worker.
+**Type:** Topology / cutover change. Minimal application code (one health-gate change + two small ④-folded improvements); the bulk is deploy/config + an operator-collaborative cutover.
+
+---
+
+## 0. Goal
+
+Move the orchestrator **control plane** (the FastAPI "brain" + its SQLite DB) off the UGREEN NAS VM onto a dedicated **Proxmox LXC**, while the **data-plane agent** (chunk-puller + cache disk-stat + SteamPrefill runner) stays on the UGREEN. This frees the brain from the 4-vCPU, CPU-steal-bound NAS VM (see `[[project_infra_topology]]`) without hairpinning prefill byte volume across the LAN.
+
+The ②/③ split already made the control plane location-agnostic: prefill, validate, and library enumeration all run on the agent today. ④ is therefore mostly **where it runs and how the two halves talk across hosts**, not new behavior.
+
+## 1. Topology
+
+**Before (everything on the UGREEN NAS, 192.168.1.40):**
+
+```
+                 UGREEN NAS 192.168.1.40 (host network)
+   ┌──────────────────────────────────────────────────────┐
+   │  orchestrator :8765 ──loopback──▶ agent :8780         │
+   │  (brain + DB)         127.0.0.1   (puller/disk-stat/   │
+   │                                    SteamPrefill)       │
+   │  lancache (nginx) :80 ◀──local prefill pulls──┘        │
+   └──────────────────────────────────────────────────────┘
+        ▲ :8765 (bearer + allowlist 10.100.23.102)
+   Game_shelf LXC 10.100.23.102 (Proxmox VLAN)
+```
+
+**After (brain → new Proxmox LXC; agent stays on the NAS):**
+
+```
+   Proxmox VLAN 10.100.23.0/24           UGREEN NAS 192.168.1.40
+   ┌─────────────────────────┐           ┌────────────────────────────┐
+   │ orchestrator LXC         │           │ agent :8780                │
+   │  10.100.23.X             │──job JSON▶│  (bearer + allowlist =     │
+   │  orchestrator :8765      │  (small)  │   ONLY 10.100.23.X)        │
+   │  + orchestrator.db       │           │  puller/disk-stat/         │
+   │  (Docker, nesting)       │           │  SteamPrefill              │
+   └─────────────────────────┘           │  lancache :80 ◀─local pulls│
+        ▲ :8765                          └────────────────────────────┘
+   Game_shelf LXC 10.100.23.102
+```
+
+**Key properties:**
+
+- **No hairpin.** Prefill byte pulls + validate disk-stat stay local to the agent (the whole reason the agent stays on the UGREEN). Only small job-control JSON crosses the LAN (LXC → agent).
+- **Two independent bearer + allowlist links**, both reusing already-shipped primitives (`SourceAllowlistMiddleware`, `BearerAuthMiddleware`): (a) Game_shelf → orchestrator `:8765`; (b) orchestrator → agent `:8780` (the allowlist tightens from loopback to the LXC IP).
+- **DB co-locates with the brain** on the LXC's local disk — the agent is stateless (no DB/pool).
+- **lancache stays put** on the NAS; Game_shelf and the SteamPrefill cron are unaffected by the brain move.
+
+## 2. Decisions (locked)
+
+| Axis | Decision | Rationale |
+|---|---|---|
+| **Target host** | New **dedicated LXC** on the Proxmox cluster, `10.100.23.X` (exact IP assigned at provisioning) | clean isolation, own resource limits, easy rollback; same VLAN as Game_shelf |
+| **DB cutover** | **Migrate** the existing `orchestrator.db` | preserves the games library (~2487 steam + epic), `validation_history` (the cache badges Game_shelf reads), jobs, block-list |
+| **Cross-host link security** | **Bearer + source-IP allowlist, plaintext** over the trusted VLAN, + host nftables rule | identical trust model to the live Game_shelf→orchestrator link; zero new code (primitives shipped) |
+| **LXC runtime** | **Docker in the LXC** (`features: nesting=1`), the same tested `orchestrator:dpa` image | the image is the proven artifact; the move is "same container, new host + network config" |
+| **Cutover** | **Parallel bring-up → atomic flip**, old VM kept for rollback | F14–F17 Game_shelf is live; prove the new endpoint before flipping, keep the old as rollback |
+
+## 3. Per-host configuration changes
+
+**Agent (stays on UGREEN; `deploy-agent.sh`):**
+
+| Change | From → To | Why |
+|---|---|---|
+| `ORCH_AGENT_BIND_HOST` | `127.0.0.1` → `0.0.0.0` | the LXC must reach it over the LAN |
+| `ORCH_ALLOWED_SOURCE_IPS` | (Game_shelf IP) → **`10.100.23.X`** (the LXC) | the allowlist becomes the real gate once off-loopback; the fail-closed boot guard enforces non-empty |
+| host nftables | add: `:8780` accept only from `10.100.23.X` | defense-in-depth over the app allowlist (mirrors the documented Game_shelf pattern) |
+
+**Orchestrator (new LXC; its own env file — same `ORCH_TOKEN`, diverged otherwise):**
+
+| Change | From → To | Why |
+|---|---|---|
+| `ORCH_AGENT_BASE_URL` | `http://127.0.0.1:8780` → `http://192.168.1.40:8780` | agent is now cross-host |
+| `ORCH_LANCACHE_HEARTBEAT_URL` | loopback → `http://192.168.1.40/lancache-heartbeat` | lancache stays on the NAS |
+| `ORCH_ALLOWED_SOURCE_IPS` | stays `10.100.23.102` (Game_shelf); the LXC's own CLI uses loopback (allowlist no-ops for loopback) | — |
+| `orchestrator.db` | migrated file → LXC-local Docker volume | the brain's state moves with it |
+| lancache cache mount | **removed** (no `/data/cache` on the LXC) | validate runs on the agent now |
+
+**Game_shelf (separate repo; at cutover):** `ORCH_API_URL` → `http://10.100.23.X:8765`.
+
+### 3a. The one required code change — validator health gate
+
+Today `validator_self_test` stat's the **local** lancache cache path to gate `/health.validator_healthy`. On the LXC there is no cache mount, so it would return unhealthy → `/health` 503s → Game_shelf reads the cache subsystem as offline.
+
+**Fix:** when `agent_enabled`, the control plane's validator-health check **probes the agent's `/health`** (the agent has the cache locally) instead of stat-ing a path it no longer has. Small, well-scoped change to `validator/self_test.py` + the health router, behind the existing `agent_enabled` flag so flag-off behavior is unchanged. **Shipped and verified on the existing NAS orchestrator (Phase 0) before any infra move**, so the LXC reports healthy on day one.
+
+### 3b. Two ④-folded review improvements (deferred here from the 2026-06-23 review)
+
+- **AgentClient connection reuse (HTTP2-1 / HTTPX-2).** `AgentClient` currently builds a fresh `httpx.AsyncClient` per request; acceptable on loopback, wasteful now that every call is a cross-host LAN round-trip. Hold a persistent client (created in the lifespan, closed on shutdown) so the control→agent connection is reused. Optional: enable `http2=True` (the `h2` dep is already installed).
+- **Agent → control-plane import decoupling (ARCH-4).** The agent process transitively imports `api.middleware` / `api.main` (and thus the DB pool). Once the agent is the only orchestrator code on the UGREEN, it should not import control-plane DB/router code. Extract the shared bits the agent needs (the LAN-bind detection helper, the two middlewares) into a neutral module both import, so the agent's import graph no longer pulls in `api.main`. (Already-shipped #192 work — the agent lifespan shutdown — stays.)
+
+These two are **in scope for ④** but are independent, test-first changes that can land before the cutover (they don't change behavior on the current co-located deployment).
+
+## 4. Cutover sequence (parallel bring-up + atomic flip)
+
+**Phase 0 — Ship the health-gate code change first (before any infra).**
+The §3a change goes out as its own PR, merged, image rebuilt, and verified on the *existing* NAS orchestrator (which still has the cache mount, so both the local-stat and agent-probe health paths can be confirmed there). De-risks the move: the LXC reports healthy on day one. (The §3b improvements may ride along or land as their own PRs — all are no-ops on the current co-located deploy.)
+
+**Phase 1 — Provision the LXC (no cutover; old stays fully live).**
+- Create the dedicated LXC on Proxmox (`features: nesting=1`), assign `10.100.23.X`, install Docker.
+- Build/load `orchestrator:dpa` on the LXC; write its env file (same `ORCH_TOKEN`; `ORCH_AGENT_BASE_URL=192.168.1.40:8780`, heartbeat → `192.168.1.40`, allowlist `10.100.23.102`, `API_HOST=0.0.0.0`, **no** cache mount).
+- Copy a **point-in-time snapshot** of `orchestrator.db` to the LXC volume.
+
+**Phase 2 — Parallel bring-up + dual-reach (test; Game_shelf still on the old endpoint).**
+- On the agent (NAS): bind `0.0.0.0` + allowlist `[10.100.23.X]`. The **old orchestrator keeps working via loopback** (the allowlist no-ops for loopback), so both reach the agent during the window.
+- Start the LXC orchestrator against the snapshot DB. Smoke-test it end-to-end against the real agent: `/health` healthy (agent-probe), one validate, one library_sync, one prefill — all crossing LXC→agent.
+- The old NAS orchestrator still serves Game_shelf throughout. Scheduled-prefill is already OFF on it (`ORCH_SCHEDULED_PREFILL_ENABLED=false`); avoid manual triggers on the old one during the window.
+
+**Phase 3 — Atomic flip (short maintenance window).**
+1. **Stop** the old NAS orchestrator (quiesces the DB; WAL checkpointed).
+2. **Final DB sync** — rsync the now-static `orchestrator.db` (+ `-wal`/`-shm`) NAS → LXC; this is authoritative.
+3. **Restart** the LXC orchestrator against the final DB.
+4. **Game_shelf** `ORCH_API_URL` → `http://10.100.23.X:8765`, redeploy.
+5. **nftables** rule on the NAS: `:8780` accept only from `10.100.23.X`.
+
+**Phase 4 — Verify live (see §5).**
+
+**Rollback (old VM + DB left intact for a grace period):**
+- Pre-flip: trivial — stop the LXC orchestrator; the old one never stopped.
+- Post-flip: stop LXC orchestrator → restart old NAS orchestrator → revert Game_shelf `ORCH_API_URL` → `192.168.1.40:8765`. Since the old DB seeded the final sync, rollback loses only LXC-side changes since the flip (minutes). Keep the `orchestrator:pre-4` image + the old VM until ④ is proven stable.
+
+## 5. Live verification (post-cutover acceptance)
+
+The move is accepted only when all pass live:
+
+| Check | How | Pass criteria |
+|---|---|---|
+| Control plane up on LXC | `GET 10.100.23.X:8765/api/v1/health` from Game_shelf's LXC | 200, `validator_healthy: true` (agent-probe path), scheduler running |
+| Cross-host control→agent | trigger one **validate** of a known-cached Steam game | job succeeds; outcome + chunk counts match the pre-move baseline |
+| Prefill round-trips | trigger one **prefill** via the agent | `ok=True`, auto-enqueued validate succeeds (full loop crosses LXC→agent→SteamPrefill→lancache) |
+| library_sync | trigger a Steam library_sync | enumerates via the agent, games upserted, no error |
+| Game_shelf F14–F17 live | load the cache page (now pointing at `10.100.23.X:8765`) | badges render, no offline/degraded banner, cache-status filter works |
+| Agent allowlist tightened | from a host NOT on the allowlist, hit `:8780` | refused (403 / nftables drop); only the LXC IP succeeds |
+| No data loss | row counts (games, validation_history, jobs, block_list) LXC-DB vs pre-flip snapshot | equal (± jobs created during the window) |
+
+**Rollback trigger:** any of validate / prefill / Game_shelf failing post-flip → execute the §4 rollback.
+
+## 6. Scope boundaries
+
+- **In scope:** the §3a health-gate change; the §3b AgentClient reuse + agent-import decoupling; the LXC provisioning + deploy scripts; the cutover + verification.
+- **Out of scope:** any change to prefill/validate/enumerate behavior (already location-agnostic); Game_shelf internals beyond the `ORCH_API_URL` switch; lancache; the SteamPrefill cron.
+- **Operator-collaborative (run by the operator/Claude on the boxes, not a subagent):** Phase 1 LXC provisioning, the Phase 3 atomic flip, and Phase 4 live verification (§5). The code changes (§3a, §3b) are normal test-first PRs.
+
+## 7. Open questions
+
+- **OQ4-1:** Exact LXC IP (`10.100.23.X`) — assigned at Phase 1. Drives the agent allowlist, the nftables rule, and Game_shelf's `ORCH_API_URL`.
+- **OQ4-2:** LXC resource allocation (vCPU / RAM) — pick at provisioning; the brain is light (FastAPI + SQLite + scheduler), so modest is fine, but it should exceed the current CPU-steal-bound NAS VM share to realize the win.
+- **OQ4-3:** Does the Proxmox cluster's firewalling already segment `10.100.23.0/24` from `192.168.1.0/24`, or is the NAS reachable from the VLAN as-is? Confirm the LXC→`192.168.1.40:8780` path is open before Phase 2.


### PR DESCRIPTION
## Re-arch ④ — design + implementation plan

The final re-architecture step: move the orchestrator control plane (FastAPI brain + SQLite DB) onto a dedicated Proxmox LXC, with the data-plane agent staying on the UGREEN NAS (no prefill hairpin). Docs-only PR (spec + plan); code lands in follow-up PRs.

### `docs/superpowers/specs/2026-06-23-lxc-move-design.md`
Topology, locked decisions (dedicated LXC `10.100.23.X` · migrate the DB · bearer+allowlist+nftables · Docker-in-LXC same image · parallel bring-up → atomic flip), per-host config, the one required code change (validator health gate), two folded review findings, cutover + live-verification + rollback, open questions.

### `docs/superpowers/plans/2026-06-23-lxc-move.md`
Three test-first code PRs + the operator cutover:
- **Phase 0** — agent-aware validator health gate (the LXC has no local cache mount, so `validator_self_test` probes the agent when `agent_enabled`). Ships + verified on the NAS first.
- **Phase 3b-1** — AgentClient connection reuse (persistent httpx client; matters cross-host).
- **Phase 3b-2** — decouple the agent import graph from `api.main` + `db.pool` (ARCH-4), with a subprocess import-graph guard.
- **Phase C** — operator-collaborative cutover (provision → parallel bring-up → atomic flip → live-verify) with rollback.

Execution: subagent-driven for the code phases; Phase C is operator-collaborative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)