### PR TITLE
feat(api): latest-validation chunk counts on GET /api/v1/games

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Added — Latest-validation chunk counts on `GET /api/v1/games` (2026-06-28) — 2026-06-28
+
+`GET /api/v1/games` now returns `chunks_cached` and `chunks_total` per game, sourced from the **newest** `validation_history` row (by `started_at`, `id` tie-break) via correlated scalar subqueries — same EXISTS-not-JOIN rationale as `blocked`, served by `idx_vh_game`. Both are `null` for games that have never been validated. This lets a UI render a "Partial · N%" badge for `validation_failed` games (and a cached-fraction for any game) without a second round-trip to `validation_history`. Purely additive to the response model; no migration.
+
 ### Added — Durable Steam manifest store + validate-all backfill (2026-06-24) — 2026-06-24
 
 Lets the orchestrator validate the *entire* prefilled Steam library, not just the subset SteamPrefill currently has a fresh manifest for. SteamPrefill only writes a manifest `.bin` when an app has new content (and treats saved manifests as temporary via `clear-temp`), so its cache covered ~330 of ~1077 prefilled apps; the other ~747 returned `no_manifest_in_cache` and could never be validated though their ~13 TB of chunks were on disk.

--- a/src/orchestrator/api/routers/games.py
+++ b/src/orchestrator/api/routers/games.py
@@ -109,6 +109,11 @@ class GameResponse(BaseModel):
     last_error: str | None
     metadata: dict[str, Any] | None
     blocked: bool
+    # Latest validation_history counts (newest row by started_at) so the UI can
+    # render a "Partial · N%" badge without a second round-trip. Both null when
+    # the game has never been validated.
+    chunks_cached: int | None
+    chunks_total: int | None
 
 
 class GamesMeta(BaseModel):
@@ -191,10 +196,21 @@ async def list_games(
     # F8: `blocked` via a correlated EXISTS subquery (NOT a JOIN) so the
     # allow-list `where_sql`/`order_sql` (bare `games` column names) stay
     # unambiguous — block_list also has platform/app_id columns.
+    # F7/UI: the latest validation_history counts via correlated scalar
+    # subqueries (NOT a JOIN), same rationale as `blocked` above — keeps the
+    # allow-list where_sql/order_sql on bare `games` columns unambiguous.
+    # idx_vh_game(game_id, started_at DESC) serves the ORDER/LIMIT; the `id DESC`
+    # tie-break makes both subqueries pick the SAME row on same-second ties.
     rows_sql = (
         f"SELECT {_GAMES_COLUMNS}, "  # noqa: S608
         "EXISTS(SELECT 1 FROM block_list b "
-        "WHERE b.platform=games.platform AND b.app_id=games.app_id) AS blocked "
+        "WHERE b.platform=games.platform AND b.app_id=games.app_id) AS blocked, "
+        "(SELECT vh.chunks_cached FROM validation_history vh "
+        " WHERE vh.game_id=games.id ORDER BY vh.started_at DESC, vh.id DESC LIMIT 1) "
+        "AS chunks_cached, "
+        "(SELECT vh.chunks_total FROM validation_history vh "
+        " WHERE vh.game_id=games.id ORDER BY vh.started_at DESC, vh.id DESC LIMIT 1) "
+        "AS chunks_total "
         f"FROM games {where_sql} {order_sql} LIMIT ? OFFSET ?"
     ).strip()
     rows_params = [*where_params, pagination.limit, pagination.offset]
@@ -274,6 +290,8 @@ async def list_games(
                     last_error=last_error,
                     metadata=metadata,
                     blocked=bool(row["blocked"]),
+                    chunks_cached=row["chunks_cached"],
+                    chunks_total=row["chunks_total"],
                 )
             )
         except ValidationError as e:

--- a/tests/api/test_games_router.py
+++ b/tests/api/test_games_router.py
@@ -88,6 +88,8 @@ class TestGamesHappyPath:
                 "last_error",
                 "metadata",
                 "blocked",
+                "chunks_cached",
+                "chunks_total",
             }
 
 
@@ -545,6 +547,8 @@ class TestGamesMetadata:
                     "last_error": None,
                     "metadata": {"already-decoded": True},  # non-buffer type
                     "blocked": 0,
+                    "chunks_cached": None,
+                    "chunks_total": None,
                 }
             ]
 
@@ -584,6 +588,8 @@ class TestGamesMetadata:
                     "last_error": None,
                     "metadata": None,
                     "blocked": 0,
+                    "chunks_cached": None,
+                    "chunks_total": None,
                 },
                 {
                     "id": 2,
@@ -600,6 +606,8 @@ class TestGamesMetadata:
                     "last_error": None,
                     "metadata": None,
                     "blocked": 0,
+                    "chunks_cached": None,
+                    "chunks_total": None,
                 },
             ]
 
@@ -663,3 +671,95 @@ class TestGamesBlockedField:
         assert match["blocked"] is True
         others = [x for x in body["games"] if x["id"] != first["id"]]
         assert all(x["blocked"] is False for x in others)
