### PR TITLE
refactor(agent): decouple agent import graph from api.main + db.pool (re-arch ④ §3b-2 / ARCH-4)

### DIFF
--- a/src/orchestrator/agent/app.py
+++ b/src/orchestrator/agent/app.py
@@ -13,6 +13,7 @@ from fastapi import FastAPI
 from orchestrator.agent.jobs import AgentJobStore
 from orchestrator.agent.routers import health, pull, stat, steam
 from orchestrator.api.middleware import BearerAuthMiddleware, SourceAllowlistMiddleware
+from orchestrator.core.net import detect_non_loopback_bind
 from orchestrator.core.settings import Settings, get_settings
 from orchestrator.platform.steam.prefill_driver import SteamPrefillDriver
 from orchestrator.validator.disk_stat import shutdown_cache_stat_executor
@@ -30,14 +31,9 @@ def _enforce_agent_lan_bind_policy(settings: Settings) -> None:
     """Fail-closed: a non-loopback agent bind MUST declare ORCH_ALLOWED_SOURCE_IPS.
 
     Mirrors the API's _enforce_lan_bind_policy but reads settings.agent_bind_host.
-    The bind-detection helper is imported lazily from orchestrator.api.main to keep
-    the agent module import lightweight (api.main pulls in the full control-plane
-    router/scheduler/db tree, which the agent process never needs at import time).
     """
-    from orchestrator.api.main import _detect_non_loopback_bind
-
     log = structlog.get_logger()
-    bind_signal = _detect_non_loopback_bind(settings.agent_bind_host)
+    bind_signal = detect_non_loopback_bind(settings.agent_bind_host)
     if bind_signal is None:
         return
     if not settings.allowed_source_ips:

--- a/src/orchestrator/api/_constants.py
+++ b/src/orchestrator/api/_constants.py
@@ -1,0 +1,66 @@
+"""Pure middleware/auth constants (no DB import).
+
+Living here (rather than in api.dependencies, which pulls the DB pool) lets the
+data-plane agent load the middlewares without dragging in the control-plane DB
+pool (ARCH-4)."""
+
+from __future__ import annotations
+
+import re
+
+# Body cap (32 KiB per Bible §9.2)
+BODY_SIZE_CAP_BYTES: int = 32 * 1024
+
+# Paths that bypass BearerAuthMiddleware (spec §3.3 + §4).
+#
+# UAT-3 S2-A: matching is EXACT-or-subpath. /api/v1/healthxxx must NOT match
+# /api/v1/health by accident. /api/v1/docs DOES allow subpaths because
+# Swagger UI loads /api/v1/docs/oauth2-redirect; the rest are exact-only.
+#
+# Format: tuple of (path, allow_subpaths) pairs. Match logic in middleware:
+#   exempt = path == p or (allow_subpaths and path.startswith(p + "/"))
+AUTH_EXEMPT_PATHS: tuple[tuple[str, bool], ...] = (
+    ("/api/v1/health", False),
+    ("/api/v1/openapi.json", False),
+    ("/api/v1/docs", True),
+    ("/api/v1/redoc", False),
+    # F10 status page: serves a single HTML file at GET /. The JS in
+    # the page prompts for the bearer + uses it for subsequent API
+    # calls (Bible §9.3). The page fetch itself is unauthenticated;
+    # all data fetches inside it ARE auth-gated by the existing
+    # middleware on /api/v1/* paths.
+    ("/", False),
+)
+
+# Path patterns that ADDITIONALLY require client.host to be loopback (OQ2).
+#
+# Loopback-only restriction applies to:
+#   - POST /api/v1/platforms/{name}/auth (operator credential intake)
+#   - /api/v1/openapi.json + /api/v1/docs + /api/v1/redoc (schema enumeration
+#     defense — UAT-3 S2-C: schema must not be reachable from LAN even
+#     unauthenticated, to prevent route mapping by adjacent attackers).
+#
+# DEPLOYMENT WARNING (UAT-3 S2-D): the loopback check reads scope["client"][0]
+# directly. If a reverse proxy (nginx, traefik, caddy) terminates TLS in
+# front of this app, every request will appear to come from 127.0.0.1 and
+# OQ2 is silently disabled. Operators running behind a reverse proxy MUST
+# either (a) bind the orchestrator to a unix socket only the reverse proxy
+# can reach, or (b) accept that loopback enforcement is moot and enforce
+# the equivalent at the proxy layer. A trust-list of proxy IPs is on the
+# Phase 3 hardening backlog; until then, document and surface the warning
+# at boot via a non-loopback bind log line (see api/main.py lifespan).
+LOOPBACK_ONLY_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^/api/v1/platforms/[^/]+/auth$"),
+    # BL10 F1: `/auth/{challenge_id}` (2FA submit) is loopback-only.
+    # `/auth/status` is NOT (Game_shelf reads it) — exempted via
+    # negative-lookahead.
+    re.compile(r"^/api/v1/platforms/[^/]+/auth/(?!status$)[^/]+$"),
+    re.compile(r"^/api/v1/openapi\.json$"),
+    re.compile(r"^/api/v1/docs/?$"),
+    re.compile(r"^/api/v1/docs/oauth2-redirect/?$"),
+    re.compile(r"^/api/v1/redoc/?$"),
+)
+
+# Loopback host values accepted by the OQ2 check. Both IPv4 (127.0.0.1) and
+# IPv6 (::1, ::ffff:127.0.0.1) forms must be honored — UAT-3 S3-h fix.
+LOOPBACK_HOSTS: frozenset[str] = frozenset({"127.0.0.1", "::1", "::ffff:127.0.0.1"})

