### PR TITLE
feat(steam): scope validation to prefilled depots + 6h sweep cadence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Changed — Validator scopes to prefilled depots; reads `.shas` manifests (2026-06-29) — 2026-06-29
+
+Fixes multi-language Steam titles showing a permanent "Check failed". The validator located **every** depot in an app's manifest set, but SteamPrefill only prefills the operator's selected language/OS depots — so other-language depots (never downloaded) dragged games like Dota 2 (44% cached) and BG3 (53%) to a perpetual `partial`/`missing`.
+
+- **Depot-scoping (`agent/routers/steam.py`):** validation now stats chunks **per depot** and **excludes any depot with zero chunk files on disk** (never prefilled — all chunks absent). Exclusion gates on *presence*, not readability: a depot whose files exist but are unreadable (mode-000, #76/#128) or empty is **kept** and counted in full, so that corruption stays a visible gap instead of being silently dropped as "never prefilled". If *no* depot has any files present the app is `missing` over the union (never a false `cached`); an empty manifest set is still `cached`. Excluded depots are logged (`steam_validate.depots_excluded`). (A depot fully evicted to 0 files is indistinguishable from never-prefilled and is excluded — accepted, as whole-depot eviction-to-zero is rare under per-file LRU.)
+- **`.shas` manifest support** (lands via the independent-fetcher commit): `locate_manifest_bins` globs both `.bin` and `.shas`, and the validate handler parses `.shas` sidecars (one SHA per line) via `parse_shas` — letting the validator cover apps SteamPrefill never wrote a `.bin` for.
+
+### Changed — Scheduled validation sweep now every 6 hours (2026-06-29) — 2026-06-29
+
+- `validation_sweep_cron` default `"0 3 * * 0"` (weekly) → `"0 3,9,15,21 * * *"` (every 6 h at 03/09/15/21 UTC), offset from the host prefill crons (steam 0/6/12/18, epic 1/7/13/19, gog 4/16) so a sweep never overlaps a prefill burst. Keeps cache statuses fresh as eviction/permission drift accumulates. Override via `ORCH_VALIDATION_SWEEP_CRON`.
+
 ### Added — Durable Steam manifest store + validate-all backfill (2026-06-24) — 2026-06-24
 
 Lets the orchestrator validate the *entire* prefilled Steam library, not just the subset SteamPrefill currently has a fresh manifest for. SteamPrefill only writes a manifest `.bin` when an app has new content (and treats saved manifests as temporary via `clear-temp`), so its cache covered ~330 of ~1077 prefilled apps; the other ~747 returned `no_manifest_in_cache` and could never be validated though their ~13 TB of chunks were on disk.

--- a/src/orchestrator/agent/manifest_locator.py
+++ b/src/orchestrator/agent/manifest_locator.py
@@ -1,14 +1,19 @@
-"""Locate an app's current manifest .bin files in SteamPrefill's cache.
+"""Locate an app's current manifest files in the Steam manifest cache.
 
-SteamPrefill caches each depot manifest as
-<cache_root>/v1/{app}_{app}_{depot}_{gid}.bin. For an app we take the NEWEST
-.bin (by mtime) per depot — the most recently fetched manifest, which tracks
-what is currently prefilled into lancache.
+Two manifest formats live side by side under <cache_root>/v1/, both named
+{app}_{app}_{depot}_{gid}.<ext>:
+  * .bin   — SteamPrefill's protobuf manifest (what SteamPrefill prefilled).
+  * .shas  — sidecar chunk list (one lowercase 40-hex SHA1 per line) written by
+             the independent fetcher, covering apps SteamPrefill never cached.
+For an app we take the NEWEST file (by mtime) per depot regardless of extension
+— the most recently fetched manifest, which tracks what is currently prefilled
+into lancache. A .bin and a .shas for the same depot de-dupe to whichever is
+newer.
 
 This deliberately does NOT use Config/successfullyDownloadedDepots.json: that
 file proved unreliable as a manifest index (it omits apps that have cached
 manifests and lists only a subset of an app's depot gids — found live during
-the ③a gate). The .bin cache itself is the source of truth.
+the ③a gate). The manifest cache itself is the source of truth.
 """
 
 from __future__ import annotations
@@ -18,38 +23,44 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from pathlib import Path
 
+# Manifest filename extensions the locator recognizes (see module docstring).
+_MANIFEST_EXTS = ("bin", "shas")
+
 
 def list_prefilled_app_ids(*, cache_roots: list[Path]) -> list[int]:
-    """Distinct app_ids with a cached manifest .bin across all roots (sorted)."""
+    """Distinct app_ids with a cached manifest (.bin or .shas) across all roots."""
     apps: set[int] = set()
     for root in cache_roots:
         v1 = root / "v1"
         if not v1.is_dir():
             continue
-        for path in v1.glob("*.bin"):
-            first = path.stem.split("_", 1)[0]
-            if first.isdigit():
-                apps.add(int(first))
+        for ext in _MANIFEST_EXTS:
+            for path in v1.glob(f"*.{ext}"):
+                first = path.stem.split("_", 1)[0]
+                if first.isdigit():
+                    apps.add(int(first))
     return sorted(apps)
 
 
 def locate_manifest_bins(app_id: int, *, cache_roots: list[Path]) -> list[Path]:
-    """Newest manifest .bin per depot for ``app_id`` across all roots (empty if none).
+    """Newest manifest per depot for ``app_id`` across all roots (empty if none).
 
-    Roots are searched in order; the newest .bin per depot by mtime wins, so a
-    fresher live-cache manifest supersedes an older archived one for the same
-    depot (and stable apps present only in the archive are still found)."""
+    Matches both .bin and .shas manifests. Roots are searched in order; the
+    newest file per depot by mtime wins regardless of extension, so a fresher
+    live-cache manifest supersedes an older archived one for the same depot (and
+    a .bin and .shas for the same depot de-dupe to whichever is newer)."""
     newest_per_depot: dict[str, Path] = {}
     for root in cache_roots:
         v1 = root / "v1"
         if not v1.is_dir():
             continue
-        for path in v1.glob(f"{app_id}_{app_id}_*.bin"):
-            parts = path.stem.split("_")
-            if len(parts) != 4:
-                continue
-            depot = parts[2]
-            current = newest_per_depot.get(depot)
-            if current is None or path.stat().st_mtime > current.stat().st_mtime:
-                newest_per_depot[depot] = path
+        for ext in _MANIFEST_EXTS:
+            for path in v1.glob(f"{app_id}_{app_id}_*.{ext}"):
+                parts = path.stem.split("_")
+                if len(parts) != 4:
+                    continue
+                depot = parts[2]
+                current = newest_per_depot.get(depot)
+                if current is None or path.stat().st_mtime > current.stat().st_mtime:
+                    newest_per_depot[depot] = path
     return list(newest_per_depot.values())

--- a/src/orchestrator/agent/manifest_parser.py
+++ b/src/orchestrator/agent/manifest_parser.py
@@ -57,6 +57,13 @@ def _length_delimited_fields(b: bytes) -> list[tuple[int, bytes]]:
     return out
 
 
+def parse_shas(text: str) -> set[str]:
+    """Extract chunk SHA1s from a ``.shas`` sidecar manifest: one lowercase
+    40-hex SHA1 per line. Blank/short/non-hex/uppercase lines are dropped
+    (same COR-2 guard as the .bin parser). Returns the deduped set."""
+    return {line.strip() for line in text.splitlines() if _SHA1_RE.match(line.strip())}
+
+
 def parse_chunk_shas(data: bytes) -> set[str]:
     """Extract the deduped set of chunk SHA1 hex strings from a .bin. A
     malformed/unrecognized buffer yields an empty set (never raises)."""

--- a/src/orchestrator/agent/routers/steam.py
+++ b/src/orchestrator/agent/routers/steam.py
@@ -18,7 +18,7 @@ from orchestrator.validator.cache_key import (
     slice_range_zero,
     steam_chunk_uri,
 )
-from orchestrator.validator.disk_stat import validate_chunks
+from orchestrator.validator.disk_stat import validate_chunks_scoped
 
 _log = structlog.get_logger(__name__)
 
@@ -128,7 +128,7 @@ async def steam_validate(body: SteamValidateRequest, request: Request) -> dict[s
     levels = settings.cache_levels
 
     seen: set[tuple[int, str]] = set()
-    paths: list[Path] = []
+    depot_paths: dict[int, list[Path]] = {}
     versions: list[str] = []
     parsed_ok = 0
     for binpath in bins:
@@ -154,6 +154,7 @@ async def steam_validate(body: SteamValidateRequest, request: Request) -> dict[s
             continue
         parsed_ok += 1
         versions.append(f"{depot_id}:{gid}")
+        dpaths = depot_paths.setdefault(depot_id, [])
         for sha in chunk_shas:
             key = (depot_id, sha)
             if key in seen:
@@ -161,7 +162,7 @@ async def steam_validate(body: SteamValidateRequest, request: Request) -> dict[s
             seen.add(key)
             uri = steam_chunk_uri(depot_id, sha)
             h = cache_key(identifier, uri, slice_range)
-            paths.append(cache_path(cache_root, h, levels))
+            dpaths.append(cache_path(cache_root, h, levels))
 
     if parsed_ok == 0:
         # Manifests existed but none could be parsed — a genuine error, not a
@@ -175,12 +176,60 @@ async def steam_validate(body: SteamValidateRequest, request: Request) -> dict[s
             "error": "manifest_parse_failed",
         }
 
-    cached, missing = await validate_chunks(paths)
-    total = len(paths)
+    # Depot-scoping: SteamPrefill only prefills the operator's selected
+    # language/OS depots, but the located manifest set can include extra depots
+    # (other languages / optional content) the fetcher mapped but whose chunks
+    # were never downloaded. A depot with NO chunk files on disk (present == 0)
+    # was never prefilled, so it must NOT count against the game — otherwise
+    # multi-language titles are perpetually 'partial'.
+    #
+    # We gate exclusion on `present`, NOT on `cached`: a depot whose files EXIST
+    # but are unreadable (mode-000, #76/#128) or empty has present > 0 and is
+    # KEPT, so that corruption stays visible as a gap instead of being silently
+    # dropped as "never prefilled". (A depot fully evicted to 0 files on disk is
+    # indistinguishable from never-prefilled and is excluded — accepted: whole-
+    # depot eviction-to-zero is rare under per-file LRU.)
+    total = 0
+    cached = 0
+    included = 0
+    excluded: list[int] = []
+    for depot_id, dpaths in sorted(depot_paths.items()):
+        if not dpaths:
+            continue
+        d_cached, d_present = await validate_chunks_scoped(dpaths)
+        if d_present == 0:
+            excluded.append(depot_id)
+            continue
+        total += len(dpaths)
+        cached += d_cached
+        included += 1
+
+    if excluded:
+        _log.info(
+            "steam_validate.depots_excluded",
+            app_id=body.app_id,
+            excluded=excluded,
+            included=included,
+        )
+
+    if included == 0:
+        # No depot has any cached chunks. If there were chunks to cache at all
+        # the app is genuinely not cached ('missing'); if the manifests held no
+        # chunks there's nothing to cache ('cached', matching _classify).
+        union_total = sum(len(p) for p in depot_paths.values())
+        return {
+            "chunks_total": union_total,
+            "chunks_cached": 0,
+            "chunks_missing": union_total,
+            "outcome": "missing" if union_total else "cached",
+            "versions": ",".join(sorted(versions)),
+            "error": None,
+        }
+
     return {
         "chunks_total": total,
         "chunks_cached": cached,
-        "chunks_missing": missing,
+        "chunks_missing": total - cached,
         "outcome": _classify(total, cached),
         "versions": ",".join(sorted(versions)),
         "error": None,

--- a/src/orchestrator/agent/routers/steam.py
+++ b/src/orchestrator/agent/routers/steam.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel, ConfigDict, Field
 
 from orchestrator.agent.manifest_locator import list_prefilled_app_ids, locate_manifest_bins
-from orchestrator.agent.manifest_parser import parse_chunk_shas
+from orchestrator.agent.manifest_parser import parse_chunk_shas, parse_shas
 from orchestrator.validator.cache_key import (
     cache_key,
     cache_path,
@@ -132,14 +132,19 @@ async def steam_validate(body: SteamValidateRequest, request: Request) -> dict[s
     versions: list[str] = []
     parsed_ok = 0
     for binpath in bins:
-        # filename is {app}_{app}_{depot}_{gid}.bin. A corrupt/foreign .bin (a
-        # non-numeric depot field, a deleted/unreadable file) must NOT 500 the
-        # whole request — skip it and keep validating the rest (COR-1).
+        # filename is {app}_{app}_{depot}_{gid}.{bin,shas}. A corrupt/foreign
+        # manifest (a non-numeric depot field, a deleted/unreadable file) must
+        # NOT 500 the whole request — skip it and keep validating the rest
+        # (COR-1). .shas is the fetcher's sidecar (one SHA per line); .bin is
+        # SteamPrefill's protobuf — same {app}_{app}_{depot}_{gid} field layout.
         try:
             parts = binpath.stem.split("_")
             depot_id = int(parts[2])
             gid = parts[3]
-            chunk_shas = parse_chunk_shas(binpath.read_bytes())
+            if binpath.suffix == ".shas":
+                chunk_shas = parse_shas(binpath.read_text())
+            else:
+                chunk_shas = parse_chunk_shas(binpath.read_bytes())
         except (ValueError, IndexError, OSError) as e:
             _log.warning(
                 "steam_validate.bin_skipped",

--- a/src/orchestrator/core/settings.py
+++ b/src/orchestrator/core/settings.py
@@ -169,7 +169,10 @@ class Settings(BaseSettings):
     scheduler_library_sync_interval_sec: int = Field(default=21600, ge=60, le=86400)
     # F13 — scheduled validation sweep.
     validation_sweep_enabled: bool = True
-    validation_sweep_cron: str = "0 3 * * 0"  # 5-field cron (min hour dom mon dow), UTC
+    # Every 6h at 03/09/15/21 UTC — offset from the host prefill crons
+    # (steam 0/6/12/18, epic 1/7/13/19, gog 4/16) so a sweep never overlaps a
+    # prefill burst. 5-field cron (min hour dom mon dow), UTC.
+    validation_sweep_cron: str = "0 3,9,15,21 * * *"
     # F8: the scheduled prefill driver runs on the library-sync interval.
     scheduled_prefill_enabled: bool = True
     sweep_batch_size: int = Field(default=10, ge=1)

--- a/src/orchestrator/scheduler/manager.py
+++ b/src/orchestrator/scheduler/manager.py
@@ -60,7 +60,7 @@ class SchedulerManager:
         enabled: bool,
         library_sync_interval_sec: int,
         validation_sweep_enabled: bool = True,
-        validation_sweep_cron: str = "0 3 * * 0",
+        validation_sweep_cron: str = "0 3,9,15,21 * * *",
         scheduled_prefill_enabled: bool = True,
     ) -> None:
         self._pool = pool

--- a/src/orchestrator/validator/disk_stat.py
+++ b/src/orchestrator/validator/disk_stat.py
@@ -69,15 +69,18 @@ def shutdown_cache_stat_executor() -> None:
         _cache_stat_executor = None
 
 
-def _stat_batch(paths: list[Path]) -> tuple[int, int]:
-    """Count (cached, errors) for a batch. Runs in a thread.
+def _stat_batch(paths: list[Path]) -> tuple[int, int, int]:
+    """Count (cached, present, errors) for a batch. Runs in a thread.
 
-    Cached = a regular file with non-empty size. Symlinks are NOT followed
-    (a cache path that is a symlink is not a genuine cached chunk).
-    `errors` counts unexpected OSErrors (e.g. EACCES) — a plain missing
-    file is not an error.
+    cached  = a regular file with non-empty size AND the owner-read bit set.
+    present = the file exists on disk (stat succeeds, not a symlink) regardless
+              of size/mode — lets callers tell a never-prefilled chunk (absent)
+              from a prefilled-but-unreadable one (mode-000) or an empty one.
+    errors  = unexpected OSErrors (e.g. EACCES on a directory, EIO). A plain
+              missing file is not an error.
     """
     cached = 0
