### PR TITLE
feat(steam): durable manifest archive + validate-all backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Added — Durable Steam manifest store + validate-all backfill (2026-06-24) — 2026-06-24
+
+Lets the orchestrator validate the *entire* prefilled Steam library, not just the subset SteamPrefill currently has a fresh manifest for. SteamPrefill only writes a manifest `.bin` when an app has new content (and treats saved manifests as temporary via `clear-temp`), so its cache covered ~330 of ~1077 prefilled apps; the other ~747 returned `no_manifest_in_cache` and could never be validated though their ~13 TB of chunks were on disk.
+
+- **Durable manifest archive (agent):** a new append-only archive (`steam_manifest_archive_dir`, default `/manifest-archive`) the agent copies every manifest `.bin` it sees into, immune to SteamPrefill `clear-temp`. Validate + enumerate now read the **union** of the live cache and the archive, newest-`.bin`-per-depot by mtime (which also fixes manifest version drift). An absent/unmounted archive dir is a no-op — byte-identical to prior behavior.
+- **Periodic archive sync (agent):** a background task (`manifest_archive_sync_interval_sec`, default 1800 s; `0` disables) copies new manifests into the archive before any pruning, with an mtime-settle guard so half-written files are skipped, append-only and per-file fault-isolated.
+- **`POST /api/v1/sweep` + `orchestrator-cli cache validate-all`:** trigger a one-shot full validation sweep (`payload {"full": true}`) over EVERY steam game — the validate-all backfill that flips genuinely-cached games to `up_to_date` after seeding the archive. The endpoint reports the actual queued sweep's mode and whether this call queued it; the CLI warns when a non-full sweep is already in flight (so a dedup never masquerades as a backfill).
+
+### Changed — F13 sweep gains a full mode (2026-06-24) — 2026-06-24
+
+- The scheduled-sweep handler honors a `full` flag on the job payload: `full` validates all steam games (`… WHERE platform='steam'`), the default keeps the status-gated candidate set (`up_to_date`/`validation_failed`). The weekly cron stays status-gated; `enqueue_validation_sweep(*, full, source)` carries the flag. No migration — reuses the existing `jobs.payload` column and the `idx_jobs_sweep_inflight` dedup.
+
 ### Changed — Re-arch ④ control-plane-to-LXC prep (2026-06-23) — 2026-06-23
 
 Makes the control plane safe to run off-host (the final re-architecture step: brain → Proxmox LXC, agent stays on the UGREEN NAS). Code merged + Phase 0 live-verified on the NAS; the cutover itself is the operator runbook below.