--- a/src/orchestrator/api/dependencies.py
+++ b/src/orchestrator/api/dependencies.py
@@ -7,72 +7,31 @@ the BL4 pool singleton).
 
 from __future__ import annotations
 
-import re
-
+from orchestrator.api._constants import (
+    AUTH_EXEMPT_PATHS,
+    BODY_SIZE_CAP_BYTES,
+    LOOPBACK_HOSTS,
+    LOOPBACK_ONLY_PATTERNS,
+)
 from orchestrator.db.pool import Pool, get_pool
 
-# Body cap (32 KiB per Bible §9.2)
-BODY_SIZE_CAP_BYTES: int = 32 * 1024
+# Re-export the pure middleware/auth constants from orchestrator.api._constants
+# (moved there in ARCH-4 so middleware.py can import them without dragging in the
+# DB pool). Kept in __all__ so existing `dependencies.<CONST>` importers still work.
+__all__ = [
+    "AUTH_EXEMPT_PATHS",
+    "AUTH_EXEMPT_PREFIXES",
+    "BODY_SIZE_CAP_BYTES",
+    "LOOPBACK_HOSTS",
+    "LOOPBACK_ONLY_PATTERNS",
+    "get_pool_dep",
+]
 
 # API version surfaced in /health
 __version__: str = "0.1.0"
 
-# Paths that bypass BearerAuthMiddleware (spec §3.3 + §4).
-#
-# UAT-3 S2-A: matching is EXACT-or-subpath. /api/v1/healthxxx must NOT match
-# /api/v1/health by accident. /api/v1/docs DOES allow subpaths because
-# Swagger UI loads /api/v1/docs/oauth2-redirect; the rest are exact-only.
-#
-# Format: tuple of (path, allow_subpaths) pairs. Match logic in middleware:
-#   exempt = path == p or (allow_subpaths and path.startswith(p + "/"))
-AUTH_EXEMPT_PATHS: tuple[tuple[str, bool], ...] = (
-    ("/api/v1/health", False),
-    ("/api/v1/openapi.json", False),
-    ("/api/v1/docs", True),
-    ("/api/v1/redoc", False),
-    # F10 status page: serves a single HTML file at GET /. The JS in
-    # the page prompts for the bearer + uses it for subsequent API
-    # calls (Bible §9.3). The page fetch itself is unauthenticated;
-    # all data fetches inside it ARE auth-gated by the existing
-    # middleware on /api/v1/* paths.
-    ("/", False),
-)
-
 # Backwards-compatibility view for older imports (just the path strings).
 AUTH_EXEMPT_PREFIXES: tuple[str, ...] = tuple(p for p, _ in AUTH_EXEMPT_PATHS)