+    present = 0
     errors = 0
     for p in paths:
         try:
@@ -85,6 +88,7 @@ def _stat_batch(paths: list[Path]) -> tuple[int, int]:
             if p.is_symlink():
                 continue
             st = p.stat()
+            present += 1  # file exists on disk (stat() needs only dir traversal)
             # F5/#128: lancache (www-data, the file owner) must be able to
             # READ the file to serve it. ~1.7% of cache files are mode-000 —
             # they exist with size>0 but are unreadable, so lancache returns
@@ -98,7 +102,7 @@ def _stat_batch(paths: list[Path]) -> tuple[int, int]:
             pass  # plain cache miss — expected, not an error
         except OSError:
             errors += 1  # EACCES, EIO, etc. — surfaced via the run WARN
-    return cached, errors
+    return cached, present, errors
 
 
 async def validate_chunks(paths: list[Path], *, batch_size: int = 256) -> tuple[int, int]:
@@ -115,12 +119,36 @@ async def validate_chunks(paths: list[Path], *, batch_size: int = 256) -> tuple[
     errors = 0
     for i in range(0, len(paths), batch_size):
         batch = paths[i : i + batch_size]
-        batch_cached, batch_errors = await loop.run_in_executor(executor, _stat_batch, batch)
+        batch_cached, _batch_present, batch_errors = await loop.run_in_executor(
+            executor, _stat_batch, batch
+        )
         cached += batch_cached
         errors += batch_errors
     if errors:
         _log.warning("validate.stat_errors", error_count=errors, total=len(paths))
     return cached, len(paths) - cached
+
+
+async def validate_chunks_scoped(paths: list[Path], *, batch_size: int = 256) -> tuple[int, int]:
+    """Return (cached, present) for a chunk list.
+
+    ``present`` counts files that exist on disk regardless of readability, so a
+    caller can distinguish a never-prefilled depot (present == 0, all absent)
+    from one whose files exist but aren't valid/readable (present > 0 — e.g.
+    mode-000 corruption, #76/#128). The latter must stay visible as a real gap,
+    NOT be silently dropped as "never prefilled". Same bounded executor + batching
+    as `validate_chunks`.
+    """
+    loop = asyncio.get_running_loop()
+    executor = _get_cache_stat_executor()
+    cached = 0
+    present = 0
+    for i in range(0, len(paths), batch_size):
+        batch = paths[i : i + batch_size]
+        batch_cached, batch_present, _err = await loop.run_in_executor(executor, _stat_batch, batch)
+        cached += batch_cached
+        present += batch_present
+    return cached, present
 
 
 async def validate_game(

--- a/tests/agent/test_manifest_locator.py
+++ b/tests/agent/test_manifest_locator.py
@@ -99,3 +99,34 @@ def test_list_prefilled_app_ids_union(tmp_path):
     _write_bin(live, 440, 441, 1)
     _write_bin(arch, 730, 731, 1)
     assert list_prefilled_app_ids(cache_roots=[live, arch]) == [440, 730]
+
+
+# --- .shas sidecar manifests (fetcher writes {app}_{app}_{depot}_{gid}.shas) ---
+
+
+def test_locates_shas_only_app(tmp_path):
+    # An app whose ONLY manifest is a .shas (SteamPrefill never cached it).
+    _write(tmp_path, "900_900_901_777.shas", 1000)
+    found = [p.name for p in locate_manifest_bins(900, cache_roots=[tmp_path])]
+    assert found == ["900_900_901_777.shas"]
+
+
+def test_bin_and_shas_same_depot_newest_mtime_wins(tmp_path):
+    # A .bin and a .shas for the SAME app+depot de-dupe to the newer mtime.
+    _write(tmp_path, "440_440_440_111.bin", 1000)
+    newer = _write(tmp_path, "440_440_440_222.shas", 2000)
+    found = locate_manifest_bins(440, cache_roots=[tmp_path])
+    assert [p.name for p in found] == [newer.name]
+
+
+def test_bin_wins_when_bin_is_newer_than_shas(tmp_path):
+    _write(tmp_path, "440_440_440_111.shas", 1000)
+    newer = _write(tmp_path, "440_440_440_222.bin", 2000)
+    found = locate_manifest_bins(440, cache_roots=[tmp_path])
+    assert [p.name for p in found] == [newer.name]
+
+
+def test_shas_only_app_in_list_prefilled_app_ids(tmp_path):
+    _write(tmp_path, "440_440_440_111.bin", 1000)  # .bin app
+    _write(tmp_path, "900_900_901_777.shas", 1000)  # .shas-only app
+    assert list_prefilled_app_ids(cache_roots=[tmp_path]) == [440, 900]

--- a/tests/agent/test_manifest_parser.py
+++ b/tests/agent/test_manifest_parser.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from orchestrator.agent.manifest_parser import parse_chunk_shas
+from orchestrator.agent.manifest_parser import parse_chunk_shas, parse_shas
 
 FIXTURE = Path(__file__).parent / "fixtures" / "sample_manifest.bin"
 
@@ -55,3 +55,36 @@ def test_rejects_non_hex_and_wrong_length_chunk_ids():
     buf = _wrap_chunk_id(valid) + _wrap_chunk_id(non_hex)
     buf += _wrap_chunk_id(too_short) + _wrap_chunk_id(uppercase)
     assert parse_chunk_shas(buf) == {"a" * 40}
+
+
+# --- .shas sidecar manifest parser (one 40-hex SHA1 per line) ---
+
+
+def test_parse_shas_multiline_blob():
+    a, b, c = "a" * 40, "b" * 40, "c" * 40
+    text = f"{a}\n{b}\n{c}\n"
+    assert parse_shas(text) == {a, b, c}
+
+
+def test_parse_shas_ignores_blank_short_and_non_hex_lines():
+    valid = "d" * 40
+    text = "\n".join(
+        [
+            valid,
+            "",  # blank
+            "   ",  # whitespace only
+            "abc123",  # too short
+            "z" * 40,  # 40 chars but not hex
+            ("A" * 40),  # uppercase -> not lowercase hex
+            f"  {valid}  ",  # surrounding whitespace stripped -> still valid
+        ]
+    )
+    assert parse_shas(text) == {valid}
+
+
+def test_parse_shas_empty_is_empty_set():
+    assert parse_shas("") == set()
+
+
+def test_parse_shas_returns_set():
+    assert isinstance(parse_shas("e" * 40), set)

--- a/tests/agent/test_steam_validate.py
+++ b/tests/agent/test_steam_validate.py
@@ -187,3 +187,94 @@ def test_validate_shas_all_missing(tmp_path):
     assert body["chunks_total"] == len(_SHAS_CHUNKS)
     assert body["chunks_cached"] == 0
     assert body["outcome"] == "missing"
+
+
+# --- depot-scoping: exclude never-prefilled (other-language/optional) depots ---
+
+MD_APP, MD_GID = 800440, 9111222333444555666
+
+
+def _build_multidepot(tmp_path: Path, *, depot_cached: dict[int, tuple[int, int]]) -> TestClient:
+    """Build a multi-depot app from .shas manifests. ``depot_cached`` maps
+    depot_id -> (n_chunks, n_cached): each depot gets ``n_chunks`` distinct 40-hex
+    SHAs, the first ``n_cached`` of which are written into the on-disk cache."""
+    mcache = tmp_path / "spcache"
+    (mcache / "v1").mkdir(parents=True)
+    cache_root = tmp_path / "lancache"
+    cache_root.mkdir()
+    levels, ident, slice_sz = "2:2", "steam", 10_485_760
+    slice_range = slice_range_zero(slice_sz)
+    for depot, (n, ncached) in depot_cached.items():
+        shas = [f"{depot:06x}{i:034x}" for i in range(n)]  # distinct per (depot, i)
+        (mcache / "v1" / f"{MD_APP}_{MD_APP}_{depot}_{MD_GID}.shas").write_text(
+            "\n".join(shas) + "\n"
+        )
+        for sha in shas[:ncached]:
+            p = cache_path(
+                cache_root, cache_key(ident, steam_chunk_uri(depot, sha), slice_range), levels
+            )
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_bytes(b"data")
+    cfg = tmp_path / "Config"
+    cfg.mkdir()
+    (cfg / "successfullyDownloadedDepots.json").write_text("{}")
+    settings = Settings(
+        orchestrator_token=TOKEN,
+        lancache_nginx_cache_path=cache_root,
+        cache_levels=levels,
+        steam_cache_identifier=ident,
+        cache_slice_size_bytes=slice_sz,
+        steam_manifest_cache_dir=mcache,
+        steam_prefill_config_dir=cfg,
+    )
+    client = TestClient(create_agent_app(settings=settings))
+    client.headers.update({"Authorization": f"Bearer {TOKEN}"})
+    return client
+
+
+def test_validate_excludes_never_prefilled_depot(tmp_path):
+    """A multi-language game: the prefilled depot is fully cached; an extra
+    never-prefilled (other-language) depot has 0 cached chunks. The validator
+    scopes to the prefilled depot only -> 'cached', not a perpetual 'partial'."""
+    client = _build_multidepot(tmp_path, depot_cached={800441: (10, 10), 800442: (8, 0)})
+    body = client.post("/v1/steam/validate", json={"app_id": MD_APP}).json()
+    assert body["chunks_total"] == 10  # only the prefilled depot counts
+    assert body["chunks_cached"] == 10
+    assert body["outcome"] == "cached"
+
+
+def test_validate_prefilled_depot_partial_still_counts(tmp_path):
+    """A prefilled depot that's genuinely partial (>=1 cached, some missing) is
+    NOT excluded -> the real gap stays visible; the never-prefilled depot is
+    still dropped."""
+    client = _build_multidepot(tmp_path, depot_cached={800441: (10, 9), 800442: (8, 0)})
+    body = client.post("/v1/steam/validate", json={"app_id": MD_APP}).json()
+    assert body["chunks_total"] == 10  # prefilled depot only (other-lang excluded)
+    assert body["chunks_cached"] == 9
+    assert body["outcome"] == "partial"
+
+
+def test_validate_all_depots_unprefilled_is_missing(tmp_path):
+    """If NO depot has any cached chunks, the app is genuinely not cached ->
+    'missing' over the union, never a false 'cached'."""
+    client = _build_multidepot(tmp_path, depot_cached={800441: (10, 0), 800442: (8, 0)})
+    body = client.post("/v1/steam/validate", json={"app_id": MD_APP}).json()
+    assert body["chunks_total"] == 18  # union of both depots
+    assert body["chunks_cached"] == 0
+    assert body["outcome"] == "missing"
+
+
+def test_validate_mode000_depot_kept_as_gap_not_excluded(tmp_path):
+    """A depot whose chunk files EXIST on disk but are mode-000 (unreadable —
+    the #76/#128 corruption) must NOT be excluded as 'never prefilled'. Its files
+    are present, so it stays a visible gap (present>0, 0 readable -> 'missing')
+    instead of being silently dropped, which would HIDE the corruption."""
+    client = _build_multidepot(tmp_path, depot_cached={800441: (10, 10)})
+    # Strip the owner-read bit from every (otherwise fully-cached) chunk file.
+    for f in (tmp_path / "lancache").rglob("*"):
+        if f.is_file():
+            f.chmod(0o000)
+    body = client.post("/v1/steam/validate", json={"app_id": MD_APP}).json()
+    assert body["chunks_total"] == 10  # depot KEPT (files present), not excluded
+    assert body["chunks_cached"] == 0  # all unreadable -> none count as cached
+    assert body["outcome"] == "missing"

--- a/tests/agent/test_steam_validate.py
+++ b/tests/agent/test_steam_validate.py
@@ -120,3 +120,70 @@ def test_validate_all_bins_corrupt_is_error_not_500(tmp_path):
     assert body["chunks_total"] == 0
     assert body["outcome"] == "error"
     assert body["error"]
+
+
+# --- .shas sidecar manifests (apps SteamPrefill never cached) ---
+
+SHAS_APP, SHAS_DEPOT, SHAS_GID = 700330, 700331, 8123456789012345678
+_SHAS_CHUNKS = [f"{i:040x}" for i in range(1, 13)]  # 12 distinct lowercase 40-hex SHAs
+
+
+def _build_shas(tmp_path: Path, *, cache_all: bool) -> TestClient:
+    """Like _build, but the only manifest for SHAS_APP is a .shas sidecar."""
+    mcache = tmp_path / "spcache"
+    (mcache / "v1").mkdir(parents=True)
+    (mcache / "v1" / f"{SHAS_APP}_{SHAS_APP}_{SHAS_DEPOT}_{SHAS_GID}.shas").write_text(
+        "\n".join(_SHAS_CHUNKS) + "\n"
+    )
+    cfg = tmp_path / "Config"
+    cfg.mkdir()
+    (cfg / "successfullyDownloadedDepots.json").write_text("{}")
+
+    cache_root = tmp_path / "lancache"
+    levels, ident, slice_sz = "2:2", "steam", 10_485_760
+    if cache_all:
+        slice_range = slice_range_zero(slice_sz)
+        for sha in _SHAS_CHUNKS:
+            h = cache_key(ident, steam_chunk_uri(SHAS_DEPOT, sha), slice_range)
+            p = cache_path(cache_root, h, levels)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_bytes(b"data")
+    else:
+        cache_root.mkdir()
+
+    settings = Settings(
+        orchestrator_token=TOKEN,
+        lancache_nginx_cache_path=cache_root,
+        cache_levels=levels,
+        steam_cache_identifier=ident,
+        cache_slice_size_bytes=slice_sz,
+        steam_manifest_cache_dir=mcache,
+        steam_prefill_config_dir=cfg,
+    )
+    app = create_agent_app(settings=settings)
+    client = TestClient(app)
+    client.headers.update({"Authorization": f"Bearer {TOKEN}"})
+    return client
+
+
+def test_validate_shas_all_cached(tmp_path):
+    """A .shas-backed app (no .bin) validates against a real cache outcome —
+    NOT 'no_manifest_in_cache'."""
+    client = _build_shas(tmp_path, cache_all=True)
+    r = client.post("/v1/steam/validate", json={"app_id": SHAS_APP})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["chunks_total"] == len(_SHAS_CHUNKS)
+    assert body["chunks_cached"] == len(_SHAS_CHUNKS)
+    assert body["chunks_missing"] == 0
+    assert body["outcome"] == "cached"
+    assert body["error"] is None
+    assert body["versions"] == f"{SHAS_DEPOT}:{SHAS_GID}"
+
+
+def test_validate_shas_all_missing(tmp_path):
+    client = _build_shas(tmp_path, cache_all=False)
+    body = client.post("/v1/steam/validate", json={"app_id": SHAS_APP}).json()
+    assert body["chunks_total"] == len(_SHAS_CHUNKS)
+    assert body["chunks_cached"] == 0
+    assert body["outcome"] == "missing"

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -327,7 +327,8 @@ class TestFieldValidators:
     def test_sweep_settings_defaults(self):
         s = Settings(orchestrator_token=VALID_TOKEN)
         assert s.validation_sweep_enabled is True
-        assert s.validation_sweep_cron == "0 3 * * 0"
+        # Every 6h (03/09/15/21 UTC), offset from the prefill crons.
+        assert s.validation_sweep_cron == "0 3,9,15,21 * * *"
         assert s.sweep_batch_size == 10
 
     def test_invalid_sweep_cron_fails_fast(self, monkeypatch):


### PR DESCRIPTION
## What

Fixes multi-language Steam titles showing a permanent **"Check failed"**, and brings the deployed-but-unmerged `.shas` validator into `main`.

**The bug:** the validator located *every* depot in an app's manifest set, but SteamPrefill only prefills the operator's selected language/OS depots. Never-downloaded other-language depots dragged genuinely-cached games (Dota 2 44%, BG3 53% — measured live) to a perpetual `partial`/`missing`.

## Changes

1. **Depot-scoping** (`agent/routers/steam.py`): validation now stats chunks **per depot** and **excludes any depot with no chunk files on disk** (never prefilled). Exclusion gates on **presence, not readability** — a depot whose files exist but are unreadable (**mode-000**, #76/#128) or empty is **kept and counted in full**, so that corruption stays a visible gap instead of being silently dropped as "never prefilled". If no depot is present → `missing` over the union (never a false `cached`); an empty manifest set → `cached`. Excluded depots are logged.
2. **`disk_stat`**: `_stat_batch` now also returns `present`; new `validate_chunks_scoped() -> (cached, present)` lets the caller distinguish *absent* from *unreadable*. `validate_chunks() -> (cached, missing)` and its other caller (`stat.py`) + tests are unchanged.
3. **Sweep cadence**: `validation_sweep_cron` default `"0 3 * * 0"` (weekly) → `"0 3,9,15,21 * * *"` (every 6 h, offset from prefill 0/6/12/18, epic 1/7/13/19, gog 4/16). Override via `ORCH_VALIDATION_SWEEP_CRON`.
4. **`.shas` validator** (`d7726c0`, cherry-picked): the already-deployed agent reads both `.bin` and `.shas` manifests — this lands it in `main`.

## Tests

New: exclude-never-prefilled-depot, partial-prefilled-still-counts, all-unprefilled→missing, and **mode-000-present-depot-kept-as-a-gap** (the corruption-stays-visible case). Existing validate/settings/scheduler tests updated/green.

- Full suite: **1281 passed** (only the env-only `pip-licenses` failure); mypy + ruff clean.

## Review

Adversarially reviewed → **FIX-FIRST on Finding 1** (a 0-cached exclusion would hide a fully-mode-000'd depot) → **fixed**: exclusion now gates on `present` (files-on-disk), so mode-000 depots stay visible. Residual: a depot *fully evicted to 0 files* is indistinguishable from never-prefilled and is excluded — accepted (whole-depot eviction-to-zero is rare under per-file LRU; documented in code + CHANGELOG).

Deploys to the agent on the UGREEN NAS (it owns the validate path); needs the agent image rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)