### PR TITLE
feat(health): agent-aware validator health gate (re-arch ④ §3a)

### DIFF
--- a/src/orchestrator/agent/routers/health.py
+++ b/src/orchestrator/agent/routers/health.py
@@ -1,12 +1,22 @@
-"""Agent liveness endpoint (auth-exempt)."""
+"""Agent liveness endpoint (auth-exempt).
+
+The agent owns the lancache cache mount, so the liveness probe also reports the
+local F7 validator self-test result. Liveness itself is always 200; the
+`validator_healthy` field lets the control plane (re-arch ④: an LXC with no
+local cache mount) source its validator health from the agent that does own it.
+"""
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
+
+from orchestrator.validator.self_test import validator_self_test
 
 router = APIRouter()
 
 
 @router.get("/v1/health")
-async def health() -> dict[str, bool]:
-    return {"ok": True}
+async def health(request: Request) -> dict[str, bool]:
+    settings = request.app.state.settings
+    healthy = await validator_self_test(settings)
+    return {"ok": True, "validator_healthy": healthy}

--- a/src/orchestrator/api/main.py
+++ b/src/orchestrator/api/main.py
@@ -278,7 +278,11 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     # cache-mount check forces /health to 503 until restart.
     from orchestrator.validator.self_test import validator_self_test
 
-    app.state.validator_healthy = await validator_self_test(settings)
+    # re-arch ④: pass agent_client so that, when agent_enabled, validator health
+    # is sourced from the agent (which owns the cache mount). On the LXC control
+    # plane there is no local cache mount, so the local stat would always report
+    # unhealthy; the agent is the source of truth.
+    app.state.validator_healthy = await validator_self_test(settings, agent_client=agent_client)
     log.info("api.boot.validator_self_test", healthy=app.state.validator_healthy)
 
     try:

--- a/src/orchestrator/clients/agent_client.py
+++ b/src/orchestrator/clients/agent_client.py
@@ -128,3 +128,12 @@ class AgentClient:
         resp = await self._request("GET", "/v1/steam/auth-status")
         result: dict[str, Any] = resp.json()
         return result
+
+    async def agent_health(self) -> dict[str, Any]:
+        # re-arch ④: the agent owns the cache mount, so its liveness probe also
+        # reports its local validator self-test. The control plane (an LXC with
+        # no cache mount) reads validator_healthy from here to gate its own
+        # app.state.validator_healthy.
+        resp = await self._request("GET", "/v1/health")
+        result: dict[str, Any] = resp.json()
+        return result

--- a/src/orchestrator/jobs/handlers/sweep.py
+++ b/src/orchestrator/jobs/handlers/sweep.py
@@ -40,7 +40,10 @@ async def sweep_handler(job: dict[str, Any], deps: Deps) -> None:
     if deps.agent_client is None:
         _log.info("sweep.skipped", job_id=job_id, reason="no_agent_client")
         return
-    if not await validator_self_test(settings):
+    # re-arch ④: pass agent_client so that, when agent_enabled, validator health
+    # is sourced from the agent (which owns the cache mount) rather than the
+    # local path — the control plane on the LXC has no local cache mount.
+    if not await validator_self_test(settings, agent_client=deps.agent_client):
         _log.info("sweep.skipped", job_id=job_id, reason="validator_unhealthy")
         return
 

--- a/src/orchestrator/validator/self_test.py
+++ b/src/orchestrator/validator/self_test.py
@@ -17,18 +17,36 @@ import structlog
 from orchestrator.validator.cache_key import cache_key, cache_path
 
 if TYPE_CHECKING:
+    from orchestrator.clients.agent_client import AgentClient
     from orchestrator.core.settings import Settings
 
 _log = structlog.get_logger(__name__)
 
 