-
-# Path patterns that ADDITIONALLY require client.host to be loopback (OQ2).
-#
-# Loopback-only restriction applies to:
-#   - POST /api/v1/platforms/{name}/auth (operator credential intake)
-#   - /api/v1/openapi.json + /api/v1/docs + /api/v1/redoc (schema enumeration
-#     defense — UAT-3 S2-C: schema must not be reachable from LAN even
-#     unauthenticated, to prevent route mapping by adjacent attackers).
-#
-# DEPLOYMENT WARNING (UAT-3 S2-D): the loopback check reads scope["client"][0]
-# directly. If a reverse proxy (nginx, traefik, caddy) terminates TLS in
-# front of this app, every request will appear to come from 127.0.0.1 and
-# OQ2 is silently disabled. Operators running behind a reverse proxy MUST
-# either (a) bind the orchestrator to a unix socket only the reverse proxy
-# can reach, or (b) accept that loopback enforcement is moot and enforce
-# the equivalent at the proxy layer. A trust-list of proxy IPs is on the
-# Phase 3 hardening backlog; until then, document and surface the warning
-# at boot via a non-loopback bind log line (see api/main.py lifespan).
-LOOPBACK_ONLY_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"^/api/v1/platforms/[^/]+/auth$"),
-    # BL10 F1: `/auth/{challenge_id}` (2FA submit) is loopback-only.
-    # `/auth/status` is NOT (Game_shelf reads it) — exempted via
-    # negative-lookahead.
-    re.compile(r"^/api/v1/platforms/[^/]+/auth/(?!status$)[^/]+$"),
-    re.compile(r"^/api/v1/openapi\.json$"),
-    re.compile(r"^/api/v1/docs/?$"),
-    re.compile(r"^/api/v1/docs/oauth2-redirect/?$"),
-    re.compile(r"^/api/v1/redoc/?$"),
-)
-
-# Loopback host values accepted by the OQ2 check. Both IPv4 (127.0.0.1) and
-# IPv6 (::1, ::ffff:127.0.0.1) forms must be honored — UAT-3 S3-h fix.
-LOOPBACK_HOSTS: frozenset[str] = frozenset({"127.0.0.1", "::1", "::ffff:127.0.0.1"})
 
 
 async def get_pool_dep() -> Pool:

--- a/src/orchestrator/api/main.py
+++ b/src/orchestrator/api/main.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
-import sys
 import time
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
@@ -39,6 +38,7 @@ from orchestrator.api.routers.status import router as status_router
 from orchestrator.api.routers.sync import router as sync_router
 from orchestrator.api.routers.validate_trigger import router as validate_trigger_router
 from orchestrator.core.logging import configure_logging
