### PR TITLE
fix(health): cache_volume_mounted agent-aware when agent_enabled (re-arch ④)

### DIFF
--- a/src/orchestrator/api/routers/health.py
+++ b/src/orchestrator/api/routers/health.py
@@ -58,7 +58,6 @@ async def get_health(
 
     settings = get_settings()
     cache_path = Path(settings.lancache_nginx_cache_path)
-    cache_volume_mounted = cache_path.is_dir()
 
     # ID2 lancache reachability probe. `app.state.lancache_probe` is built
     # in lifespan startup; `probe()` is cache-fast (no IO most of the time)
@@ -102,6 +101,12 @@ async def get_health(
         steam_auth_ok = (
             bool(prefill_driver.auth_status().ok) if prefill_driver is not None else False
         )
+
+    # re-arch ④: the control plane on the LXC has no local lancache cache mount —
+    # the cache lives on the agent. When agent_enabled, "volume mounted" means the
+    # cache-holding agent is reachable (validator_healthy, sourced from the agent,
+    # separately covers cache USABILITY). Flag-off keeps the local is_dir() check.
+    cache_volume_mounted = agent_reachable if settings.agent_enabled else cache_path.is_dir()
 
     body = HealthResponse(
         status="ok" if pool_ok else "degraded",

--- a/tests/api/test_health_endpoint.py
+++ b/tests/api/test_health_endpoint.py
@@ -312,3 +312,69 @@ class TestHealthResponseShape:
                 git_sha="x",
                 unknown_extra_field="leak",  # forbidden
             )
+
+
+class TestCacheVolumeMountedAgentAware:
+    """re-arch ④: when agent_enabled, `cache_volume_mounted` reflects the AGENT
+    (which owns the lancache cache mount), not a local path the LXC control plane
+    does not have. Flag-off keeps the local `is_dir()` check."""
+
+    async def test_agent_enabled_cache_mounted_tracks_reachable_agent(
+        self, client, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("ORCH_AGENT_ENABLED", "true")
+        # No local cache dir (the LXC case) — must still report mounted via agent.
+        monkeypatch.setenv("ORCH_LANCACHE_NGINX_CACHE_PATH", str(tmp_path / "absent"))
+        from orchestrator.core.settings import get_settings
+
+        get_settings.cache_clear()
+
+        class _UpAgent:
+            async def auth_status(self):
+                return {"ok": True}
+
+        app_state = client._transport.app.state
+        app_state.agent_client = _UpAgent()
+        try:
+            body = (await client.get("/api/v1/health")).json()
+            assert body["agent_reachable"] is True
+            assert body["cache_volume_mounted"] is True
+        finally:
+            del app_state.agent_client
+            get_settings.cache_clear()
+
+    async def test_agent_enabled_cache_unmounted_when_agent_down(
+        self, client, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("ORCH_AGENT_ENABLED", "true")
+        monkeypatch.setenv("ORCH_LANCACHE_NGINX_CACHE_PATH", str(tmp_path / "absent"))
+        from orchestrator.core.settings import get_settings
+
+        get_settings.cache_clear()
+
+        class _DownAgent:
+            async def auth_status(self):
+                raise RuntimeError("agent down")
+
+        app_state = client._transport.app.state
+        app_state.agent_client = _DownAgent()
+        try:
+            body = (await client.get("/api/v1/health")).json()
+            assert body["agent_reachable"] is False
+            assert body["cache_volume_mounted"] is False
+        finally:
+            del app_state.agent_client
+            get_settings.cache_clear()
+
+    async def test_flag_off_cache_mounted_uses_local_dir(self, client, monkeypatch, tmp_path):
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        monkeypatch.setenv("ORCH_LANCACHE_NGINX_CACHE_PATH", str(cache))
+        from orchestrator.core.settings import get_settings
+
+        get_settings.cache_clear()
+        try:
+            body = (await client.get("/api/v1/health")).json()
+            assert body["cache_volume_mounted"] is True
+        finally:
+            get_settings.cache_clear()


### PR DESCRIPTION
## Found live during the ④ LXC cutover

Phase 0 (#195) made `validator_healthy` agent-aware, but the **sibling** `/health` field `cache_volume_mounted` still did a local `cache_path.is_dir()` — and it's in the `all_healthy` 503 gate. On the LXC control plane (no local cache mount) it returned `False` → `/health` **503** even though every agent-sourced signal was healthy (`validator_healthy=True`, `agent_reachable=True`). Caught during the parallel-bring-up smoke test, before the flip.

### Fix
When `agent_enabled`, `cache_volume_mounted` reflects `agent_reachable` (the agent owns the cache mount; `validator_healthy`, sourced from the agent, separately covers cache *usability*). Flag-off keeps the local `is_dir()` check. Test-first.

### Verification
- New `TestCacheVolumeMountedAgentAware` (agent-up → mounted; agent-down → unmounted; flag-off → local dir).
- Full suite **1236 passed** (only pre-existing `test_licenses`) · mypy clean · ruff clean.

This is the cutover gate doing its job — a real LXC-only defect surfaced before flipping. Completes the ④ health-gate work alongside #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)