+
+
+class TestGamesValidationChunks:
+    """The latest validation_history counts are surfaced per game so the UI can
+    render a 'Partial · N%' badge without a second round-trip."""
+
+    async def _vh(self, pool, game_id, *, started_at, total, cached, outcome):
+        await pool.execute_write(
+            "INSERT INTO validation_history "
+            "(game_id, manifest_version, started_at, finished_at, method, "
+            " chunks_total, chunks_cached, chunks_missing, outcome) "
+            "VALUES (?, '1.0', ?, ?, 'disk_stat', ?, ?, ?, ?)",
+            (game_id, started_at, started_at, total, cached, total - cached, outcome),
+        )
+
+    async def test_latest_validation_counts_surface(self, client, populated_pool):
+        # Two rows for game 1; the NEWEST (started_at) must win.
+        await self._vh(
+            populated_pool,
+            1,
+            started_at="2026-05-01T00:00:00Z",
+            total=100,
+            cached=50,
+            outcome="partial",
+        )
+        await self._vh(
+            populated_pool,
+            1,
+            started_at="2026-06-01T00:00:00Z",
+            total=100,
+            cached=90,
+            outcome="partial",
+        )
+        body = (
+            await client.get(
+                "/api/v1/games?limit=500", headers={"Authorization": f"Bearer {VALID_TOKEN}"}
+            )
+        ).json()
+        game = next(g for g in body["games"] if g["id"] == 1)
+        assert game["chunks_total"] == 100
+        assert game["chunks_cached"] == 90  # newest row, not the older 50
+
+    async def test_no_validation_history_is_null(self, client, populated_pool):
+        # game 4 has no validation_history row.
+        body = (
+            await client.get(
+                "/api/v1/games?limit=500", headers={"Authorization": f"Bearer {VALID_TOKEN}"}
+            )
+        ).json()
+        game = next(g for g in body["games"] if g["id"] == 4)
+        assert game["chunks_total"] is None
+        assert game["chunks_cached"] is None
+
+    async def test_fully_cached_counts_surface(self, client, populated_pool):
+        await self._vh(
+            populated_pool,
+            2,
+            started_at="2026-06-02T00:00:00Z",
+            total=2430,
+            cached=2430,
+            outcome="cached",
+        )
+        body = (
+            await client.get(
+                "/api/v1/games?limit=500", headers={"Authorization": f"Bearer {VALID_TOKEN}"}
+            )
+        ).json()
+        game = next(g for g in body["games"] if g["id"] == 2)
+        assert game["chunks_total"] == 2430
+        assert game["chunks_cached"] == 2430
+
+    async def test_same_second_tie_break_by_id(self, client, populated_pool):
+        # Two rows with the IDENTICAL started_at (validate stamps CURRENT_TIMESTAMP
+        # at second resolution, so same-second ties are real). The row inserted
+        # last has the higher AUTOINCREMENT id and must win — this is exactly the
+        # `id DESC` tie-break, and it also guarantees both subqueries pick the
+        # SAME row (cached/total can't come from different rows).
+        same_ts = "2026-06-03T00:00:00Z"
+        await self._vh(
+            populated_pool, 3, started_at=same_ts, total=100, cached=10, outcome="partial"
+        )
+        await self._vh(
+            populated_pool, 3, started_at=same_ts, total=100, cached=88, outcome="partial"
+        )
+        body = (
+            await client.get(
+                "/api/v1/games?limit=500", headers={"Authorization": f"Bearer {VALID_TOKEN}"}
+            )
+        ).json()
+        game = next(g for g in body["games"] if g["id"] == 3)
+        assert game["chunks_total"] == 100
+        assert game["chunks_cached"] == 88  # the later-inserted (higher-id) row


### PR DESCRIPTION
## What

`GET /api/v1/games` now returns **`chunks_cached`** and **`chunks_total`** per game, sourced from the newest `validation_history` row (`ORDER BY started_at DESC, id DESC LIMIT 1`) via correlated scalar subqueries — the same EXISTS-not-JOIN rationale as the existing `blocked` field, served by `idx_vh_game(game_id, started_at DESC)`. Both are `null` for games that have never been validated.

## Why

Game_shelf is adding a **"Partial · N%"** badge for `validation_failed` games (and a cached-fraction readout for any game). The percentage lives in the `validation_history` table; surfacing it on the games list avoids a second per-game round-trip. Purely additive to `GameResponse`; **no migration**.

## Tests

New `TestGamesValidationChunks`: newest-row-wins, null-when-never-validated, fully-cached, and a **same-second `id`-tiebreak** case (verifies both subqueries pick the same row deterministically). Existing keyset/metadata tests updated for the two additive fields.

- Full suite: **1271 passed** (only the env-only `pip-licenses` failure)
- mypy clean, ruff clean

## Reviewer notes

- Adversarially reviewed: verdict **SHIP**, no SEV-2/3. Twice-correlated subquery is an index seek per row (cheap at current scale); a single-lookup collapse is noted as an optional future optimization.
- Deploys to control plane LXC 1105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)