-async def validator_self_test(settings: Settings) -> bool:
+async def validator_self_test(
+    settings: Settings, *, agent_client: AgentClient | None = None
+) -> bool:
     """Return True iff the cache mount is usable and key derivation runs.
+
+    re-arch ④: when `settings.agent_enabled` and an agent client is supplied,
+    validator health is sourced from the AGENT (which owns the cache mount),
+    because the control plane now runs on an LXC with no local cache mount —
+    stat'ing `lancache_nginx_cache_path` there would always (wrongly) report
+    unhealthy. With the flag off (default) the behaviour below is unchanged: the
+    local cache path is the source of truth and `agent_client` is ignored.
 
     1. `lancache_nginx_cache_path` must be an existing, listable directory.
     2. The cache-key derivation must run without error (exercises the
        `cache_key` module end-to-end, no I/O).
     """
+    if settings.agent_enabled and agent_client is not None:
+        try:
+            body = await agent_client.agent_health()
+        except Exception as e:
+            _log.error("validator.self_test.agent_unreachable", reason=str(e)[:200])
+            return False
+        return bool(body.get("validator_healthy", False))
+
     root = Path(settings.lancache_nginx_cache_path)
     try:
         if not root.is_dir():

--- a/tests/agent/test_health.py
+++ b/tests/agent/test_health.py
@@ -1,0 +1,48 @@
+"""Tests for the agent /v1/health liveness endpoint (re-arch ④ Phase 0).
+
+The agent owns the lancache cache mount, so its liveness probe also reports its
+local validator self-test result. Liveness stays 200 either way; the control
+plane (running on an LXC with no cache mount) reads `validator_healthy` to gate
+its own `app.state.validator_healthy`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi.testclient import TestClient
+
+from orchestrator.agent.app import create_agent_app
+from orchestrator.core.settings import Settings
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _settings(cache_root: Path) -> Settings:
+    return Settings(
+        orchestrator_token="a" * 32,
+        lancache_nginx_cache_path=cache_root,
+        cache_levels="2:2",
+    )
+
+
+def test_health_validator_healthy_true_when_cache_present(tmp_path):
+    (tmp_path / "ab").mkdir()  # non-empty cache dir → self-test passes
+    app = create_agent_app(settings=_settings(tmp_path))
+    client = TestClient(app)
+    resp = client.get("/v1/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["validator_healthy"] is True
+
+
+def test_health_still_200_but_validator_unhealthy_when_cache_missing(tmp_path):
+    app = create_agent_app(settings=_settings(tmp_path / "nope"))
+    client = TestClient(app)
+    resp = client.get("/v1/health")
+    assert resp.status_code == 200  # liveness is unaffected by validator state
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["validator_healthy"] is False

--- a/tests/clients/test_agent_client.py
+++ b/tests/clients/test_agent_client.py
@@ -174,6 +174,20 @@ async def test_steam_validate_unreachable_raises():
         await client.steam_validate(1018130)
 
 
+async def test_agent_health_single_call():
+    """re-arch ④: agent_health() does a single GET /v1/health and returns the
+    body, so the control plane can source validator health from the agent."""
+
+    def handler(request):
+        assert request.method == "GET"
+        assert request.url.path == "/v1/health"
+        return httpx.Response(200, json={"ok": True, "validator_healthy": True})
+
+    client = _client(handler)
+    body = await client.agent_health()
+    assert body == {"ok": True, "validator_healthy": True}
+
+
 async def test_steam_validate_uses_long_timeout():
     # A large validate (tens of thousands of chunks) stat's many files over NFS
     # and can take well over the default 30s; steam_validate must use a generous

--- a/tests/jobs/test_sweep_handler.py
+++ b/tests/jobs/test_sweep_handler.py
@@ -34,14 +34,14 @@ async def _seed(pool, *, platform="steam", status="up_to_date", app_id="730"):
 def _healthy(monkeypatch):
     """Force the validator self-test to pass so the sweep proceeds."""
 
-    async def _ok(settings):
+    async def _ok(settings, *, agent_client=None):
         return True
 
     monkeypatch.setattr("orchestrator.jobs.handlers.sweep.validator_self_test", _ok)
 
 
 async def test_sweep_skips_when_validator_unhealthy(pool, monkeypatch):
-    async def _unhealthy(settings):
+    async def _unhealthy(settings, *, agent_client=None):
         return False
 
     monkeypatch.setattr("orchestrator.jobs.handlers.sweep.validator_self_test", _unhealthy)
@@ -136,6 +136,59 @@ async def test_sweep_error_outcome_not_counted_as_evicted(pool, monkeypatch):
     assert done, "sweep.completed not logged"
     assert done[0].kwargs["evicted"] == 0  # error != eviction
     assert done[0].kwargs["validation_error"] == 1  # surfaced, not silently absent
+
+
+async def test_sweep_skips_when_agent_reports_validator_unhealthy(pool, monkeypatch, tmp_path):
+    """re-arch ④: when agent_enabled, the sweep's pre-flight self-test sources
+    health from the agent (not the local cache path). Even with a perfectly
+    valid LOCAL cache path, an agent reporting validator_healthy=False must skip
+    the sweep — proving the agent_client is actually threaded into the pre-flight
+    gate. If the agent_client were NOT passed, the valid local path would report
+    healthy and the sweep would proceed to call validate_one_game."""
+    import structlog.testing as st
+
+    import orchestrator.jobs.handlers.sweep as sweep_mod
+    from orchestrator.core.settings import Settings
+
+    (tmp_path / "ab").mkdir()  # a perfectly healthy LOCAL cache dir
+
+    def _agent_settings():
+        return Settings(
+            orchestrator_token="a" * 32,
+            agent_enabled=True,
+            lancache_nginx_cache_path=tmp_path,
+        )
+
+    monkeypatch.setattr(sweep_mod, "get_settings", _agent_settings)
+
+    # If the agent gate were bypassed, the (valid) local path would let the sweep
+    # proceed and this would run, flipping the sentinel.
+    ran = {"validated": False}
+
+    async def _track(*a, **k):
+        ran["validated"] = True
+        from orchestrator.validator.disk_stat import ValidationResult
+
+        return ValidationResult(1, 1, 0, "cached", "100", None)
+
+    monkeypatch.setattr(sweep_mod, "validate_one_game", _track)
+
+    class _UnhealthyAgent:
+        async def agent_health(self):
+            return {"ok": True, "validator_healthy": False}
+
+    cap = st.CapturingLogger()
+    monkeypatch.setattr(sweep_mod, "_log", cap)
+
+    await _seed(pool)
+    await sweep_handler(_job(), Deps(pool=pool, agent_client=_UnhealthyAgent()))
+
+    assert ran["validated"] is False  # sweep never reached validation
+    skips = [c for c in cap.calls if c.args and c.args[0] == "sweep.skipped"]
+    assert skips, "sweep.skipped not logged"
+    assert skips[0].kwargs["reason"] == "validator_unhealthy"
+    g = await pool.read_one("SELECT status FROM games WHERE app_id='730'")
+    assert g["status"] == "up_to_date"  # game untouched
 
 
 async def test_sweep_registered():

--- a/tests/validator/test_self_test.py
+++ b/tests/validator/test_self_test.py
@@ -54,3 +54,74 @@ async def test_true_when_non_empty_cache(tmp_path):
     (tmp_path / "ab").mkdir()
     s = Settings(orchestrator_token=VALID_TOKEN, lancache_nginx_cache_path=tmp_path)
     assert await validator_self_test(s) is True
+
+
+# --- re-arch ④: agent-sourced validator health (control plane has no cache mount) ---
+
+
+class _StubAgent:
+    """Minimal AgentClient stand-in: agent_health() returns a canned body or
+    raises, so we can exercise validator_self_test's agent branch in isolation."""
+
+    def __init__(self, *, healthy: bool | None = None, raises: bool = False) -> None:
+        self._healthy = healthy
+        self._raises = raises
+
+    async def agent_health(self) -> dict[str, object]:
+        if self._raises:
+            raise RuntimeError("agent unreachable")
+        return {"ok": True, "validator_healthy": self._healthy}
+
+
+async def test_agent_enabled_sources_health_from_agent_true(tmp_path):
+    """With agent_enabled and an agent client, health comes from the agent, not
+    the (absent on the LXC) local cache path."""
+    s = Settings(
+        orchestrator_token=VALID_TOKEN,
+        agent_enabled=True,
+        lancache_nginx_cache_path=tmp_path / "does-not-exist",
+    )
+    assert await validator_self_test(s, agent_client=_StubAgent(healthy=True)) is True
+
+
+async def test_agent_enabled_sources_health_from_agent_false(tmp_path):
+    s = Settings(
+        orchestrator_token=VALID_TOKEN,
+        agent_enabled=True,
+        lancache_nginx_cache_path=tmp_path,
+    )
+    assert await validator_self_test(s, agent_client=_StubAgent(healthy=False)) is False
+
+
+async def test_agent_enabled_agent_raises_returns_false(tmp_path):
+    s = Settings(
+        orchestrator_token=VALID_TOKEN,
+        agent_enabled=True,
+        lancache_nginx_cache_path=tmp_path,
+    )
+    assert await validator_self_test(s, agent_client=_StubAgent(raises=True)) is False
+
+
+async def test_flag_off_still_uses_local_cache_path(tmp_path):
+    """Flag-off (default) is byte-identical: the local cache path is the source of
+    truth and the agent_client argument is ignored entirely."""
+    (tmp_path / "ab").mkdir()
+    s = Settings(orchestrator_token=VALID_TOKEN, lancache_nginx_cache_path=tmp_path)
+    # Even passing an agent that would say False, flag-off must read local → True.
+    assert await validator_self_test(s, agent_client=_StubAgent(healthy=False)) is True
+
+
+async def test_agent_health_missing_key_defaults_false(tmp_path):
+    """An agent body that omits `validator_healthy` defaults to False — locks the
+    `.get(..., False)` contract against an older/partial agent response."""
+
+    class _NoKeyAgent:
+        async def agent_health(self) -> dict[str, object]:
+            return {"ok": True}  # no validator_healthy key
+
+    s = Settings(
+        orchestrator_token=VALID_TOKEN,
+        agent_enabled=True,
+        lancache_nginx_cache_path=tmp_path,
+    )
+    assert await validator_self_test(s, agent_client=_NoKeyAgent()) is False