+from orchestrator.core.net import detect_non_loopback_bind
 from orchestrator.core.settings import Settings, get_settings
 from orchestrator.db import migrate
 from orchestrator.db.pool import (
@@ -61,41 +61,13 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
 
-_LOOPBACK_HOST_VALUES = frozenset({"127.0.0.1", "::1", "localhost"})
-
-
-def _detect_non_loopback_bind(settings_api_host: str) -> str | None:
-    """Return the non-loopback host string if any signal indicates it,
-    or None if all known signals say loopback. UAT-3 S2-D — covers
-    settings, the UVICORN_HOST env var, and `--host` in argv.
-    """
-    if settings_api_host not in _LOOPBACK_HOST_VALUES:
-        return settings_api_host
-
-    uvicorn_host = os.environ.get("UVICORN_HOST")
-    if uvicorn_host and uvicorn_host not in _LOOPBACK_HOST_VALUES:
-        return uvicorn_host
-
-    argv = sys.argv
-    for i, arg in enumerate(argv):
-        if arg == "--host" and i + 1 < len(argv):
-            value = argv[i + 1]
-            if value not in _LOOPBACK_HOST_VALUES:
-                return value
-        elif arg.startswith("--host="):
-            value = arg.split("=", 1)[1]
-            if value not in _LOOPBACK_HOST_VALUES:
-                return value
-    return None
-
-
 def _enforce_lan_bind_policy(settings: Settings) -> None:
     """Fail-closed LAN-bind guard (security priority #1). A non-loopback bind
     MUST declare ORCH_ALLOWED_SOURCE_IPS; otherwise refuse to start. A loopback
     bind is always fine. Called at the top of the lifespan, before migrations,
     so a misconfiguration fails fast."""
     log = structlog.get_logger()
-    bind_signal = _detect_non_loopback_bind(settings.api_host)
+    bind_signal = detect_non_loopback_bind(settings.api_host)
     if bind_signal is None:
         return
     if not settings.allowed_source_ips:

--- a/src/orchestrator/api/middleware.py
+++ b/src/orchestrator/api/middleware.py
@@ -20,7 +20,7 @@ from typing import Any
 
 import structlog
 
-from orchestrator.api.dependencies import (
+from orchestrator.api._constants import (
     AUTH_EXEMPT_PATHS,
     BODY_SIZE_CAP_BYTES,
     LOOPBACK_HOSTS,

--- a/src/orchestrator/core/net.py
+++ b/src/orchestrator/core/net.py
@@ -1,0 +1,31 @@
+"""Network bind-detection helpers (neutral home so both the control-plane API
+and the data-plane agent can detect a non-loopback bind without importing each
+other). Pure stdlib — no DB, no routers."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+LOOPBACK_HOST_VALUES = frozenset({"127.0.0.1", "::1", "localhost"})
+
+
+def detect_non_loopback_bind(settings_host: str) -> str | None:
+    """Return the non-loopback host string if any signal indicates it, else None.
+    Covers the settings host, the UVICORN_HOST env var, and `--host` in argv."""
+    if settings_host not in LOOPBACK_HOST_VALUES:
+        return settings_host
+    uvicorn_host = os.environ.get("UVICORN_HOST")
+    if uvicorn_host and uvicorn_host not in LOOPBACK_HOST_VALUES:
+        return uvicorn_host
+    argv = sys.argv
+    for i, arg in enumerate(argv):
+        if arg == "--host" and i + 1 < len(argv):
+            value = argv[i + 1]
+            if value not in LOOPBACK_HOST_VALUES:
+                return value
+        elif arg.startswith("--host="):
+            value = arg.split("=", 1)[1]
+            if value not in LOOPBACK_HOST_VALUES:
+                return value
+    return None

--- a/tests/agent/test_import_isolation.py
+++ b/tests/agent/test_import_isolation.py
@@ -1,0 +1,22 @@
+"""ARCH-4 / re-arch ④: the data-plane agent process must not transitively import
+the control-plane API entrypoint or the DB pool."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_agent_app_does_not_import_api_main_or_pool():
+    code = (
+        "import orchestrator.agent.app as a\n"
+        "_ = a.create_agent_app\n"
+        "import sys\n"
+        "bad = [m for m in ('orchestrator.api.main', 'orchestrator.db.pool') "
+        "if m in sys.modules]\n"
+        "print('BAD=' + ','.join(bad))\n"
+    )
+    out = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True
+    ).stdout
+    assert out.strip() == "BAD=", f"agent pulled in control-plane/DB modules: {out.strip()}"

--- a/tests/api/test_uat3_remediation.py
+++ b/tests/api/test_uat3_remediation.py
@@ -440,43 +440,43 @@ class TestS2DBindDetection:
     signals so the warning fires even when the operator uses bare CLI flags."""
 
     def test_detects_settings_api_host(self):
-        from orchestrator.api.main import _detect_non_loopback_bind
+        from orchestrator.core.net import detect_non_loopback_bind
 
-        assert _detect_non_loopback_bind("0.0.0.0") == "0.0.0.0"  # noqa: S104
-        assert _detect_non_loopback_bind("127.0.0.1") is None
-        assert _detect_non_loopback_bind("::1") is None
-        assert _detect_non_loopback_bind("localhost") is None
+        assert detect_non_loopback_bind("0.0.0.0") == "0.0.0.0"  # noqa: S104
+        assert detect_non_loopback_bind("127.0.0.1") is None
+        assert detect_non_loopback_bind("::1") is None
+        assert detect_non_loopback_bind("localhost") is None
 
     def test_detects_uvicorn_host_env(self, monkeypatch):
-        from orchestrator.api.main import _detect_non_loopback_bind
+        from orchestrator.core.net import detect_non_loopback_bind
 
         monkeypatch.setenv("UVICORN_HOST", "0.0.0.0")  # noqa: S104
-        assert _detect_non_loopback_bind("127.0.0.1") == "0.0.0.0"  # noqa: S104
+        assert detect_non_loopback_bind("127.0.0.1") == "0.0.0.0"  # noqa: S104
 
     def test_detects_argv_host_flag_separate(self, monkeypatch):
         import sys
 
-        from orchestrator.api.main import _detect_non_loopback_bind
+        from orchestrator.core.net import detect_non_loopback_bind
 
         monkeypatch.setattr(sys, "argv", ["uvicorn", "--host", "0.0.0.0", "module:app"])  # noqa: S104
-        assert _detect_non_loopback_bind("127.0.0.1") == "0.0.0.0"  # noqa: S104
+        assert detect_non_loopback_bind("127.0.0.1") == "0.0.0.0"  # noqa: S104
 
     def test_detects_argv_host_flag_equals(self, monkeypatch):
         import sys
 
-        from orchestrator.api.main import _detect_non_loopback_bind
+        from orchestrator.core.net import detect_non_loopback_bind
 
         monkeypatch.setattr(sys, "argv", ["uvicorn", "--host=0.0.0.0", "module:app"])
-        assert _detect_non_loopback_bind("127.0.0.1") == "0.0.0.0"  # noqa: S104
+        assert detect_non_loopback_bind("127.0.0.1") == "0.0.0.0"  # noqa: S104
 
     def test_returns_none_when_all_signals_loopback(self, monkeypatch):
         import sys
 
-        from orchestrator.api.main import _detect_non_loopback_bind
+        from orchestrator.core.net import detect_non_loopback_bind
 
         monkeypatch.delenv("UVICORN_HOST", raising=False)
         monkeypatch.setattr(sys, "argv", ["uvicorn", "--host", "127.0.0.1", "module:app"])
-        assert _detect_non_loopback_bind("127.0.0.1") is None
+        assert detect_non_loopback_bind("127.0.0.1") is None
 
 
 class TestS2JNoTracebackOnSystemExit:

--- a/tests/core/test_net.py
+++ b/tests/core/test_net.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from orchestrator.core.net import detect_non_loopback_bind
+
+
+def test_loopback_returns_none(monkeypatch):
+    monkeypatch.delenv("UVICORN_HOST", raising=False)
+    monkeypatch.setattr("sys.argv", ["x"])
+    assert detect_non_loopback_bind("127.0.0.1") is None
+
+
+def test_non_loopback_setting_returned(monkeypatch):
+    monkeypatch.delenv("UVICORN_HOST", raising=False)
+    monkeypatch.setattr("sys.argv", ["x"])
+    assert detect_non_loopback_bind("0.0.0.0") == "0.0.0.0"  # noqa: S104
+
+
+def test_uvicorn_host_env_detected(monkeypatch):
+    monkeypatch.setenv("UVICORN_HOST", "0.0.0.0")  # noqa: S104
+    monkeypatch.setattr("sys.argv", ["x"])
+    assert detect_non_loopback_bind("127.0.0.1") == "0.0.0.0"  # noqa: S104
+
+
+def test_host_argv_flag_detected(monkeypatch):
+    monkeypatch.delenv("UVICORN_HOST", raising=False)
+    monkeypatch.setattr("sys.argv", ["x", "--host", "0.0.0.0"])  # noqa: S104
+    assert detect_non_loopback_bind("127.0.0.1") == "0.0.0.0"  # noqa: S104


### PR DESCRIPTION
## Re-arch ④ Phase 3b-2 — decouple the agent import graph (ARCH-4)

The data-plane agent process transitively imported the **control-plane entrypoint** and the **DB pool**: `agent/app.py → api.middleware → api.dependencies → db.pool`, plus a lazy `from orchestrator.api.main import _detect_non_loopback_bind` (which pulls all routers + scheduler + pool). Once ④ makes the agent the only orchestrator code on the UGREEN, that coupling should go.

### Change
- `detect_non_loopback_bind` + `LOOPBACK_HOST_VALUES` → neutral **`core/net.py`** (pure stdlib); both `api.main` and `agent/app.py` import from there.
- The pure middleware constants (`AUTH_EXEMPT_PATHS`, `BODY_SIZE_CAP_BYTES`, `LOOPBACK_HOSTS`, `LOOPBACK_ONLY_PATTERNS`) → **`api/_constants.py`**; `api/middleware.py` imports them from there instead of `api/dependencies.py` (which pulls `db.pool`). `dependencies.py` re-exports for back-compat — **constant values unchanged** (verified value-identical).
- **`tests/agent/test_import_isolation.py`** — a subprocess import-graph guard asserts `orchestrator.api.main` and `orchestrator.db.pool` are absent after importing the agent app.

### Build / verification
- Built **subagent-driven** (implementer + adversarial spec/quality review — APPROVED; constants value-identical, no scope creep; the review's minor note applied: removed the dead `_detect_non_loopback_bind` back-compat alias and pointed the one test at `core.net`).
- Independently confirmed: the agent imports **NEITHER** `api.main` nor `db.pool`.
- Full suite **1221 passed** (only pre-existing `test_licenses`) · mypy clean · ruff clean.

**Last code PR of re-arch ④.** Independent of #195 (Phase 0) and #196 (Phase 3b-1). After these three merge, only the operator-collaborative cutover (Phase C) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)