--- a/docs/superpowers/plans/2026-06-24-durable-manifest-store.md
+++ b/docs/superpowers/plans/2026-06-24-durable-manifest-store.md
@@ -1,0 +1,890 @@
+# Durable Steam Manifest Store + Validate-All Backfill — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the orchestrator validate the *entire* prefilled Steam library by copying SteamPrefill's transient `.bin` manifests into a permanent agent-owned archive (validate reads live∪archive), plus a one-off "validate-all" full sweep to flip genuinely-cached games to `up_to_date`.
+
+**Architecture:** Agent half — a new append-only manifest archive volume, a `union` read across [live cache, archive], and a periodic sync that copies new manifests into the archive before SteamPrefill prunes them. Control-plane half — the F13 sweep gains a `full` mode (carried on `jobs.payload`, no migration) that validates every steam game, triggered by a new `POST /api/v1/sweep` endpoint and an `orchestrator-cli cache validate-all` command.
+
+**Tech Stack:** Python 3.12, FastAPI, pydantic-settings, click, structlog, stdlib `shutil`/`asyncio`; pytest/ruff/mypy.
+
+**Spec:** `docs/superpowers/specs/2026-06-24-durable-manifest-store-design.md`
+
+**Conventions:** TDD (failing test → red → minimal impl → green). **No per-task commits — ONE `feat` commit at the very end** (Task 8). Before that commit: `.venv/bin/ruff format`, `.venv/bin/ruff check`, `.venv/bin/mypy src/orchestrator` (all clean), full suite `.venv/bin/python -m pytest -q --ignore=tests/scripts` (only acceptable failure: `tests/test_licenses.py`). No `assert` in `src/` (ruff S101 → use `if … raise`); bare dict returns need `dict[str, Any]`. No new third-party libs (stdlib + already-researched fastapi/pydantic/click). Mark each task `in_progress` (enforce-plan-tracking) before editing its source.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `src/orchestrator/core/settings.py` | new `steam_manifest_archive_dir`, `manifest_archive_sync_interval_sec` | modify |
+| `src/orchestrator/agent/manifest_locator.py` | union read across multiple cache roots | modify (signature) |
+| `src/orchestrator/agent/routers/steam.py` | pass `cache_roots=[live, archive]` | modify (2 call sites) |
+| `src/orchestrator/agent/manifest_archive.py` | append-only sync + periodic loop (stdlib only) | **create** |
+| `src/orchestrator/agent/app.py` | wire the periodic sync task into the lifespan | modify |
+| `src/orchestrator/jobs/handlers/sweep.py` | `full` mode candidate SQL via `payload` | modify |
+| `src/orchestrator/scheduler/jobs.py` | `enqueue_validation_sweep(*, full, source)` payload | modify |
+| `src/orchestrator/api/routers/sweep_trigger.py` | `POST /api/v1/sweep` | **create** |
+| `src/orchestrator/api/main.py` | register the sweep-trigger router | modify |
+| `src/orchestrator/cli/commands/cache.py` | `cache validate-all` command | **create** |
+| `src/orchestrator/cli/main.py` | register the `cache` group | modify |
+
+---
+
+## Task 1: Settings — archive dir + sync interval
+
+**Files:**
+- Modify: `src/orchestrator/core/settings.py` (after `steam_manifest_cache_dir`, ~line 109; `Field` import already present)
+- Test: `tests/core/test_settings.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_settings.py`:
+
+```python
+def test_manifest_archive_defaults():
+    s = Settings()
+    assert str(s.steam_manifest_archive_dir) == "/manifest-archive"
+    assert s.manifest_archive_sync_interval_sec == 1800
+
+
+def test_manifest_archive_env_override(monkeypatch):
+    monkeypatch.setenv("ORCH_STEAM_MANIFEST_ARCHIVE_DIR", "/tmp/arch")
+    monkeypatch.setenv("ORCH_MANIFEST_ARCHIVE_SYNC_INTERVAL_SEC", "0")
+    s = Settings()
+    assert str(s.steam_manifest_archive_dir) == "/tmp/arch"
+    assert s.manifest_archive_sync_interval_sec == 0
+```
+
+(If `tests/core/test_settings.py` imports `Settings` differently, match the file's existing import. Env prefix is `ORCH_`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/core/test_settings.py -k manifest_archive -q`
+Expected: FAIL (`AttributeError: 'Settings' object has no attribute 'steam_manifest_archive_dir'`).
+
+- [ ] **Step 3: Implement**
+
+In `src/orchestrator/core/settings.py`, immediately after the `steam_manifest_cache_dir` field:
+
+```python
+    # Durable manifest archive (2026-06-24). SteamPrefill only writes a manifest
+    # .bin when an app has NEW content, so its live cache covers a shrinking
+    # subset of the prefilled library. The agent copies every manifest it sees
+    # into this permanent, append-only archive (immune to SteamPrefill
+    # `clear-temp`); validate reads the UNION of the live cache + this archive.
+    # An absent/unmounted dir is a no-op — byte-identical to pre-archive behavior.
+    steam_manifest_archive_dir: Path = Path("/manifest-archive")
+    # Agent sync cadence (seconds) for copying live manifests into the archive.
+    # 0 disables the periodic sync.
+    manifest_archive_sync_interval_sec: int = Field(default=1800, ge=0)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/core/test_settings.py -k manifest_archive -q`
+Expected: PASS.
+
+---
+
+## Task 2: manifest_locator — union across cache roots
+
+**Files:**
+- Modify: `src/orchestrator/agent/manifest_locator.py`
+- Modify: `src/orchestrator/agent/routers/steam.py` (lines ~82-87 `prefilled_apps`, ~112-114 `steam_validate`)
+- Test: `tests/agent/test_manifest_locator.py` (update existing calls + add new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the body of `tests/agent/test_manifest_locator.py` calls so every `cache_root=X` becomes `cache_roots=[X]`, and add:
+
+```python
+def _write_bin(root: Path, app: int, depot: int, gid: int, mtime: float | None = None) -> Path:
+    v1 = root / "v1"
+    v1.mkdir(parents=True, exist_ok=True)
+    p = v1 / f"{app}_{app}_{depot}_{gid}.bin"
+    p.write_bytes(b"x")
+    if mtime is not None:
+        import os
+        os.utime(p, (mtime, mtime))
+    return p
+
+
+def test_union_live_only(tmp_path):
+    live = tmp_path / "live"
+    _write_bin(live, 440, 441, 111)
+    assert locate_manifest_bins(440, cache_roots=[live, tmp_path / "absent"])
+
+
+def test_union_archive_only(tmp_path):
+    arch = tmp_path / "arch"
+    _write_bin(arch, 730, 731, 222)
+    found = locate_manifest_bins(730, cache_roots=[tmp_path / "absent", arch])
+    assert len(found) == 1
+
+
+def test_union_newest_per_depot_across_roots(tmp_path):
+    live, arch = tmp_path / "live", tmp_path / "arch"
+    _write_bin(arch, 570, 571, 1, mtime=1000.0)   # older, archived
+    newer = _write_bin(live, 570, 571, 2, mtime=2000.0)  # newer, live, same depot
+    found = locate_manifest_bins(570, cache_roots=[live, arch])
+    assert found == [newer]  # newest-per-depot wins regardless of root order
+
+
+def test_union_both_absent_returns_empty(tmp_path):
+    assert locate_manifest_bins(1, cache_roots=[tmp_path / "a", tmp_path / "b"]) == []
+
+
+def test_list_prefilled_app_ids_union(tmp_path):
+    live, arch = tmp_path / "live", tmp_path / "arch"
+    _write_bin(live, 440, 441, 1)
+    _write_bin(arch, 730, 731, 1)
+    assert list_prefilled_app_ids(cache_roots=[live, arch]) == [440, 730]
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python -m pytest tests/agent/test_manifest_locator.py -q`
+Expected: FAIL (`TypeError: … unexpected keyword argument 'cache_roots'`).
+
+- [ ] **Step 3: Implement the union**
+
+Replace both functions in `src/orchestrator/agent/manifest_locator.py` (keep the module docstring; update the param wording):
+
+```python
+def list_prefilled_app_ids(*, cache_roots: list[Path]) -> list[int]:
+    """Distinct app_ids with a cached manifest .bin across all roots (sorted)."""
+    apps: set[int] = set()
+    for root in cache_roots:
+        v1 = root / "v1"
+        if not v1.is_dir():
+            continue
+        for path in v1.glob("*.bin"):
+            first = path.stem.split("_", 1)[0]
+            if first.isdigit():
+                apps.add(int(first))
+    return sorted(apps)
+
+
+def locate_manifest_bins(app_id: int, *, cache_roots: list[Path]) -> list[Path]:
+    """Newest manifest .bin per depot for ``app_id`` across all roots (empty if none).
+
+    Roots are searched in order; the newest .bin per depot by mtime wins, so a
+    fresher live-cache manifest supersedes an older archived one for the same
+    depot (and stable apps present only in the archive are still found)."""
+    newest_per_depot: dict[str, Path] = {}
+    for root in cache_roots:
+        v1 = root / "v1"
+        if not v1.is_dir():
+            continue
+        for path in v1.glob(f"{app_id}_{app_id}_*.bin"):
+            parts = path.stem.split("_")
+            if len(parts) != 4:
+                continue
+            depot = parts[2]
+            current = newest_per_depot.get(depot)
+            if current is None or path.stat().st_mtime > current.stat().st_mtime:
+                newest_per_depot[depot] = path
+    return list(newest_per_depot.values())
+```
+
+- [ ] **Step 4: Update the two callers in `src/orchestrator/agent/routers/steam.py`**
+
+`prefilled_apps` (replace the body lines that build `manifest_cache` + return):
+
+```python
+    s = request.app.state.settings
+    roots = [Path(s.steam_manifest_cache_dir), Path(s.steam_manifest_archive_dir)]
+    return {"app_ids": list_prefilled_app_ids(cache_roots=roots)}
+```
+
+`steam_validate` (replace the `manifest_cache = …` + `bins = locate_manifest_bins(…)` lines):
+
+```python
+    roots = [Path(settings.steam_manifest_cache_dir), Path(settings.steam_manifest_archive_dir)]
+    bins = locate_manifest_bins(body.app_id, cache_roots=roots)
+```
+
+(`Path` is already imported in `steam.py`. The `slice_range`/`identifier`/`levels` lines below are unchanged.)
+
+- [ ] **Step 5: Run to verify pass (incl. existing steam-validate tests)**
+
+Run: `.venv/bin/python -m pytest tests/agent/test_manifest_locator.py tests/agent/test_steam_validate.py tests/agent/test_steam.py -q`
+Expected: PASS. (If `test_steam_validate.py`/`test_steam.py` set up a manifest dir, they still work because the absent archive root is a no-op.)
+
+---
+
+## Task 3: manifest_archive.py — append-only sync (stdlib only)
+
+**Files:**
+- Create: `src/orchestrator/agent/manifest_archive.py`
+- Test: `tests/agent/test_manifest_archive.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/agent/test_manifest_archive.py`:
+
+```python
+import os
+import time
+from pathlib import Path
+
+import orchestrator.agent.manifest_archive as mod
+from orchestrator.agent.manifest_archive import sync_manifests_to_archive
+
+
+def _bin(root: Path, name: str, age_seconds: float = 100.0) -> Path:
+    v1 = root / "v1"
+    v1.mkdir(parents=True, exist_ok=True)
+    p = v1 / name
+    p.write_bytes(b"data")
+    t = time.time() - age_seconds
+    os.utime(p, (t, t))
+    return p
+
+
+def test_copies_new_bin(tmp_path):
+    live, arch = tmp_path / "live", tmp_path / "arch"
+    _bin(live, "440_440_441_1.bin")
+    assert sync_manifests_to_archive(live, arch) == 1
+    assert (arch / "v1" / "440_440_441_1.bin").is_file()
+
+
+def test_skips_already_archived(tmp_path):
+    live, arch = tmp_path / "live", tmp_path / "arch"
+    _bin(live, "440_440_441_1.bin")
+    _bin(arch, "440_440_441_1.bin")
+    assert sync_manifests_to_archive(live, arch) == 0
+
+
+def test_preserves_mtime(tmp_path):
+    live, arch = tmp_path / "live", tmp_path / "arch"
+    src = _bin(live, "1_1_2_3.bin", age_seconds=5000.0)
+    sync_manifests_to_archive(live, arch)
+    assert (arch / "v1" / "1_1_2_3.bin").stat().st_mtime == src.stat().st_mtime
+
+
+def test_settle_guard_skips_too_fresh(tmp_path):
+    live, arch = tmp_path / "live", tmp_path / "arch"
+    _bin(live, "9_9_9_9.bin", age_seconds=0.0)  # written "now"
+    assert sync_manifests_to_archive(live, arch, settle_seconds=10.0) == 0
+
+
+def test_tolerates_unreadable_file(tmp_path, monkeypatch):
+    live, arch = tmp_path / "live", tmp_path / "arch"
+    _bin(live, "1_1_2_3.bin")
+    _bin(live, "4_4_5_6.bin")
+    real = mod.shutil.copy2
+    def flaky(src, dst, *a, **k):
+        if Path(src).name == "1_1_2_3.bin":
+            raise OSError("boom")
+        return real(src, dst, *a, **k)
+    monkeypatch.setattr(mod.shutil, "copy2", flaky)
+    assert sync_manifests_to_archive(live, arch) == 1  # the good one still copied
+
+
+def test_no_op_when_live_absent(tmp_path):
+    assert sync_manifests_to_archive(tmp_path / "nope", tmp_path / "arch") == 0
+
+
+def test_never_deletes_archive(tmp_path):
+    live, arch = tmp_path / "live", tmp_path / "arch"
+    keep = _bin(arch, "stale_only_in_archive.bin")
+    _bin(live, "1_1_2_3.bin")
+    sync_manifests_to_archive(live, arch)
+    assert keep.is_file()
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python -m pytest tests/agent/test_manifest_archive.py -q`
+Expected: FAIL (`ModuleNotFoundError: orchestrator.agent.manifest_archive`).
+
+- [ ] **Step 3: Implement**
+
+Create `src/orchestrator/agent/manifest_archive.py`:
+
+```python
+"""Durable manifest archive — copy SteamPrefill's transient .bin manifests into a
+permanent, append-only store so validate can cover the whole prefilled library.
+
+SteamPrefill only writes a manifest when an app has new content (and treats saved
+manifests as temporary), so its live cache covers a shrinking subset of the
+prefilled library. We snapshot every manifest we see into the archive; validate
+reads the union (see manifest_locator). STDLIB ONLY — this module must not import
+orchestrator.api / orchestrator.db (agent import-isolation guard,
+tests/agent/test_import_isolation.py)."""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import time
+from pathlib import Path
+
+import structlog
+
+_log = structlog.get_logger(__name__)
+
+
+def sync_manifests_to_archive(
+    live_root: Path, archive_root: Path, *, settle_seconds: float = 10.0
+) -> int:
+    """Copy .bin files present in live/v1 but not archive/v1 (append-only).
+
+    Preserves mtime (shutil.copy2), skips files written within ``settle_seconds``
+    (may be mid-write — picked up next cycle), never deletes from the archive, and
+    isolates per-file errors. Returns the number copied. A missing live dir or an
+    unwritable archive is a no-op returning 0."""
+    live_v1 = live_root / "v1"
+    if not live_v1.is_dir():
+        return 0
+    archive_v1 = archive_root / "v1"
+    try:
+        archive_v1.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        _log.warning(
+            "manifest_archive.mkdir_failed",
+            archive=str(archive_v1),
+            reason=f"{type(e).__name__}: {e}"[:200],
+        )
+        return 0
+    existing = {p.name for p in archive_v1.glob("*.bin")}
+    now = time.time()
+    copied = 0
+    for src in live_v1.glob("*.bin"):
+        if src.name in existing:
+            continue
+        try:
+            if now - src.stat().st_mtime < settle_seconds:
+                continue
+            shutil.copy2(src, archive_v1 / src.name)
+            copied += 1
+        except OSError as e:
+            _log.warning(
+                "manifest_archive.copy_failed",
+                bin=src.name,
+                reason=f"{type(e).__name__}: {e}"[:200],
+            )
+            continue
+    if copied:
+        _log.info("manifest_archive.synced", copied=copied, archive=str(archive_v1))
+    return copied
+
+
+async def manifest_archive_sync_loop(
+    live_root: Path,
+    archive_root: Path,
+    interval_sec: int,
+    *,
+    settle_seconds: float = 10.0,
+) -> None:
+    """Run sync once immediately, then every ``interval_sec`` seconds, forever.
+
+    The sync runs in a worker thread so the event loop is never blocked. Per-cycle
+    errors are logged and swallowed (never kill the loop); CancelledError on
+    shutdown propagates so the lifespan teardown can await the cancel."""
+    while True:
+        try:
+            await asyncio.to_thread(
+                sync_manifests_to_archive,
+                live_root,
+                archive_root,
+                settle_seconds=settle_seconds,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # never let a bad cycle kill the loop
+            _log.warning(
+                "manifest_archive.loop_error", reason=f"{type(e).__name__}: {e}"[:200]
+            )
+        await asyncio.sleep(interval_sec)
+```
+
+- [ ] **Step 4: Run to verify pass + import-isolation still green**
+
+Run: `.venv/bin/python -m pytest tests/agent/test_manifest_archive.py tests/agent/test_import_isolation.py -q`
+Expected: PASS.
+
+---
+
+## Task 4: wire the periodic sync into the agent lifespan
+
+**Files:**
+- Modify: `src/orchestrator/agent/app.py`
+- Test: `tests/agent/test_app_lifespan.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/agent/test_app_lifespan.py` (match the file's existing settings-construction helper/fixture; if it builds `Settings(...)` inline, mirror that):
+
+```python
+import asyncio
+import contextlib
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+import orchestrator.agent.manifest_archive as marc
+from orchestrator.agent.app import create_agent_app
+from orchestrator.core.settings import Settings
+
+
+def test_sync_task_wired_when_enabled():
+    app = create_agent_app(settings=Settings(manifest_archive_sync_interval_sec=1800))
+    with TestClient(app):
+        assert len(app.state.agent_bg_tasks) == 1  # the sync loop task
+
+
+def test_sync_task_absent_when_disabled():
+    app = create_agent_app(settings=Settings(manifest_archive_sync_interval_sec=0))
+    with TestClient(app):
+        assert len(app.state.agent_bg_tasks) == 0
+
+
+async def test_loop_runs_immediately(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        marc, "sync_manifests_to_archive", lambda *a, **k: calls.append(1) or 0
+    )
+    task = asyncio.create_task(
+        marc.manifest_archive_sync_loop(Path("/live"), Path("/arch"), 3600)
+    )
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+    assert calls  # ran once immediately, before the first sleep
+```
+
+(`test_loop_runs_immediately` is async — the suite already runs under `pytest-asyncio`; add the module/function marker the file uses, e.g. `pytestmark = pytest.mark.asyncio`, if not auto.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python -m pytest tests/agent/test_app_lifespan.py -k "sync_task or loop_runs" -q`
+Expected: FAIL (`assert len(...) == 1` → 0; the loop import/behavior not wired).
+
+- [ ] **Step 3: Implement the wiring**
+
+In `src/orchestrator/agent/app.py`, add imports near the top:
+
+```python
+from pathlib import Path
+
+from orchestrator.agent.manifest_archive import manifest_archive_sync_loop
+```
+
+Inside `_lifespan`, after the `prefill_driver` setup block and **before** `try:`/`yield`, add:
+
+```python
+        interval = settings.manifest_archive_sync_interval_sec
+        if interval > 0:
+            sync_task = asyncio.create_task(
+                manifest_archive_sync_loop(
+                    Path(settings.steam_manifest_cache_dir),
+                    Path(settings.steam_manifest_archive_dir),
+                    interval,
+                )
+            )
+            app.state.agent_bg_tasks.add(sync_task)
+            sync_task.add_done_callback(app.state.agent_bg_tasks.discard)
+```
+
+(`asyncio` is already imported. The existing teardown — cancel `agent_bg_tasks`, gather — already cancels this task on shutdown.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/python -m pytest tests/agent/test_app_lifespan.py -q`
+Expected: PASS.
+
+---
+
+## Task 5: sweep `full` mode
+
+**Files:**
+- Modify: `src/orchestrator/jobs/handlers/sweep.py`
+- Test: `tests/jobs/handlers/test_sweep.py` (match existing sweep test location)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the sweep test module (mirror its existing fake-`Deps`/fake-`pool` style — these assert which SQL `read_all` receives):
+
+```python
+async def test_full_payload_selects_all_steam(monkeypatch):
+    captured = {}
+    deps = _make_deps(read_all_capture=captured)  # existing helper; see file
+    monkeypatch.setattr(sweep_mod, "validator_self_test", _async_true)
+    await sweep_mod.sweep_handler({"id": 1, "payload": '{"full": true}'}, deps)
+    assert captured["sql"] == sweep_mod._CANDIDATE_SQL_FULL
+    assert "status IN" not in captured["sql"]
+
+
+async def test_default_payload_keeps_status_gated(monkeypatch):
+    captured = {}
+    deps = _make_deps(read_all_capture=captured)
+    monkeypatch.setattr(sweep_mod, "validator_self_test", _async_true)
+    await sweep_mod.sweep_handler({"id": 1, "payload": None}, deps)
+    assert captured["sql"] == sweep_mod._CANDIDATE_SQL
+    assert "status IN ('up_to_date','validation_failed')" in captured["sql"]
+
+
+async def test_malformed_payload_falls_back_to_gated(monkeypatch):
+    captured = {}
+    deps = _make_deps(read_all_capture=captured)
+    monkeypatch.setattr(sweep_mod, "validator_self_test", _async_true)
+    await sweep_mod.sweep_handler({"id": 1, "payload": "not json"}, deps)
+    assert captured["sql"] == sweep_mod._CANDIDATE_SQL
+```
+
+If the existing sweep tests don't already provide a capturing fake `Deps`/pool, add a minimal one in the test file: a fake pool whose `read_all(sql, *a)` records `captured["sql"] = sql` and returns `[]`, an `agent_client` that is not None, and patch `validator_self_test` to an async `True`. (`_CANDIDATE_SQL` already exists; add `_CANDIDATE_SQL_FULL` in impl.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python -m pytest tests/jobs/handlers/test_sweep.py -k "payload" -q`
+Expected: FAIL (`AttributeError: module … has no attribute '_CANDIDATE_SQL_FULL'`).
+
+- [ ] **Step 3: Implement**
+
+In `src/orchestrator/jobs/handlers/sweep.py`: add `import json` near the top; add the full SQL next to `_CANDIDATE_SQL`:
+
+```python
+_CANDIDATE_SQL_FULL = "SELECT id, status FROM games WHERE platform='steam' ORDER BY id"
+```
+
+In `sweep_handler`, after the `validator_self_test` gate and before `rows = await deps.pool.read_all(...)`, replace the read with:
+
+```python
+    try:
+        full = bool(json.loads(job.get("payload") or "{}").get("full", False))
+    except (json.JSONDecodeError, TypeError, AttributeError):
+        full = False
+    candidate_sql = _CANDIDATE_SQL_FULL if full else _CANDIDATE_SQL
+    rows = await deps.pool.read_all(candidate_sql)
+    _log.info("sweep.started", job_id=job_id, candidates=len(rows), full=full)
+```
+
+(Remove the old `rows = …` + `sweep.started` log lines being replaced. The semaphore, `_one`, gather, and completion log are unchanged. A no-manifest game still returns `outcome="error"` from `validate_one_game`, which is excluded from `_STATUS_FOR` — status stays unchanged; this is covered by existing `tests/jobs/handlers/test_validate.py`.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/python -m pytest tests/jobs/handlers/test_sweep.py -q`
+Expected: PASS.
+
+---
+
+## Task 6: enqueue `full` + `POST /api/v1/sweep` trigger
+
+**Files:**
+- Modify: `src/orchestrator/scheduler/jobs.py` (`enqueue_validation_sweep`)
+- Create: `src/orchestrator/api/routers/sweep_trigger.py`
+- Modify: `src/orchestrator/api/main.py` (register router)
+- Test: `tests/scheduler/test_jobs.py` (enqueue), `tests/api/test_sweep_trigger.py` (endpoint)
+
+- [ ] **Step 1: Write the failing tests**
+
+Enqueue test (mirror the existing `enqueue_validation_sweep` test setup with a real test pool):
+
+```python
+async def test_enqueue_sweep_full_writes_payload(pool):
+    n = await enqueue_validation_sweep(pool, full=True, source="api")
+    assert n == 1
+    row = await pool.read_one("SELECT payload, source FROM jobs WHERE kind='sweep'")
+    assert row["payload"] == '{"full": true}'
+    assert row["source"] == "api"
+
+
+async def test_enqueue_sweep_default_no_payload(pool):
+    await enqueue_validation_sweep(pool)
+    row = await pool.read_one("SELECT payload, source FROM jobs WHERE kind='sweep'")
+    assert row["payload"] is None
+    assert row["source"] == "scheduler"
+```
+
+Endpoint test (mirror `tests/api/test_validate_trigger.py` client/pool fixture):
+
+```python
+def test_sweep_trigger_full(client):  # client = TestClient over a test app+pool
+    r = client.post("/api/v1/sweep", json={"full": True})
+    assert r.status_code == 202
+    body = r.json()
+    assert body["full"] is True and isinstance(body["job_id"], int)
+
+
+def test_sweep_trigger_default_false(client):
+    r = client.post("/api/v1/sweep")
+    assert r.status_code == 202
+    assert r.json()["full"] is False
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python -m pytest tests/scheduler/test_jobs.py -k sweep_full tests/api/test_sweep_trigger.py -q`
+Expected: FAIL (`TypeError: enqueue_validation_sweep() got an unexpected keyword 'full'`; `404` on `/api/v1/sweep`).
+
+- [ ] **Step 3a: Implement enqueue**
+
+Replace `enqueue_validation_sweep` in `src/orchestrator/scheduler/jobs.py`:
+
+```python
+async def enqueue_validation_sweep(
+    pool: Pool, *, full: bool = False, source: str = "scheduler"
+) -> int:
+    """Insert a `sweep` job row if none is queued/running (F13).
+
+    ``full=True`` validates EVERY steam game (the validate-all backfill), carried
+    on the job payload `{"full": true}`; the weekly cron uses the default
+    (status-gated) sweep. Mirrors `enqueue_library_sync`: at most one in-flight
+    sweep, DB-enforced by `idx_jobs_sweep_inflight` via `ON CONFLICT DO NOTHING`.
+    Returns the rowcount (1 queued / 0 deduped-or-failed). Never raises."""
+    payload = '{"full": true}' if full else None
+    try:
+        inserted = await pool.execute_write(
+            "INSERT INTO jobs (kind, state, source, payload) "
+            "VALUES ('sweep', 'queued', ?, ?) ON CONFLICT DO NOTHING",
+            (source, payload),
+        )
+        if inserted:
+            _log.info("scheduler.sweep.queued", full=full, source=source)
+        else:
+            _log.info("scheduler.sweep.dedup_skip")
+        return inserted
+    except PoolError as e:
+        _log.error("scheduler.sweep.db_error", reason=str(e)[:200])
+        return 0
+    except Exception as e:
+        _log.error(
+            "scheduler.sweep.unexpected_error",
+            error=type(e).__name__,
+            reason=str(e)[:200],
+        )
+        return 0
+```
+
+(The APScheduler callback still calls `enqueue_validation_sweep(pool)` — defaults give the prior behavior, now with an explicit `source='scheduler'` and `payload=NULL`.)
+
+- [ ] **Step 3b: Implement the endpoint**
+
+Create `src/orchestrator/api/routers/sweep_trigger.py`:
+
+```python
+"""POST /api/v1/sweep — manually enqueue a validation sweep (F13).
+
+`{"full": true}` runs the validate-all backfill over EVERY steam game (used after
+seeding the durable manifest archive); the default re-validates only the cached
+library, same as the weekly cron. Reuses the sweep in-flight dedup."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict
+
+from orchestrator.api.dependencies import get_pool_dep
+from orchestrator.db.pool import PoolError
+from orchestrator.scheduler.jobs import enqueue_validation_sweep
+
+if TYPE_CHECKING:
+    from orchestrator.db.pool import Pool
+
+_log = structlog.get_logger(__name__)
+router = APIRouter(prefix="/api/v1", tags=["sweep"])
+
+
+class SweepTriggerRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    full: bool = False
+
+
+@router.post(
+    "/sweep",
+    responses={
+        202: {"description": "Sweep queued (or existing in-flight sweep returned)"},
+        401: {"description": "Missing/invalid bearer"},
+        503: {"description": "Database unavailable"},
+    },
+)
+async def trigger_sweep(
+    body: SweepTriggerRequest | None = None,
+    pool: Pool = Depends(get_pool_dep),  # noqa: B008
+) -> JSONResponse:
+    full = bool(body.full) if body is not None else False
+    try:
+        await enqueue_validation_sweep(pool, full=full, source="api")
+        row = await pool.read_one(
+            "SELECT id FROM jobs WHERE kind='sweep' "
+            "AND state IN ('queued','running') ORDER BY id LIMIT 1"
+        )
+        if row is None:
+            return JSONResponse(status_code=503, content={"detail": "database unavailable"})
+        _log.info("sweep_trigger.queued", job_id=int(row["id"]), full=full)
+        return JSONResponse(status_code=202, content={"job_id": int(row["id"]), "full": full})
+    except PoolError as e:
+        _log.error("sweep_trigger.db_unavailable", reason=str(e))
+        return JSONResponse(status_code=503, content={"detail": "database unavailable"})
+```
+
+- [ ] **Step 3c: Register the router** in `src/orchestrator/api/main.py`:
+
+Add the import alongside the others (~line 38):
+
+```python
+from orchestrator.api.routers.sweep_trigger import router as sweep_trigger_router
+```
+
+Add the include alongside the others (after `validate_trigger_router`, ~line 427):
+
+```python
+    app.include_router(sweep_trigger_router)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/python -m pytest tests/scheduler/test_jobs.py tests/api/test_sweep_trigger.py -q`
+Expected: PASS.
+
+---
+
+## Task 7: `orchestrator-cli cache validate-all`
+
+**Files:**
+- Create: `src/orchestrator/cli/commands/cache.py`
+- Modify: `src/orchestrator/cli/main.py` (register `cache` group)
+- Test: `tests/cli/test_cache.py` (mirror existing CLI test pattern, e.g. `tests/cli/test_game.py`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/cli/test_cache.py` (mirror how other CLI tests stub `OrchClient`/`make_client`; example shape):
+
+```python
+from click.testing import CliRunner
+
+from orchestrator.cli.main import cli
+
+
+def test_cache_validate_all_posts_full_sweep(monkeypatch):
+    posted = {}
+
+    class FakeClient:
+        def post(self, path, json=None):
+            posted["path"] = path
+            posted["json"] = json
+            return {"job_id": 42, "full": True}
+
+    monkeypatch.setattr("orchestrator.cli.commands.cache.make_client", lambda ctx: FakeClient())
+    result = CliRunner().invoke(cli, ["cache", "validate-all"])
+    assert result.exit_code == 0
+    assert posted["path"] == "/api/v1/sweep"
+    assert posted["json"] == {"full": True}
+    assert "42" in result.output
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python -m pytest tests/cli/test_cache.py -q`
+Expected: FAIL (`No such command 'cache'`).
+
+- [ ] **Step 3: Implement**
+
+Create `src/orchestrator/cli/commands/cache.py`:
+
+```python
+"""``cache`` subcommands — cache-maintenance operations (F11)."""
+
+from __future__ import annotations
+
+import click
+
+from orchestrator.cli import output
+from orchestrator.cli.base import handles_api_errors, make_client
+
+
+@click.group()
+def cache() -> None:
+    """Cache-maintenance operations."""
+
+
+@cache.command("validate-all")
+@click.pass_context
+@handles_api_errors
+def cache_validate_all(ctx: click.Context) -> None:
+    """Enqueue a full validation sweep over EVERY steam game (backfill).
+
+    Use after seeding the durable manifest archive so genuinely-cached games are
+    re-checked and flip to up_to_date."""
+    client = make_client(ctx)
+    resp = client.post("/api/v1/sweep", json={"full": True})
+    output.success(f"queued full validation sweep (job_id={resp['job_id']}).")
+```
+
+Register in `src/orchestrator/cli/main.py`: add `cache` to the import line and `cli.add_command(cache.cache)`:
+
+```python
+from orchestrator.cli.commands import auth, cache, config, db, game, jobs, library, status
+```
+```python
+cli.add_command(cache.cache)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/python -m pytest tests/cli/test_cache.py -q`
+Expected: PASS.
+
+---
+
+## Task 8: Full verification + single commit (controller)
+
+- [ ] **Step 1: Format + lint + type-check**
+
+```bash
+.venv/bin/ruff format src tests
+.venv/bin/ruff check src tests
+.venv/bin/mypy src/orchestrator
+```
+Expected: ruff clean; mypy clean (watch for bare-dict returns needing `dict[str, Any]`; no `assert` in `src`).
+
+- [ ] **Step 2: Full suite**
+
+Run: `.venv/bin/python -m pytest -q --ignore=tests/scripts`
+Expected: all pass except the known `tests/test_licenses.py` (pip-licenses) failure.
+
+- [ ] **Step 3: enforce-evaluate + commit (controller)**
+
+Present the implementation evaluation, run `scripts/mark-evaluated.sh`, then **present commit-structure options A/B/C and wait** before the single `feat` commit. Karl opens/merges the PR.
+
+Suggested message:
+```
+feat(steam): durable manifest archive + validate-all backfill
+
+Agent copies SteamPrefill's transient .bin manifests into an append-only
+archive (validate reads live∪archive, newest-per-depot); a periodic agent
+task keeps it current. Sweep gains a `full` mode (jobs.payload) that
+validates every steam game, triggered by POST /api/v1/sweep and
+`orchestrator-cli cache validate-all`. Fixes the ~747 prefilled apps that
+had no manifest to validate against (see
+docs/superpowers/specs/2026-06-24-durable-manifest-store-design.md).
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+---
+
+## Operator runbook (POST-MERGE — Claude runs on the boxes; not code tasks)
+
+1. **Mount the archive.** Add `-v orchestrator-manifests:/manifest-archive` to `/home/karl/deploy-agent.sh`; recreate the agent. (`ORCH_STEAM_MANIFEST_ARCHIVE_DIR` defaults to `/manifest-archive`.) The named volume survives recreation.
+2. **Seed.** Compute `missing = selectedAppsToPrefill ∖ archived-apps`; run `SteamPrefill prefill --force <batch>` for those app_ids in throttled off-hours batches (LAN re-read → HITs, no WAN), not overlapping the root cron. The background sync archives each batch's manifests. Repeat until `missing` is empty.
+3. **Backfill.** `orchestrator-cli cache validate-all` once (consider a lower `ORCH_SWEEP_BATCH_SIZE` for this run given NAS load). Genuinely-cached → `up_to_date`, partial/missing → `validation_failed`, no-manifest → unchanged. This also corrects the wrongly-`not_downloaded` rows.
+
+---
+
+## Self-Review
+
+**Spec coverage:** A (archive + union read) → Tasks 1,2. B (sync + periodic) → Tasks 3,4. C (full sweep + trigger) → Tasks 5,6,7. Settings → Task 1. Deploy/seed/backfill → operator runbook. Import-isolation preserved → Task 3 (stdlib-only) verified in Task 3 Step 4. All spec sections map to a task.
+
+**Placeholder scan:** none — every code step has full code; test steps have full test bodies.
+
+**Type consistency:** `cache_roots: list[Path]` used identically in Tasks 2 (definition) and the Task 2 caller edit; `sync_manifests_to_archive(live_root, archive_root, *, settle_seconds)` and `manifest_archive_sync_loop(live_root, archive_root, interval_sec, *, settle_seconds)` consistent across Tasks 3,4; `enqueue_validation_sweep(pool, *, full, source)` consistent across Tasks 6 (def) and the sweep_trigger caller; `_CANDIDATE_SQL_FULL` consistent across Tasks 5 (def) and its test.

--- a/docs/superpowers/specs/2026-06-24-durable-manifest-store-design.md
+++ b/docs/superpowers/specs/2026-06-24-durable-manifest-store-design.md
@@ -1,0 +1,220 @@
+# Durable Steam Manifest Store + Validate-All Backfill — Design
+
+**Date:** 2026-06-24
+**Status:** Approved (design)
+**Re-arch follow-up to:** ③ steam worker deletion ([[project_steam_worker_deletion]]), ④ LXC move ([[project_lxc_move]])
+**Root-cause memo:** [[project_validation_manifest_gap]]
+
+## Problem (proven live 2026-06-24)
+
+The data-plane agent validates a Steam game by reading that app's manifest (chunk
+list) from SteamPrefill's `.bin` cache only:
+`POST /v1/steam/validate` → `locate_manifest_bins(app_id, cache_root=/steamprefill-cache)`
+→ `/steamprefill-cache/v1/{app}_{app}_{depot}_{gid}.bin`. If no `.bin` exists it
+returns `outcome="error", error="no_manifest_in_cache"`, and the control plane
+deliberately leaves the game's status unchanged (`error` is excluded from
+`_STATUS_FOR` in `jobs/handlers/validate.py`).
+
+Live facts on the NAS (192.168.1.40):
+
+- Karl's root cron (`/SteamPrefill/prefill_cronjob.sh`) prefills **1077 selected
+  apps** (`selectedAppsToPrefill.json`); SteamPrefill has downloaded **2248
+  depots** (`successfullyDownloadedDepots.json`) ≈ **13 TB** on the NFS lancache
+  (`192.168.1.30:/volume1/cache` → `/lancache/lancache/cache` → agent
+  `/data/cache`; real chunks at `/data/cache/cache/H[-2:]/H[-4:-2]/H`).
+- The agent's manifest cache (`/root/.cache/SteamPrefill/v1`, mounted RO at
+  `/steamprefill-cache/v1`) holds manifests for only **330 distinct apps**.
+- Cause: SteamPrefill only *writes* a depot manifest `.bin` when it actually
+  downloads that depot's content. An app that is already up to date is skipped
+  (it compares manifest GIDs from cheap product-info, never fetching the full
+  manifest), so its `.bin` is never (re)written. SteamPrefill v3.4.2 has **no
+  manifest-only mode**; `prefill -f|--force` ("always run, overrides only-if-newer")
+  is the only lever to regenerate a manifest, and it re-requests the app's chunks.
+- Live proof: app `105600` (has manifest) → `partial 1670/15820`; app `1517970`
+  (selected, no manifest) → `error / no_manifest_in_cache`.
+
+Net: ~747 of Karl's selected/prefilled apps are **structurally unvalidatable** —
+their chunks are on disk but the orchestrator can't get a manifest to check them.
+The F13 sweep only re-checks `status IN ('up_to_date','validation_failed')`, so
+these games (sitting at `unknown`/`not_downloaded`) are never revisited.
+
+## Goal
+
+Let the orchestrator validate the **entire** prefilled Steam library — durably —
+**without** adding an independent Steam manifest fetcher (i.e. keep the
+SteamPrefill-only architecture from re-arch ③; do not revive SteamKit/ValvePython
+or add DepotDownloader).
+
+## Non-goals
+
+- Epic. There is no disk-stat validator for Epic at all (validate route 400s for
+  non-steam; sweep is steam-only). Epic is **deferred** to a separate feature.
+- Pre-reverting the 2156 wrongly-`not_downloaded` rows. The backfill pass
+  (Component C) corrects them in one shot; no separate revert.
+- Pruning owned-but-not-selected clutter rows from `games`. Out of scope.
+
+## Architecture
+
+One feature, two code halves (agent + control plane) plus an operator runbook.
+
+### Component A — durable manifest archive + union read (agent)
+
+A new permanent docker volume `orchestrator-manifests` mounted **rw** at
+`/manifest-archive`, mirroring SteamPrefill's layout
+(`/manifest-archive/v1/{app}_{app}_{depot}_{gid}.bin`).
+
+New setting `steam_manifest_archive_dir: Path = Path("/manifest-archive")`
+(`src/orchestrator/core/settings.py`). The archive is treated as **append-only**
+and is never touched by SteamPrefill's `clear-temp`/pruning.
+
+`src/orchestrator/agent/manifest_locator.py` changes so both functions read the
+**union** of `[live cache, archive]`:
+
+- `locate_manifest_bins(app_id, *, cache_roots: list[Path]) -> list[Path]` —
+  glob `{app}_{app}_*.bin` under each root's `v1/`, keep the **newest `.bin`
+  per depot by mtime across all roots**.
+- `list_prefilled_app_ids(*, cache_roots: list[Path]) -> list[int]` — distinct
+  union of app_ids across all roots' `v1/*.bin`.
+
+Each root is independently guarded by the existing `if not v1.is_dir(): continue`
+check, so an **absent/unmounted archive contributes nothing → byte-identical to
+today** (the archive dir's mere existence is the on/off signal; no separate flag).
+
+The two callers in `src/orchestrator/agent/routers/steam.py`
+(`steam_validate`, `prefilled_apps`) pass
+`cache_roots=[settings.steam_manifest_cache_dir, settings.steam_manifest_archive_dir]`.
+
+**Why union, newest-per-depot:** it fixes version drift for free. When an app
+updates, SteamPrefill writes a newer-GID `.bin` to the *live* cache (newer mtime
+→ wins over the archived old one); stable apps live only in the archive and are
+still found. The archive copies preserve mtime (see Component B) so this ordering
+holds.
+
+### Component B — archive sync (agent)
+
+`src/orchestrator/agent/manifest_archive.py` (new):
+`sync_manifests_to_archive(live_root: Path, archive_root: Path, *, settle_seconds: float) -> int`
+
+- Copy any `.bin` present under `live_root/v1` but **not** under `archive_root/v1`
+  (compared by filename), using `shutil.copy2` to **preserve mtime**.
+- **Append-only:** never deletes from the archive.
+- **Settle guard:** skip files whose mtime is within `settle_seconds` of now
+  (default 10s) so a half-written manifest is never copied (it is picked up on a
+  later cycle once settled).
+- Fault-isolated: per-file `try/except (OSError)` → skip + log; a missing or
+  unwritable archive dir → log once + return 0 (never crashes the agent).
+- Returns the count copied (for logging/metrics).
+
+Runs as a **periodic agent background task** (new setting
+`manifest_archive_sync_interval_sec: int = 1800`, i.e. every 30 min), wired into
+the agent lifespan alongside the existing `agent_bg_tasks` (see
+`src/orchestrator/agent/app.py`), and also once at startup. This is what pins the
+manifests Karl's **root cron** writes — permanently, before any future
+`clear-temp` can drop them. Interval `0` disables it.
+
+### Component C — validate-all backfill (control plane)
+
+Extend the existing F13 sweep with a `full` mode carried on the job's `payload`
+(the `jobs.payload` TEXT/JSON column already exists; **no migration**):
+
+- `src/orchestrator/jobs/handlers/sweep.py`: parse
+  `full = json.loads(job.get("payload") or "{}").get("full", False)`. Select with
+  `_CANDIDATE_SQL_FULL = "SELECT id, status FROM games WHERE platform='steam' ORDER BY id"`
+  when `full`, else the existing status-gated `_CANDIDATE_SQL`. Everything else is
+  reused unchanged: the agent-health pre-flight gate, the
+  `asyncio.Semaphore(settings.sweep_batch_size)` bounded concurrency (already
+  present — the NAS is CPU-steal-bound, so this matters), per-game error
+  isolation, `validate_one_game` (records `validation_history`, maps
+  `outcome → games.status`). No-manifest apps return `error` and correctly leave
+  status unchanged.
+- `src/orchestrator/scheduler/jobs.py`:
+  `enqueue_validation_sweep(pool, *, full: bool = False)` sets
+  `payload='{"full": true}'` when `full`. The weekly cron keeps `full=False`.
+  Reuses the `idx_jobs_sweep_inflight` dedup (at most one sweep queued/running),
+  so the one-off backfill is enqueued only when no sweep is in flight.
+- Operator trigger: a new orchestrator-cli command
+  `orchestrator-cli cache validate-all` (under `src/orchestrator/cli/commands/`)
+  that enqueues a `sweep` job with `payload={"full": true}` via the loopback jobs
+  API. (The jobs API/`POST /api/v1/jobs` already accepts `kind="sweep"`; the
+  command passes the `full` payload.)
+
+**Side benefit:** once the archive is seeded, `list_prefilled_app_ids` returns
+~1077 apps, so steam `library_sync` enumeration self-heals toward the real
+selected library instead of 330 (still budget-throttled per run by
+`steam_store_fetch_budget=150`).
+
+## Data flow (steady state, after rollout)
+
+1. Karl's nightly root cron prefills new content → SteamPrefill writes manifests
+   to the live cache.
+2. Agent background sync (every 30 min) copies new manifests → durable archive
+   (mtime preserved, settle-guarded, append-only).
+3. `validate` reads `union(live, archive)`, newest-per-depot → can validate any
+   app once its manifest has been archived.
+4. Weekly F13 sweep re-checks `up_to_date`/`validation_failed` for drift (unchanged).
+
+## Operator runbook (post-merge gates; Claude runs these on the boxes)
+
+**R1 — mount the archive.** Add `-v orchestrator-manifests:/manifest-archive` to
+`/home/karl/deploy-agent.sh`; recreate the agent. Set
+`ORCH_STEAM_MANIFEST_ARCHIVE_DIR=/manifest-archive` (or rely on the default).
+The named volume survives agent recreation.
+
+**R2 — seed.** Compute the missing set = `selectedAppsToPrefill ∖ archived apps`.
+Run `SteamPrefill prefill --force <batch>` for those app_ids in **throttled
+off-hours batches** (LAN re-read from the warm lancache → HITs, no WAN), sized to
+spare the NAS, coordinated so as not to overlap the root cron. The background
+sync archives each batch's manifests as they appear. Repeat until the missing set
+is empty. (Forcing only the missing apps avoids re-reading the already-archived
+330.)
+
+**R3 — backfill.** Once the archive is populated, run
+`orchestrator-cli cache validate-all` once. The full sweep validates every steam
+game: genuinely-cached → `up_to_date`, partial/missing → `validation_failed`,
+no-manifest → unchanged. This corrects the wrongly-`not_downloaded` rows in the
+same pass. Consider a lower `sweep_batch_size` env for this run given NAS load.
+
+## Settings (new)
+
+| Setting | Default | Purpose |
+|---|---|---|
+| `steam_manifest_archive_dir: Path` | `/manifest-archive` | durable manifest store (absent dir ⇒ off / parity) |
+| `manifest_archive_sync_interval_sec: int` | `1800` | agent sync cadence; `0` disables |
+
+## Error handling & rollout
+
+- **Feature-flagged by presence of the archive dir.** Until the volume is mounted,
+  `union` reads live-only and the sync no-ops — byte-identical to today. Safe to
+  merge before any box changes.
+- Sync and backfill are per-item fault-isolated; the archive is append-only and
+  survives container recreation.
+- The agent must still import neither `orchestrator.api.main` nor
+  `orchestrator.db.pool` — the new agent module (`manifest_archive.py`) uses only
+  stdlib (`shutil`, `pathlib`, `time`); the import-isolation guard
+  (`tests/agent/test_import_isolation.py`) must stay green.
+
+## Testing (TDD)
+
+- `manifest_locator` union: newest-per-depot across two roots by mtime; archive-only
+  app found; live-only app found; archive root absent → live-only (parity); both
+  empty → `[]`; `list_prefilled_app_ids` returns the union set.
+- `manifest_archive.sync`: copies new `.bin`; skips ones already in archive;
+  preserves mtime; settle-guard skips too-fresh files; tolerates an unreadable
+  file (skip+log); no-op when archive dir absent/unwritable; never deletes from
+  archive; returns the copied count.
+- `sweep` full mode: payload `{"full": true}` selects all steam games (quote the
+  full SQL); `full=False`/absent payload keeps the status-gated SQL; reuses the
+  semaphore, agent-health gate, and `validate_one_game`; a no-manifest game leaves
+  status unchanged.
+- `enqueue_validation_sweep(full=True)` writes the `{"full": true}` payload;
+  `full=False` writes none and dedups as today.
+- CLI `cache validate-all` enqueues a `sweep` job with the `full` payload.
+- `settings`: new fields default + env override.
+- Agent import-isolation guard still passes.
+
+## Scope
+
+Ships as **1 PR** (`feat/durable-manifest-store`): the agent half (A + B + the
+two `manifest_locator` call-site updates) and the control-plane half (C) are
+small and cohesive. The operator runbook (R1–R3) is executed post-merge and
+monitored — not code.

--- a/src/orchestrator/agent/app.py
+++ b/src/orchestrator/agent/app.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import structlog
 from fastapi import FastAPI
 
 from orchestrator.agent.jobs import AgentJobStore
+from orchestrator.agent.manifest_archive import manifest_archive_sync_loop
 from orchestrator.agent.routers import health, pull, stat, steam
 from orchestrator.api.middleware import BearerAuthMiddleware, SourceAllowlistMiddleware
 from orchestrator.core.net import detect_non_loopback_bind
@@ -61,6 +63,17 @@ def create_agent_app(*, settings: Settings | None = None) -> FastAPI:
                 binary=settings.steam_prefill_binary,
                 config_dir=settings.steam_prefill_config_dir,
             )
+        interval = settings.manifest_archive_sync_interval_sec
+        if interval > 0:
+            sync_task = asyncio.create_task(
+                manifest_archive_sync_loop(
+                    Path(settings.steam_manifest_cache_dir),
+                    Path(settings.steam_manifest_archive_dir),
+                    interval,
+                )
+            )
+            app.state.agent_bg_tasks.add(sync_task)
+            sync_task.add_done_callback(app.state.agent_bg_tasks.discard)
         try:
             yield
         finally:

--- a/src/orchestrator/agent/manifest_archive.py
+++ b/src/orchestrator/agent/manifest_archive.py
@@ -1,0 +1,95 @@
+"""Durable manifest archive — copy SteamPrefill's transient .bin manifests into a
+permanent, append-only store so validate can cover the whole prefilled library.
+
+SteamPrefill only writes a manifest when an app has new content (and treats saved
+manifests as temporary), so its live cache covers a shrinking subset of the
+prefilled library. We snapshot every manifest we see into the archive; validate
+reads the union (see manifest_locator). STDLIB ONLY — this module must not import
+orchestrator.api / orchestrator.db (agent import-isolation guard,
+tests/agent/test_import_isolation.py)."""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import time
+from typing import TYPE_CHECKING
+
+import structlog
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_log = structlog.get_logger(__name__)
+
+
+def sync_manifests_to_archive(
+    live_root: Path, archive_root: Path, *, settle_seconds: float = 10.0
+) -> int:
+    """Copy .bin files present in live/v1 but not archive/v1 (append-only).
+
+    Preserves mtime (shutil.copy2), skips files written within ``settle_seconds``
+    (may be mid-write — picked up next cycle), never deletes from the archive, and
+    isolates per-file errors. Returns the number copied. A missing live dir or an
+    unwritable archive is a no-op returning 0."""
+    live_v1 = live_root / "v1"
+    if not live_v1.is_dir():
+        return 0
+    archive_v1 = archive_root / "v1"
+    try:
+        archive_v1.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        _log.warning(
+            "manifest_archive.mkdir_failed",
+            archive=str(archive_v1),
+            reason=f"{type(e).__name__}: {e}"[:200],
+        )
+        return 0
+    existing = {p.name for p in archive_v1.glob("*.bin")}
+    now = time.time()
+    copied = 0
+    for src in live_v1.glob("*.bin"):
+        if src.name in existing:
+            continue
+        try:
+            if now - src.stat().st_mtime < settle_seconds:
+                continue
+            shutil.copy2(src, archive_v1 / src.name)
+            copied += 1
+        except OSError as e:
+            _log.warning(
+                "manifest_archive.copy_failed",
+                bin=src.name,
+                reason=f"{type(e).__name__}: {e}"[:200],
+            )
+            continue
+    if copied:
+        _log.info("manifest_archive.synced", copied=copied, archive=str(archive_v1))
+    return copied
+
+
+async def manifest_archive_sync_loop(
+    live_root: Path,
+    archive_root: Path,
+    interval_sec: int,
+    *,
+    settle_seconds: float = 10.0,
+) -> None:
+    """Run sync once immediately, then every ``interval_sec`` seconds, forever.
+
+    The sync runs in a worker thread so the event loop is never blocked. Per-cycle
+    errors are logged and swallowed (never kill the loop); CancelledError on
+    shutdown propagates so the lifespan teardown can await the cancel."""
+    while True:
+        try:
+            await asyncio.to_thread(
+                sync_manifests_to_archive,
+                live_root,
+                archive_root,
+                settle_seconds=settle_seconds,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # never let a bad cycle kill the loop
+            _log.warning("manifest_archive.loop_error", reason=f"{type(e).__name__}: {e}"[:200])
+        await asyncio.sleep(interval_sec)

--- a/src/orchestrator/agent/manifest_locator.py
+++ b/src/orchestrator/agent/manifest_locator.py
@@ -19,36 +19,37 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-def list_prefilled_app_ids(*, cache_root: Path) -> list[int]:
-    """Distinct app_ids that have a cached manifest .bin (sorted ascending).
-
-    The .bin filename is {app}_{app}_{depot}_{gid}.bin, so the first field is
-    the app_id. These are the prefilled GAMES (real app_ids), unlike
-    successfullyDownloadedDepots.json whose keys are depot_ids.
-    """
-    v1 = cache_root / "v1"
-    if not v1.is_dir():
-        return []
+def list_prefilled_app_ids(*, cache_roots: list[Path]) -> list[int]:
+    """Distinct app_ids with a cached manifest .bin across all roots (sorted)."""
     apps: set[int] = set()
-    for path in v1.glob("*.bin"):
-        first = path.stem.split("_", 1)[0]
-        if first.isdigit():
-            apps.add(int(first))
+    for root in cache_roots:
+        v1 = root / "v1"
+        if not v1.is_dir():
+            continue
+        for path in v1.glob("*.bin"):
+            first = path.stem.split("_", 1)[0]
+            if first.isdigit():
+                apps.add(int(first))
     return sorted(apps)
 
 
-def locate_manifest_bins(app_id: int, *, cache_root: Path) -> list[Path]:
-    """Return the newest manifest .bin per depot for ``app_id`` (empty if none)."""
-    v1 = cache_root / "v1"
-    if not v1.is_dir():
-        return []
+def locate_manifest_bins(app_id: int, *, cache_roots: list[Path]) -> list[Path]:
+    """Newest manifest .bin per depot for ``app_id`` across all roots (empty if none).
+
+    Roots are searched in order; the newest .bin per depot by mtime wins, so a
+    fresher live-cache manifest supersedes an older archived one for the same
+    depot (and stable apps present only in the archive are still found)."""
     newest_per_depot: dict[str, Path] = {}
-    for path in v1.glob(f"{app_id}_{app_id}_*.bin"):
-        parts = path.stem.split("_")
-        if len(parts) != 4:
+    for root in cache_roots:
+        v1 = root / "v1"
+        if not v1.is_dir():
             continue
-        depot = parts[2]
-        current = newest_per_depot.get(depot)
-        if current is None or path.stat().st_mtime > current.stat().st_mtime:
-            newest_per_depot[depot] = path
+        for path in v1.glob(f"{app_id}_{app_id}_*.bin"):
+            parts = path.stem.split("_")
+            if len(parts) != 4:
+                continue
+            depot = parts[2]
+            current = newest_per_depot.get(depot)
+            if current is None or path.stat().st_mtime > current.stat().st_mtime:
+                newest_per_depot[depot] = path
     return list(newest_per_depot.values())

--- a/src/orchestrator/agent/routers/steam.py
+++ b/src/orchestrator/agent/routers/steam.py
@@ -83,8 +83,9 @@ async def auth_status(request: Request) -> dict[str, Any]:
 async def prefilled_apps(request: Request) -> dict[str, list[int]]:
     """Distinct app_ids with a cached manifest (real game app_ids from the .bin
     filenames) — the enumeration source for library_sync."""
-    manifest_cache = Path(request.app.state.settings.steam_manifest_cache_dir)
-    return {"app_ids": list_prefilled_app_ids(cache_root=manifest_cache)}
+    s = request.app.state.settings
+    roots = [Path(s.steam_manifest_cache_dir), Path(s.steam_manifest_archive_dir)]
+    return {"app_ids": list_prefilled_app_ids(cache_roots=roots)}
 
 
 class SteamValidateRequest(BaseModel):
@@ -109,9 +110,9 @@ def _classify(total: int, cached: int) -> str:
 async def steam_validate(body: SteamValidateRequest, request: Request) -> dict[str, Any]:
     settings = request.app.state.settings
     cache_root = Path(settings.lancache_nginx_cache_path)
-    manifest_cache = Path(settings.steam_manifest_cache_dir)
+    roots = [Path(settings.steam_manifest_cache_dir), Path(settings.steam_manifest_archive_dir)]
 
-    bins = locate_manifest_bins(body.app_id, cache_root=manifest_cache)
+    bins = locate_manifest_bins(body.app_id, cache_roots=roots)
     if not bins:
         return {
             "chunks_total": 0,

--- a/src/orchestrator/api/main.py
+++ b/src/orchestrator/api/main.py
@@ -35,6 +35,7 @@ from orchestrator.api.routers.manifests import router as manifests_router
 from orchestrator.api.routers.platforms import router as platforms_router
 from orchestrator.api.routers.prefill_trigger import router as prefill_trigger_router
 from orchestrator.api.routers.status import router as status_router
+from orchestrator.api.routers.sweep_trigger import router as sweep_trigger_router
 from orchestrator.api.routers.sync import router as sync_router
 from orchestrator.api.routers.validate_trigger import router as validate_trigger_router
 from orchestrator.core.logging import configure_logging
@@ -425,6 +426,7 @@ def create_app() -> FastAPI:
     app.include_router(jobs_router)
     app.include_router(manifests_router)
     app.include_router(validate_trigger_router)
+    app.include_router(sweep_trigger_router)
     app.include_router(prefill_trigger_router)
     app.include_router(sync_router)
     app.include_router(epic_sync_router)

--- a/src/orchestrator/api/routers/sweep_trigger.py
+++ b/src/orchestrator/api/routers/sweep_trigger.py
@@ -1,0 +1,77 @@
+"""POST /api/v1/sweep — manually enqueue a validation sweep (F13).
+
+`{"full": true}` runs the validate-all backfill over EVERY steam game (used after
+seeding the durable manifest archive); the default re-validates only the cached
+library, same as the weekly cron. Reuses the sweep in-flight dedup."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import structlog
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict
+
+from orchestrator.api.dependencies import get_pool_dep
+from orchestrator.db.pool import PoolError
+from orchestrator.scheduler.jobs import enqueue_validation_sweep
+
+if TYPE_CHECKING:
+    from orchestrator.db.pool import Pool
+
+_log = structlog.get_logger(__name__)
+router = APIRouter(prefix="/api/v1", tags=["sweep"])
+
+
+class SweepTriggerRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    full: bool = False
+
+
+@router.post(
+    "/sweep",
+    responses={
+        202: {"description": "Sweep queued (or existing in-flight sweep returned)"},
+        401: {"description": "Missing/invalid bearer"},
+        503: {"description": "Database unavailable"},
+    },
+)
+async def trigger_sweep(
+    body: SweepTriggerRequest | None = None,
+    pool: Pool = Depends(get_pool_dep),  # noqa: B008
+) -> JSONResponse:
+    full = bool(body.full) if body is not None else False
+    try:
+        inserted = await enqueue_validation_sweep(pool, full=full, source="api")
+        row = await pool.read_one(
+            "SELECT id, payload FROM jobs WHERE kind='sweep' "
+            "AND state IN ('queued','running') ORDER BY id LIMIT 1"
+        )
+        if row is None:
+            return JSONResponse(status_code=503, content={"detail": "database unavailable"})
+        # Report the ACTUAL in-flight job's mode, not what THIS call requested.
+        # When a non-full sweep is already queued, the ON CONFLICT DO NOTHING
+        # insert is a no-op and the operator's full=true request did NOT take
+        # effect — surface that via the real payload + a `queued` flag so the
+        # CLI can warn (parse robustly; a malformed stored payload must not 500).
+        actual_full: bool = False
+        try:
+            actual_full = bool(json.loads(row["payload"] or "{}").get("full", False))
+        except (json.JSONDecodeError, TypeError, AttributeError):
+            actual_full = False
+        _log.info(
+            "sweep_trigger.queued",
+            job_id=int(row["id"]),
+            requested_full=full,
+            actual_full=actual_full,
+            queued=bool(inserted),
+        )
+        return JSONResponse(
+            status_code=202,
+            content={"job_id": int(row["id"]), "full": actual_full, "queued": bool(inserted)},
+        )
+    except PoolError as e:
+        _log.error("sweep_trigger.db_unavailable", reason=str(e))
+        return JSONResponse(status_code=503, content={"detail": "database unavailable"})

--- a/src/orchestrator/cli/commands/cache.py
+++ b/src/orchestrator/cli/commands/cache.py
@@ -1,0 +1,36 @@
+"""``cache`` subcommands — cache-maintenance operations (F11)."""
+
+from __future__ import annotations
+
+import click
+
+from orchestrator.cli import output
+from orchestrator.cli.base import handles_api_errors, make_client
+
+
+@click.group()
+def cache() -> None:
+    """Cache-maintenance operations."""
+
+
+@cache.command("validate-all")
+@click.pass_context
+@handles_api_errors
+def cache_validate_all(ctx: click.Context) -> None:
+    """Enqueue a full validation sweep over EVERY steam game (backfill).
+
+    Use after seeding the durable manifest archive so genuinely-cached games are
+    re-checked and flip to up_to_date."""
+    client = make_client(ctx)
+    resp = client.post("/api/v1/sweep", json={"full": True})
+    job_id = resp["job_id"]
+    if resp.get("full"):
+        output.success(f"queued full validation sweep (job_id={job_id}).")
+    else:
+        # The full=true request was deduped against an already-in-flight
+        # NON-full sweep — the backfill is NOT running. Warn so the operator
+        # isn't misled into thinking validate-all is underway.
+        output.warn(
+            f"a sweep is already in flight (job_id={job_id}) and it is NOT a full "
+            "backfill — re-run `cache validate-all` after it completes."
+        )

--- a/src/orchestrator/cli/main.py
+++ b/src/orchestrator/cli/main.py
@@ -11,7 +11,7 @@ import os
 
 import click
 
-from orchestrator.cli.commands import auth, config, db, game, jobs, library, status
+from orchestrator.cli.commands import auth, cache, config, db, game, jobs, library, status
 
 _DEFAULT_URL = "http://127.0.0.1:8765"
 
@@ -39,6 +39,7 @@ cli.add_command(game.game)
 cli.add_command(jobs.jobs)
 cli.add_command(db.db)
 cli.add_command(config.config)
+cli.add_command(cache.cache)
 
 
 def main() -> None:

--- a/src/orchestrator/core/settings.py
+++ b/src/orchestrator/core/settings.py
@@ -107,6 +107,16 @@ class Settings(BaseSettings):
     # The agent reads SteamPrefill's manifest cache (mounted read-only from the
     # host's /root/.cache/SteamPrefill) to source chunk SHAs for validate.
     steam_manifest_cache_dir: Path = Path("/steamprefill-cache")
+    # Durable manifest archive (2026-06-24). SteamPrefill only writes a manifest
+    # .bin when an app has NEW content, so its live cache covers a shrinking
+    # subset of the prefilled library. The agent copies every manifest it sees
+    # into this permanent, append-only archive (immune to SteamPrefill
+    # `clear-temp`); validate reads the UNION of the live cache + this archive.
+    # An absent/unmounted dir is a no-op — byte-identical to pre-archive behavior.
+    steam_manifest_archive_dir: Path = Path("/manifest-archive")
+    # Agent sync cadence (seconds) for copying live manifests into the archive.
+    # 0 disables the periodic sync.
+    manifest_archive_sync_interval_sec: int = Field(default=1800, ge=0)
     # How many UNCACHED apps library_sync looks up from the Steam store per run
     # (the store API is rate-limited ~200/5min; the rest fill on later syncs).
     steam_store_fetch_budget: int = Field(default=150, ge=0)

--- a/src/orchestrator/jobs/handlers/sweep.py
+++ b/src/orchestrator/jobs/handlers/sweep.py
@@ -8,6 +8,7 @@ recovery. Pre-flight-skips on validator-unhealthy; per-game errors are isolated.
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import TYPE_CHECKING, Any
 
 import structlog
@@ -26,6 +27,10 @@ _CANDIDATE_SQL = (
     "WHERE platform='steam' AND status IN ('up_to_date','validation_failed') "
     "ORDER BY id"
 )
+
+# `full` mode (validate-all backfill, 2026-06-24): validate EVERY steam game,
+# not just the already-cached subset. Carried on jobs.payload `{"full": true}`.
+_CANDIDATE_SQL_FULL = "SELECT id, status FROM games WHERE platform='steam' ORDER BY id"
 
 
 async def sweep_handler(job: dict[str, Any], deps: Deps) -> None:
@@ -47,8 +52,13 @@ async def sweep_handler(job: dict[str, Any], deps: Deps) -> None:
         _log.info("sweep.skipped", job_id=job_id, reason="validator_unhealthy")
         return
 
-    rows = await deps.pool.read_all(_CANDIDATE_SQL)
-    _log.info("sweep.started", job_id=job_id, candidates=len(rows))
+    try:
+        full = bool(json.loads(job.get("payload") or "{}").get("full", False))
+    except (json.JSONDecodeError, TypeError, AttributeError):
+        full = False
+    candidate_sql = _CANDIDATE_SQL_FULL if full else _CANDIDATE_SQL
+    rows = await deps.pool.read_all(candidate_sql)
+    _log.info("sweep.started", job_id=job_id, candidates=len(rows), full=full)
 
     sem = asyncio.Semaphore(settings.sweep_batch_size)
     counts = {"cached": 0, "partial": 0, "missing": 0, "error": 0}

--- a/src/orchestrator/scheduler/jobs.py
+++ b/src/orchestrator/scheduler/jobs.py
@@ -57,22 +57,28 @@ async def enqueue_library_sync(pool: Pool) -> int:
         return 0
 
 
-async def enqueue_validation_sweep(pool: Pool) -> int:
+async def enqueue_validation_sweep(
+    pool: Pool, *, full: bool = False, source: str = "scheduler"
+) -> int:
     """Insert a `sweep` job row if none is queued/running (F13).
 
-    Mirrors `enqueue_library_sync`: at most one in-flight sweep, DB-enforced by
-    `idx_jobs_sweep_inflight` (migration 0005) via `ON CONFLICT DO NOTHING`.
-    Returns the rowcount (1 queued / 0 deduped-or-failed). Never raises — a
-    failing scheduler tick must not degrade APScheduler. The sweep is not
-    platform-scoped, so `platform` is left NULL.
+    ``full=True`` validates EVERY steam game (the validate-all backfill), carried
+    on the job payload `{"full": true}`; the weekly cron uses the default
+    (status-gated) sweep. Mirrors `enqueue_library_sync`: at most one in-flight
+    sweep, DB-enforced by `idx_jobs_sweep_inflight` (migration 0005) via
+    `ON CONFLICT DO NOTHING`. Returns the rowcount (1 queued / 0 deduped-or-failed).
+    Never raises — a failing scheduler tick must not degrade APScheduler. The
+    sweep is not platform-scoped, so `platform` is left NULL.
     """
+    payload = '{"full": true}' if full else None
     try:
         inserted = await pool.execute_write(
-            "INSERT INTO jobs (kind, state, source) "
-            "VALUES ('sweep', 'queued', 'scheduler') ON CONFLICT DO NOTHING"
+            "INSERT INTO jobs (kind, state, source, payload) "
+            "VALUES ('sweep', 'queued', ?, ?) ON CONFLICT DO NOTHING",
+            (source, payload),
         )
         if inserted:
-            _log.info("scheduler.sweep.queued")
+            _log.info("scheduler.sweep.queued", full=full, source=source)
         else:
             _log.info("scheduler.sweep.dedup_skip")
         return inserted

--- a/tests/agent/test_app_lifespan.py
+++ b/tests/agent/test_app_lifespan.py
@@ -44,3 +44,38 @@ async def test_lifespan_shutdown_tears_down_cache_stat_executor(monkeypatch):
     async with app.router.lifespan_context(app):
         pass
     assert calls["n"] == 1
+
+
+# --- Durable manifest archive: periodic sync task wiring ---
+
+
+async def test_sync_task_wired_when_enabled():
+    app = create_agent_app(
+        settings=Settings(orchestrator_token=TOKEN, manifest_archive_sync_interval_sec=1800)
+    )
+    async with app.router.lifespan_context(app):
+        assert len(app.state.agent_bg_tasks) == 1  # the sync loop task
+
+
+async def test_sync_task_absent_when_disabled():
+    app = create_agent_app(
+        settings=Settings(orchestrator_token=TOKEN, manifest_archive_sync_interval_sec=0)
+    )
+    async with app.router.lifespan_context(app):
+        assert len(app.state.agent_bg_tasks) == 0
+
+
+async def test_loop_runs_immediately(monkeypatch):
+    import contextlib
+    from pathlib import Path
+
+    import orchestrator.agent.manifest_archive as marc
+
+    calls = []
+    monkeypatch.setattr(marc, "sync_manifests_to_archive", lambda *a, **k: calls.append(1) or 0)
+    task = asyncio.create_task(marc.manifest_archive_sync_loop(Path("/live"), Path("/arch"), 3600))
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+    assert calls  # ran once immediately, before the first sleep

--- a/tests/agent/test_manifest_archive.py
+++ b/tests/agent/test_manifest_archive.py
@@ -1,0 +1,75 @@
+"""Tests for the durable manifest archive — append-only sync of SteamPrefill's
+transient .bin manifests into a permanent store."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import orchestrator.agent.manifest_archive as mod
+from orchestrator.agent.manifest_archive import sync_manifests_to_archive
+
+
+def _bin(root: Path, name: str, age_seconds: float = 100.0) -> Path:
+    v1 = root / "v1"
+    v1.mkdir(parents=True, exist_ok=True)
+    p = v1 / name
+    p.write_bytes(b"data")
+    t = time.time() - age_seconds
+    os.utime(p, (t, t))
+    return p
+
+
+def test_copies_new_bin(tmp_path):
+    live, arch = tmp_path / "live", tmp_path / "arch"
+    _bin(live, "440_440_441_1.bin")
+    assert sync_manifests_to_archive(live, arch) == 1
+    assert (arch / "v1" / "440_440_441_1.bin").is_file()
+
+
+def test_skips_already_archived(tmp_path):
+    live, arch = tmp_path / "live", tmp_path / "arch"
+    _bin(live, "440_440_441_1.bin")
+    _bin(arch, "440_440_441_1.bin")
+    assert sync_manifests_to_archive(live, arch) == 0
+
+
+def test_preserves_mtime(tmp_path):
+    live, arch = tmp_path / "live", tmp_path / "arch"
+    src = _bin(live, "1_1_2_3.bin", age_seconds=5000.0)
+    sync_manifests_to_archive(live, arch)
+    assert (arch / "v1" / "1_1_2_3.bin").stat().st_mtime == src.stat().st_mtime
+
+
+def test_settle_guard_skips_too_fresh(tmp_path):
+    live, arch = tmp_path / "live", tmp_path / "arch"
+    _bin(live, "9_9_9_9.bin", age_seconds=0.0)  # written "now"
+    assert sync_manifests_to_archive(live, arch, settle_seconds=10.0) == 0
+
+
+def test_tolerates_unreadable_file(tmp_path, monkeypatch):
+    live, arch = tmp_path / "live", tmp_path / "arch"
+    _bin(live, "1_1_2_3.bin")
+    _bin(live, "4_4_5_6.bin")
+    real = mod.shutil.copy2
+
+    def flaky(src, dst, *a, **k):
+        if Path(src).name == "1_1_2_3.bin":
+            raise OSError("boom")
+        return real(src, dst, *a, **k)
+
+    monkeypatch.setattr(mod.shutil, "copy2", flaky)
+    assert sync_manifests_to_archive(live, arch) == 1  # the good one still copied
+
+
+def test_no_op_when_live_absent(tmp_path):
+    assert sync_manifests_to_archive(tmp_path / "nope", tmp_path / "arch") == 0
+
+
+def test_never_deletes_archive(tmp_path):
+    live, arch = tmp_path / "live", tmp_path / "arch"
+    keep = _bin(arch, "stale_only_in_archive.bin")
+    _bin(live, "1_1_2_3.bin")
+    sync_manifests_to_archive(live, arch)
+    assert keep.is_file()

--- a/tests/agent/test_manifest_locator.py
+++ b/tests/agent/test_manifest_locator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING
 
-from orchestrator.agent.manifest_locator import locate_manifest_bins
+from orchestrator.agent.manifest_locator import list_prefilled_app_ids, locate_manifest_bins
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -26,35 +26,76 @@ def test_locates_newest_bin_per_depot(tmp_path):
     _write(tmp_path, "440_440_441_222.bin", 1000)
     _write(tmp_path, "440_440_441_333.bin", 2000)  # newer for depot 441
     _write(tmp_path, "570_570_5701_999.bin", 1000)  # other app
-    found = sorted(p.name for p in locate_manifest_bins(440, cache_root=tmp_path))
+    found = sorted(p.name for p in locate_manifest_bins(440, cache_roots=[tmp_path]))
     assert found == ["440_440_440_111.bin", "440_440_441_333.bin"]
 
 
 def test_app_with_no_bins_returns_empty(tmp_path):
     _write(tmp_path, "440_440_440_111.bin", 1000)
-    assert locate_manifest_bins(999, cache_root=tmp_path) == []
+    assert locate_manifest_bins(999, cache_roots=[tmp_path]) == []
 
 
 def test_no_cache_dir_returns_empty(tmp_path):
-    assert locate_manifest_bins(440, cache_root=tmp_path / "missing") == []
+    assert locate_manifest_bins(440, cache_roots=[tmp_path / "missing"]) == []
 
 
 def test_single_depot_single_gid(tmp_path):
     _write(tmp_path, "1182900_1182900_1182901_3367036266289852265.bin", 1000)
-    found = locate_manifest_bins(1182900, cache_root=tmp_path)
+    found = locate_manifest_bins(1182900, cache_roots=[tmp_path])
     assert [p.name for p in found] == ["1182900_1182900_1182901_3367036266289852265.bin"]
 
 
 def test_list_prefilled_app_ids(tmp_path):
-    from orchestrator.agent.manifest_locator import list_prefilled_app_ids
-
     _write(tmp_path, "440_440_440_111.bin", 1000)
     _write(tmp_path, "440_440_441_222.bin", 1000)  # same app, diff depot
     _write(tmp_path, "730_730_731_333.bin", 1000)
-    assert list_prefilled_app_ids(cache_root=tmp_path) == [440, 730]
+    assert list_prefilled_app_ids(cache_roots=[tmp_path]) == [440, 730]
 
 
 def test_list_prefilled_app_ids_no_cache(tmp_path):
-    from orchestrator.agent.manifest_locator import list_prefilled_app_ids
+    assert list_prefilled_app_ids(cache_roots=[tmp_path / "missing"]) == []
 
-    assert list_prefilled_app_ids(cache_root=tmp_path / "missing") == []
+
+# --- Union read across multiple cache roots (durable manifest archive) ---
+
+
+def _write_bin(root: Path, app: int, depot: int, gid: int, mtime: float | None = None) -> Path:
+    v1 = root / "v1"
+    v1.mkdir(parents=True, exist_ok=True)
+    p = v1 / f"{app}_{app}_{depot}_{gid}.bin"
+    p.write_bytes(b"x")
+    if mtime is not None:
+        os.utime(p, (mtime, mtime))
+    return p
+
+
+def test_union_live_only(tmp_path):
+    live = tmp_path / "live"
+    _write_bin(live, 440, 441, 111)
+    assert locate_manifest_bins(440, cache_roots=[live, tmp_path / "absent"])
+
+
+def test_union_archive_only(tmp_path):
+    arch = tmp_path / "arch"
+    _write_bin(arch, 730, 731, 222)
+    found = locate_manifest_bins(730, cache_roots=[tmp_path / "absent", arch])
+    assert len(found) == 1
+
+
+def test_union_newest_per_depot_across_roots(tmp_path):
+    live, arch = tmp_path / "live", tmp_path / "arch"
+    _write_bin(arch, 570, 571, 1, mtime=1000.0)  # older, archived
+    newer = _write_bin(live, 570, 571, 2, mtime=2000.0)  # newer, live, same depot
+    found = locate_manifest_bins(570, cache_roots=[live, arch])
+    assert found == [newer]  # newest-per-depot wins regardless of root order
+
+
+def test_union_both_absent_returns_empty(tmp_path):
+    assert locate_manifest_bins(1, cache_roots=[tmp_path / "a", tmp_path / "b"]) == []
+
+
+def test_list_prefilled_app_ids_union(tmp_path):
+    live, arch = tmp_path / "live", tmp_path / "arch"
+    _write_bin(live, 440, 441, 1)
+    _write_bin(arch, 730, 731, 1)
+    assert list_prefilled_app_ids(cache_roots=[live, arch]) == [440, 730]

--- a/tests/api/test_sweep_trigger_router.py
+++ b/tests/api/test_sweep_trigger_router.py
@@ -1,0 +1,137 @@
+"""Tests for POST /api/v1/sweep (validate-all trigger, 2026-06-24)."""
+
+from __future__ import annotations
+
+import pytest
+
+VALID_TOKEN = "a" * 32
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestQueueSweep:
+    async def test_full_queues_and_returns_202(self, client, populated_pool):
+        r = await client.post(
+            "/api/v1/sweep",
+            json={"full": True},
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r.status_code == 202
+        body = r.json()
+        assert body["full"] is True
+        assert isinstance(body["job_id"], int)
+        row = await populated_pool.read_one(
+            "SELECT kind, payload, source, state FROM jobs WHERE id=?",
+            (body["job_id"],),
+        )
+        assert row == {
+            "kind": "sweep",
+            "payload": '{"full": true}',
+            "source": "api",
+            "state": "queued",
+        }
+
+    async def test_default_full_false(self, client, populated_pool):
+        r = await client.post(
+            "/api/v1/sweep",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r.status_code == 202
+        body = r.json()
+        assert body["full"] is False
+        row = await populated_pool.read_one(
+            "SELECT payload FROM jobs WHERE id=?", (body["job_id"],)
+        )
+        assert row["payload"] is None
+
+    async def test_full_after_inflight_default_reports_actual_full(self, client, populated_pool):
+        # A fresh full sweep (nothing in flight) queues and reports full=True.
+        fresh = await client.post(
+            "/api/v1/sweep",
+            json={"full": True},
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert fresh.status_code == 202
+        assert fresh.json()["full"] is True
+        assert fresh.json()["queued"] is True
+
+        # Now simulate the misleading case the other way around: a DEFAULT
+        # (non-full) sweep is already in flight, then the operator POSTs
+        # full=true. The insert is a no-op (ON CONFLICT DO NOTHING), so the
+        # response must reflect the EXISTING non-full job — not the request.
+        await populated_pool.execute_write(
+            "DELETE FROM jobs WHERE kind='sweep' AND state IN ('queued','running')"
+        )
+        default = await client.post(
+            "/api/v1/sweep",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert default.status_code == 202
+        assert default.json()["full"] is False
+        assert default.json()["queued"] is True
+        existing_id = default.json()["job_id"]
+
+        r = await client.post(
+            "/api/v1/sweep",
+            json={"full": True},
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r.status_code == 202
+        body = r.json()
+        assert body["full"] is False
+        assert body["queued"] is False
+        assert body["job_id"] == existing_id
+
+    async def test_dedup_returns_existing_inflight(self, client, populated_pool):
+        r1 = await client.post(
+            "/api/v1/sweep",
+            json={"full": True},
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        r2 = await client.post(
+            "/api/v1/sweep",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r1.status_code == 202
+        assert r2.status_code == 202
+        # One in-flight sweep allowed (idx_jobs_sweep_inflight); both resolve to it.
+        assert r1.json()["job_id"] == r2.json()["job_id"]
+
+
+class TestErrors:
+    async def test_extra_field_rejected(self, client):
+        r = await client.post(
+            "/api/v1/sweep",
+            json={"full": True, "bogus": 1},
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r.status_code == 400
+
+    async def test_missing_bearer_returns_401(self, client):
+        r = await client.post("/api/v1/sweep", json={"full": True})
+        assert r.status_code == 401
+
+
+class TestPoolFailure:
+    async def test_db_failure_returns_503(self, unit_app):
+        from orchestrator.api.dependencies import get_pool_dep
+        from orchestrator.db.pool import PoolError
+
+        class _BrokenPool:
+            async def read_one(self, *_a, **_kw):
+                raise PoolError("simulated outage")
+
+            async def execute_write(self, *_a, **_kw):
+                raise PoolError("simulated outage")
+
+        unit_app.dependency_overrides[get_pool_dep] = lambda: _BrokenPool()
+        import httpx
+
+        transport = httpx.ASGITransport(app=unit_app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as c:
+            r = await c.post(
+                "/api/v1/sweep",
+                json={"full": True},
+                headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+            )
+        assert r.status_code == 503

--- a/tests/cli/test_cmd_cache.py
+++ b/tests/cli/test_cmd_cache.py
@@ -1,0 +1,40 @@
+"""F11 — ``cache`` subcommands (validate-all backfill trigger, 2026-06-24)."""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from orchestrator.cli.main import cli
+
+
+def test_cache_validate_all_posts_full_sweep(monkeypatch):
+    posted = {}
+
+    class FakeClient:
+        def post(self, path, json=None):
+            posted["path"] = path
+            posted["json"] = json
+            return {"job_id": 42, "full": True, "queued": True}
+
+    monkeypatch.setattr("orchestrator.cli.commands.cache.make_client", lambda ctx: FakeClient())
+    result = CliRunner().invoke(cli, ["cache", "validate-all"])
+    assert result.exit_code == 0
+    assert posted["path"] == "/api/v1/sweep"
+    assert posted["json"] == {"full": True}
+    assert "42" in result.output
+    assert "queued full validation sweep" in result.output
+
+
+def test_cache_validate_all_warns_when_not_full(monkeypatch):
+    """full=true deduped against an in-flight NON-full sweep: warn, don't mislead."""
+
+    class FakeClient:
+        def post(self, path, json=None):
+            return {"job_id": 7, "full": False, "queued": False}
+
+    monkeypatch.setattr("orchestrator.cli.commands.cache.make_client", lambda ctx: FakeClient())
+    result = CliRunner().invoke(cli, ["cache", "validate-all"])
+    assert result.exit_code == 0
+    assert "7" in result.output
+    assert "NOT a full backfill" in result.output
+    assert "already in flight" in result.output

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -708,3 +708,17 @@ class TestSteamWorkerDeletionSettings:
     def test_manifest_cache_dir_default(self):
         s = Settings(orchestrator_token="a" * 32)
         assert s.steam_manifest_cache_dir == Path("/steamprefill-cache")
+
+
+class TestManifestArchiveSettings:
+    def test_manifest_archive_defaults(self):
+        s = Settings(orchestrator_token=VALID_TOKEN)
+        assert str(s.steam_manifest_archive_dir) == "/manifest-archive"
+        assert s.manifest_archive_sync_interval_sec == 1800
+
+    def test_manifest_archive_env_override(self, monkeypatch):
+        monkeypatch.setenv("ORCH_STEAM_MANIFEST_ARCHIVE_DIR", "/opt/arch")
+        monkeypatch.setenv("ORCH_MANIFEST_ARCHIVE_SYNC_INTERVAL_SEC", "0")
+        s = Settings(orchestrator_token=VALID_TOKEN)
+        assert str(s.steam_manifest_archive_dir) == "/opt/arch"
+        assert s.manifest_archive_sync_interval_sec == 0

--- a/tests/jobs/test_sweep_handler.py
+++ b/tests/jobs/test_sweep_handler.py
@@ -196,3 +196,54 @@ async def test_sweep_registered():
 
     _register_builtin_handlers()
     assert "sweep" in HANDLERS
+
+
+def _capture_pool(pool, captured):
+    """Wrap pool.read_all to record the candidate SQL the sweep selects with."""
+    real = pool.read_all
+
+    async def _spy(sql, *args):
+        captured["sql"] = sql
+        return await real(sql, *args)
+
+    pool.read_all = _spy
+    return pool
+
+
+async def test_full_payload_selects_all_steam(pool, monkeypatch):
+    """`{"full": true}` payload => the validate-all candidate SQL (every steam
+    game, no status gate)."""
+    import orchestrator.jobs.handlers.sweep as sweep_mod
+
+    _healthy(monkeypatch)
+    captured: dict[str, str] = {}
+    _capture_pool(pool, captured)
+    job = {"id": 1, "kind": "sweep", "payload": '{"full": true}'}
+    await sweep_handler(job, Deps(pool=pool, agent_client=_Agent()))
+    assert captured["sql"] == sweep_mod._CANDIDATE_SQL_FULL
+    assert "status IN" not in captured["sql"]
+
+
+async def test_default_payload_keeps_status_gated(pool, monkeypatch):
+    """A null payload keeps the status-gated weekly-cron candidate SQL."""
+    import orchestrator.jobs.handlers.sweep as sweep_mod
+
+    _healthy(monkeypatch)
+    captured: dict[str, str] = {}
+    _capture_pool(pool, captured)
+    job = {"id": 1, "kind": "sweep", "payload": None}
+    await sweep_handler(job, Deps(pool=pool, agent_client=_Agent()))
+    assert captured["sql"] == sweep_mod._CANDIDATE_SQL
+    assert "status IN ('up_to_date','validation_failed')" in captured["sql"]
+
+
+async def test_malformed_payload_falls_back_to_gated(pool, monkeypatch):
+    """A non-JSON payload must not raise — fall back to the status-gated sweep."""
+    import orchestrator.jobs.handlers.sweep as sweep_mod
+
+    _healthy(monkeypatch)
+    captured: dict[str, str] = {}
+    _capture_pool(pool, captured)
+    job = {"id": 1, "kind": "sweep", "payload": "not json"}
+    await sweep_handler(job, Deps(pool=pool, agent_client=_Agent()))
+    assert captured["sql"] == sweep_mod._CANDIDATE_SQL

--- a/tests/scheduler/test_jobs.py
+++ b/tests/scheduler/test_jobs.py
@@ -145,6 +145,21 @@ class TestEnqueueValidationSweep:
         pool.execute_write = AsyncMock(side_effect=PoolError("simulated"))
         assert await enqueue_validation_sweep(pool) == 0  # never raises
 
+    async def test_enqueue_sweep_full_writes_payload(self, pool):
+        """`full=True` carries `{"full": true}` on jobs.payload; explicit source."""
+        n = await enqueue_validation_sweep(pool, full=True, source="api")
+        assert n == 1
+        row = await pool.read_one("SELECT payload, source FROM jobs WHERE kind='sweep'")
+        assert row["payload"] == '{"full": true}'
+        assert row["source"] == "api"
+
+    async def test_enqueue_sweep_default_no_payload(self, pool):
+        """The default (weekly-cron) sweep has a NULL payload and scheduler source."""
+        await enqueue_validation_sweep(pool)
+        row = await pool.read_one("SELECT payload, source FROM jobs WHERE kind='sweep'")
+        assert row["payload"] is None
+        assert row["source"] == "scheduler"
+
 
 async def _seed_game(
     pool, app_id, *, owned=1, current="42", cached=None, status="up_to_date", platform="steam"


### PR DESCRIPTION
## Why

Investigation (2026-06-24) found the orchestrator could only validate ~330 of your ~1077 prefilled Steam apps. Root cause: validate sources chunk lists **only** from SteamPrefill's `.bin` manifest cache, and SteamPrefill writes a manifest only when an app has *new* content (treating saved manifests as temporary). The other ~747 prefilled apps — part of ~13 TB cached on the NFS lancache — returned `no_manifest_in_cache`, so their status never updated and the F13 sweep (status-gated) never revisited them. Full analysis: `docs/superpowers/specs/2026-06-24-durable-manifest-store-design.md`.

This keeps the SteamPrefill-only architecture (no revived Steam manifest fetcher).

## What

**Agent half**
- **Durable manifest archive** (`steam_manifest_archive_dir`, default `/manifest-archive`): an append-only store the agent copies every manifest `.bin` into, immune to SteamPrefill `clear-temp`. Validate + enumerate now read the **union** of live cache + archive, newest-`.bin`-per-depot by mtime (also fixes manifest version drift).
- **Periodic sync** (`manifest_archive_sync_interval_sec`, default 1800 s; `0` disables): copies new manifests into the archive with an mtime-settle guard (no half-written files), append-only, per-file fault-isolated.
- Stdlib-only module → agent import-isolation guard stays green.

**Control plane**
- F13 sweep gains a **`full` mode** (carried on `jobs.payload`, no migration): validates every steam game vs. the status-gated default. Weekly cron stays status-gated.
- **`POST /api/v1/sweep`** + **`orchestrator-cli cache validate-all`** trigger the one-shot backfill. The endpoint reports the *actual* queued sweep mode + a `queued` flag, and the CLI warns when a non-full sweep is already in flight (a dedup never masquerades as a backfill).

## Safety

Feature-flagged by the archive dir's presence — until `/manifest-archive` is mounted, validate reads live-only and the sync no-ops: **byte-identical to current behavior**. Safe to merge before any box change.

## Testing

- Full suite **1267 passed** (only `tests/test_licenses.py` fails locally — pip-licenses not installed); `mypy` clean (88 files); `ruff format`/`check` clean.
- New coverage: locator union (newest-per-depot/parity/empty), sync (append-only/settle/mtime/fault-isolation/never-delete), lifespan wiring (enabled/disabled/immediate-run), sweep full mode (full/default/malformed payload), enqueue payload+source, endpoint (202/auth-401/extra-forbid/503/dedup-reports-actual-full), CLI (full + warn-on-dedup).
- Built subagent-driven with a spec + code-quality review per half; the review caught the dedup-`full` reporting trap, fixed test-first before this PR.

## Operator runbook (post-merge — I run on the boxes)

1. Add `-v orchestrator-manifests:/manifest-archive` to `deploy-agent.sh`; recreate the agent.
2. Seed: `prefill --force` the apps missing a manifest, in throttled off-hours batches (LAN re-read, no WAN); the sync archives them.
3. `orchestrator-cli cache validate-all` once → genuinely-cached games flip to `up_to_date` (also corrects the earlier wrongly-`not_downloaded` rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)