### PR DESCRIPTION
## Re-arch ④ Phase 0 — agent-aware validator health gate

First code PR of ④ (move the control plane to a Proxmox LXC). The LXC has **no local lancache cache mount**, so today's `validator_self_test` (which stat's the local cache path to gate `validator_healthy`) would falsely report unhealthy there → `/health` 503 + F13 sweep skipping every game. Fix: when `agent_enabled`, source validator health from the **agent** (which owns the cache mount).

### Changes
- **agent** `GET /v1/health` now returns `{ok, validator_healthy}` — it runs the agent's own `validator_self_test` against its mounted cache (liveness stays 200; the field carries the cache signal).
- `AgentClient.agent_health()` fetches it.
- `validator_self_test(settings, *, agent_client=None)`: `agent_enabled` + client → use the agent's `validator_healthy` (unreachable agent → `False`, logged not raised; missing key → `False`); **flag-off keeps the local-stat path byte-identical**.
- The boot gate (`api/main.py` §5b) and the F13 sweep pre-flight pass `agent_client`.

### Build / verification
- Built **subagent-driven** (implementer + spec-compliance review + code-quality review; 2 minor code-quality items fixed: tightened `agent_client: AgentClient | None`, added a missing-key→False test).
- Full suite **1225 passed** (only pre-existing `test_licenses` / pip-licenses) · mypy clean · ruff clean.

### Next (operator gate, after merge)
Ship + **live-verify on the existing NAS host** (which has both paths): confirm `/health.validator_healthy` resolves via the agent path (`agent_enabled` is already ON live) and the sweep still runs — proving the path before the LXC (no cache mount) relies on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)