### PR TITLE
feat(agent-client): reuse one persistent httpx client across calls (re-arch ④ §3b-1)

### DIFF
--- a/src/orchestrator/api/main.py
+++ b/src/orchestrator/api/main.py
@@ -317,6 +317,11 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
                 await close_pool()
             except PoolError as e:
                 log.error("api.shutdown.pool_close_failed", reason=str(e))
+
+        # Close the persistent data-plane agent client (re-arch ④ §3b-1).
+        # Best-effort: a failed close must not break shutdown.
+        with contextlib.suppress(Exception):
+            await agent_client.aclose()
         # Tear down the dedicated cache-stat thread pool (#123.4). Idempotent and
         # safe even if validation never ran (the executor is created lazily).
         shutdown_cache_stat_executor()

--- a/src/orchestrator/clients/agent_client.py
+++ b/src/orchestrator/clients/agent_client.py
@@ -42,21 +42,35 @@ class AgentClient:
         # above any real prefill; the orchestrator job's own timeout is the
         # primary guard, this is the client-side backstop.
         self._poll_timeout = poll_timeout_sec
+        # Re-arch ④ §3b-1: hold ONE persistent AsyncClient, built lazily and
+        # reused across calls (and across the many GET polls in
+        # _post_then_poll). On loopback rebuilding per request was harmless;
+        # once the control plane moves to an LXC every call is a cross-host LAN
+        # round-trip, so connection reuse (keep-alive) matters. Closed on the
+        # API lifespan shutdown via aclose().
+        self._client: httpx.AsyncClient | None = None
 
-    def _new_client(self) -> httpx.AsyncClient:
-        kwargs: dict[str, Any] = {
-            "base_url": self._base_url,
-            "headers": self._headers,
-            "timeout": self._timeout,
-        }
-        if self._transport is not None:
-            kwargs["transport"] = self._transport
-        return httpx.AsyncClient(**kwargs)
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            kwargs: dict[str, Any] = {
+                "base_url": self._base_url,
+                "headers": self._headers,
+                "timeout": self._timeout,
+            }
+            if self._transport is not None:
+                kwargs["transport"] = self._transport
+            self._client = httpx.AsyncClient(**kwargs)
+        return self._client
+
+    async def aclose(self) -> None:
+        """Close the persistent client. Idempotent — safe if never built."""
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
 
     async def _request(self, method: str, path: str, **kw: Any) -> httpx.Response:
         try:
-            async with self._new_client() as client:
-                resp = await client.request(method, path, **kw)
+            resp = await self._get_client().request(method, path, **kw)
         except httpx.HTTPError as e:
             raise AgentError(f"agent unreachable: {type(e).__name__}") from e
         if resp.status_code >= 400:

--- a/tests/clients/test_agent_client.py
+++ b/tests/clients/test_agent_client.py
@@ -197,3 +197,58 @@ async def test_steam_validate_uses_long_timeout():
     client = _client(handler)
     await client.steam_validate(1)
     assert seen["timeout"]["read"] == 300.0
+
+
+async def test_reuses_single_client_across_calls():
+    """Re-arch ④ §3b-1: the cross-host client is built once and reused, not
+    rebuilt per request."""
+    built = []
+
+    def handler(request):
+        return httpx.Response(200, json={"cached": 1, "missing": 0})
+
+    transport = httpx.MockTransport(handler)
+    client = AgentClient(base_url="http://agent:8780", token=TOKEN, transport=transport)
+    import orchestrator.clients.agent_client as mod
+
+    real = mod.httpx.AsyncClient
+
+    def counting(*a, **k):
+        c = real(*a, **k)
+        built.append(c)
+        return c
+
+    mod.httpx.AsyncClient = counting  # type: ignore[assignment]
+    try:
+        await client.stat(["a" * 32])
+        await client.stat(["b" * 32])
+    finally:
+        mod.httpx.AsyncClient = real  # type: ignore[assignment]
+        await client.aclose()
+    assert len(built) == 1  # ONE client built, reused for both stat calls
+
+
+async def test_aclose_is_idempotent():
+    client = AgentClient(base_url="http://agent:8780", token=TOKEN)
+    await client.aclose()  # never used → no client built, no error
+    await client.aclose()  # twice → safe
+
+
+async def test_aclose_closes_underlying_and_rebuilds_on_next_call():
+    """aclose() actually closes the underlying httpx client, and the next call
+    transparently rebuilds a fresh one."""
+
+    def handler(request):
+        return httpx.Response(200, json={"cached": 1, "missing": 0})
+
+    client = _client(handler)
+    await client.stat(["a" * 32])  # builds the client
+    underlying = client._client
+    assert underlying is not None and not underlying.is_closed
+    await client.aclose()
+    assert underlying.is_closed
+    assert client._client is None
+    # Next call rebuilds transparently.
+    await client.stat(["b" * 32])
+    assert client._client is not None and not client._client.is_closed
+    await client.aclose()


### PR DESCRIPTION
## Re-arch ④ Phase 3b-1 — AgentClient connection reuse

`AgentClient` built a brand-new `httpx.AsyncClient` for **every** request (and every poll in `_post_then_poll`). Fine on loopback, wasteful once ④ moves the control plane to an LXC and every call is a cross-host LAN round-trip.

### Change
- Hold ONE persistent client via lazy `_get_client()` (built once, reused across all calls).
- `aclose()` closes it (idempotent), wired into the API lifespan shutdown (best-effort).
- `_request` no longer opens/closes a client per call.
- The per-call **300s validate timeout** override still applies (httpx request-level `timeout=`).

### Build / verification
- Built **subagent-driven** (implementer + adversarial spec/quality review — APPROVED; no lazy-init race since `_get_client` is synchronous; the lifespan owns the single instance so no leak; added a belt-and-suspenders test that `aclose()` closes the underlying client + rebuilds on the next call).
- Full suite **1219 passed** (only pre-existing `test_licenses`) · mypy clean · ruff clean. `test_steam_validate_uses_long_timeout` still passes.

Part of re-arch ④ (control plane → Proxmox LXC); independent of #195 (Phase 0) and the Phase 3b-2 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)