### PR TITLE
feat(prefill): add force option to refill evicted/partial games

### DIFF
--- a/.claude/build-progress.json
+++ b/.claude/build-progress.json
@@ -22,13 +22,14 @@
     "f6-epic-prefill",
     "f13-scheduled-sweep",
     "f11-cli",
-    "f8-block-list"
+    "f8-block-list",
+    "force-prefill"
   ],
-  "features_since_last_test": 1,
-  "features_since_last_health_check": 1,
+  "features_since_last_test": 2,
+  "features_since_last_health_check": 2,
   "test_interval": 2,
   "last_test_session": "2026-06-14",
-  "testing_required": false,
+  "testing_required": true,
   "tester_count": 1,
   "bug_tracker": "github_issues",
   "sessions_completed": 11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Added — Force prefill option (`--force` / `?force=true`) (2026-06-29) — 2026-06-29
+
+A normal prefill skips any app SteamPrefill's own state already considers complete, so a game left `partial` by **lancache eviction** (chunks evicted from disk, but SteamPrefill still records them as downloaded) is never refilled — triggering a plain prefill does nothing. A **forced** prefill re-requests *every* chunk (SteamPrefill `--force`): lancache serves still-cached chunks as LAN hits and re-fetches only the evicted/missing ones from the Steam CDN, repairing the partial. It never re-downloads a whole game from the internet — only the genuinely-missing chunks cost WAN.
+
+- **API:** `POST /api/v1/games/{id}/prefill?force=true` (bearer-gated; default false → fully backward-compatible). The flag rides in the job's existing `payload` column as `{"force": true}` — **no migration**.
+- **Dedup upgrade:** a force request that dedups onto a still-**queued** non-force prefill rewrites that job's payload to force, so the in-flight dedup (migration-0006, one prefill per game) doesn't silently swallow the force; a **running** prefill is returned unchanged (can't switch mid-run).
+- **Handler (`jobs/handlers/prefill.py`):** `_steam_prefill` parses `payload.force` (robust to NULL / non-JSON → False) and threads it through the existing `force=` seam to `SteamPrefillDriver.prefill_apps` / the agent's `POST /v1/steam/prefill`. **Steam only**; Epic ignores it.
+- **CLI:** `orchestrator-cli game prefill <id> --force` / `-f`.
+- Re-introduces a per-job force the 2026-06-23 CORE-2 cleanup removed as a *dead* top-level key — now sourced from the `payload` the worker actually selects, so it is live, not dead.
+
 ### Changed — Validator scopes to prefilled depots; reads `.shas` manifests (2026-06-29) — 2026-06-29
 
 Fixes multi-language Steam titles showing a permanent "Check failed". The validator located **every** depot in an app's manifest set, but SteamPrefill only prefills the operator's selected language/OS depots — so other-language depots (never downloaded) dragged games like Dota 2 (44% cached) and BG3 (53%) to a perpetual `partial`/`missing`.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -968,6 +968,14 @@ the feature that generates the content F7 checks, closing the prefill → cache
 F6 (Epic) deferred. Bundled a small F7 fix to stop counting mode-000
 unreadable cache files.
 
+**Enhancement — Force prefill (2026-06-29):** `?force=true` on the prefill
+trigger (CLI `game prefill --force` / `-f`) threads SteamPrefill `--force` via
+the job `payload` `{"force": true}`, re-requesting every chunk to refill a game
+left `partial` by lancache eviction (a normal prefill skips apps SteamPrefill's
+own state deems complete, so it would refill nothing). The trigger dedup-upgrades
+a still-queued non-force prefill to force; Steam only (Epic ignores it). No
+migration — reuses the existing `jobs.payload` column. See CHANGELOG (2026-06-29).
+
 **Key Interfaces:**
   - `src/orchestrator/prefill/downloader.py` — `prefill_chunks` (async httpx,
     bounded `Semaphore`, stream+discard, retry/backoff) + `PrefillResult`

--- a/docs/security-audits/force-prefill-security-audit.md
+++ b/docs/security-audits/force-prefill-security-audit.md
@@ -1,0 +1,107 @@
+# Security Audit — Force prefill option
+
+**Feature:** force-prefill (`--force` / `?force=true`)
+**Modules:**
+- `src/orchestrator/api/routers/prefill_trigger.py` — `force` query param, payload write, dedup force-upgrade
+- `src/orchestrator/jobs/handlers/prefill.py` — `_payload_force()`, force threaded through `_steam_prefill`/`_steam_prefill_inner`
+- `src/orchestrator/cli/client.py` — `OrchClient.post(..., params=)`
+- `src/orchestrator/cli/commands/game.py` — `game prefill --force` / `-f`
+**Audit date:** 2026-06-29
+**Auditor:** self-review (Senior Security Engineer persona) + ruff (incl. flake8-bandit `S` rules) + mypy --strict + full test suite
+**Phase:** 2 (Construction), Build Loop step 2.4
+
+<!-- Last Updated: 2026-06-29 -->
+
+## Scope
+
+Post-implementation security review of the force-prefill capability: a `force`
+flag that threads SteamPrefill `--force` (re-request every chunk) so the
+orchestrator can refill a game left `partial` by lancache eviction. The flag
+travels API → job `payload` → worker → handler → driver/agent. No new
+dependency, no schema migration (reuses the existing `jobs.payload` TEXT column).
+
+10 new tests across `tests/jobs/test_prefill_handler.py` (4),
+`tests/api/test_prefill_trigger_router.py` (4), `tests/cli/test_cmd_game.py` (2).
+
+## Methodology
+
+1. **SAST-lite.** `ruff check src/orchestrator tests` (flake8-bandit `S` rules
+   enabled — incl. `S101` no-assert, `S608` SQL-injection heuristics) — clean.
+2. **Type safety.** `mypy src/orchestrator` — clean (88 source files).
+3. **Threat-model cross-check** against the project threat model: SQL injection
+   (parameterized), auth boundary (bearer), resource-exhaustion / DoS
+   amplification, log credential leak.
+4. **Test verification.** Full suite `pytest -q --ignore=tests/scripts` — 1295
+   passed (only the documented `tests/test_licenses.py` local-tooling failure).
+   Force-specific behavior (payload set, default NULL, dedup-upgrade queued vs
+   running, handler parse incl. malformed-payload, CLI param) covered by the 10
+   new tests.
+
+## Audit findings
+
+| # | Severity | Title | Status |
+|---|----------|-------|--------|
+| — | — | No findings. | — |
+
+## Non-findings (explicitly checked, clean)
+
+- **SQL injection.** The trigger's INSERT/UPDATE/SELECT all use `?` parameter
+  binding. The only value the feature adds to SQL is the payload, bound as a
+  parameter and sourced from a **fixed module literal** `_FORCE_PAYLOAD =
+  '{"force": true}'` — never from request data. No user-controllable string
+  reaches SQL composition.
+- **No injection via the flag.** `force` is parsed by FastAPI as a strict
+  `bool` query param (`?force=true`); a non-bool value yields a 422, never
+  reaches the DB. The CLI sends the literal string `"true"`; the boolean comes
+  from a Click `is_flag` option (no free-form value).
+- **Payload parse is crash-safe (DoS via malformed payload).**
+  `_payload_force()` wraps `json.loads` in `try/except (ValueError, TypeError)`
+  and type-checks the parsed object is a `dict` before `.get("force")`. A NULL,
+  non-JSON, non-object, or oversized payload returns `False` — it cannot raise
+  out of the worker loop or flip force on unexpectedly. Verified by
+  `test_steam_prefill_malformed_payload_is_false` and
+  `test_steam_prefill_payload_without_force_is_false`.
+- **Auth boundary unchanged.** `POST /api/v1/games/{id}/prefill` remains
+  bearer-gated (`test_missing_bearer_returns_401`, `test_wrong_bearer_returns_401`
+  still green). The feature adds no new endpoint and no new unauthenticated
+  surface. The CLI talks to the same bearer-gated API.
+- **Resource-exhaustion / DoS amplification.** A forced prefill is more
+  expensive than a normal one (re-requests every chunk → LAN reads + WAN for the
+  evicted subset). Amplification is bounded: (a) the caller must already hold the
+  orchestrator bearer, with which they can already enqueue prefills; (b) the
+  migration-0006 in-flight UNIQUE index permits at most one prefill per game, so
+  force cannot stack duplicate concurrent runs; (c) force never re-downloads a
+  whole game from the internet — lancache serves still-cached chunks as LAN hits.
+  Accepted: no privilege boundary is crossed that the bearer didn't already grant.
+- **Dedup force-upgrade is state-guarded.** The upgrade only rewrites the payload
+  of a **queued** job (`existing["state"] == "queued"`); a **running** prefill is
+  returned unchanged (it cannot be mutated mid-run). The UPDATE binds the job id
+  as a parameter and is idempotent (`!= _FORCE_PAYLOAD` guard avoids a redundant
+  write). Verified by `test_force_upgrades_queued_nonforce_job` and
+  `test_force_does_not_upgrade_running_job`.
+- **No secret exposure in logs.** The only new log field is `force=<bool>`
+  (`prefill.started`, `prefill_trigger.force_upgraded`). No token, password,
+  Steam Guard, or session material is read or logged by this feature. The
+  SteamPrefill driver's existing token-redaction is unchanged.
+- **No dead/misleading flag re-introduced.** This deliberately revives a per-job
+  force the 2026-06-23 CORE-2 cleanup removed *as dead* (it read a top-level job
+  key the row never carried). The new force is sourced from the `payload` column
+  the worker actually `SELECT`s, and the CORE-2 guard tests
+  (`..._ignores_dead_force_key`) remain green — a stray top-level `force` key is
+  still ignored; only `payload.force` is honored.
+- **Steam-scoped.** Force is consumed only in the steam path; the Epic prefill
+  path ignores it (no behavior change, no Epic `--force` semantics assumed).
+
+## Decision
+
+**Force-prefill is cleared to advance through the Build Loop.** No SEV-1/2/3/4
+findings. The change is additive, bearer-gated, parameterized, crash-safe on
+malformed input, and bounded against amplification by the existing per-game
+in-flight dedup. Covered by 10 new tests; ruff + mypy clean; full suite green.
+
+## Sign-off
+
+- Implementation: commit `<pending>` (appended after the green-phase commit lands)
+- Test suite: 1295 passed (`--ignore=tests/scripts`); 10 new force tests
+- ruff (incl. bandit `S` rules) + mypy clean on the four changed modules
+- No new dependency; no migration (reuses `jobs.payload`)

--- a/src/orchestrator/api/routers/prefill_trigger.py
+++ b/src/orchestrator/api/routers/prefill_trigger.py
@@ -27,6 +27,13 @@ if TYPE_CHECKING:
 _log = structlog.get_logger(__name__)
 router = APIRouter(prefix="/api/v1/games", tags=["prefill"])
 
+# Job-payload marker for a FORCED prefill — threads SteamPrefill `--force`, which
+# re-requests every chunk so lancache refills evicted/partial games (a normal
+# prefill skips an app SteamPrefill's own state thinks is already complete).
+# Single source of truth for the INSERT, the dedup force-upgrade, and the
+# handler's payload parse (jobs/handlers/prefill.py:_payload_force).
+_FORCE_PAYLOAD = '{"force": true}'
+
 
 @router.post(
     "/{game_id}/prefill",
@@ -40,6 +47,7 @@ router = APIRouter(prefix="/api/v1/games", tags=["prefill"])
 )
 async def trigger_prefill(
     game_id: int,
+    force: bool = False,
     pool: Pool = Depends(get_pool_dep),  # noqa: B008
 ) -> JSONResponse:
     try:
@@ -54,18 +62,34 @@ async def trigger_prefill(
             )
 
         existing = await pool.read_one(
-            "SELECT id FROM jobs "
+            "SELECT id, state, payload FROM jobs "
             "WHERE kind='prefill' AND game_id=? "
             "AND state IN ('queued','running') "
             "ORDER BY id LIMIT 1",
             (game_id,),
         )
         if existing is not None:
-            _log.info(
-                "prefill_trigger.dedup_hit",
-                game_id=game_id,
-                existing_job_id=existing["id"],
-            )
+            # Force-upgrade: a force request that dedups onto a still-QUEUED
+            # non-force prefill rewrites its payload so the force isn't silently
+            # swallowed by the in-flight dedup (migration-0006 allows only one
+            # prefill per game). A RUNNING prefill can't change mid-flight, so
+            # it's returned as-is.
+            if force and existing["state"] == "queued" and existing["payload"] != _FORCE_PAYLOAD:
+                await pool.execute_write(
+                    "UPDATE jobs SET payload=? WHERE id=?",
+                    (_FORCE_PAYLOAD, existing["id"]),
+                )
+                _log.info(
+                    "prefill_trigger.force_upgraded",
+                    game_id=game_id,
+                    existing_job_id=int(existing["id"]),
+                )
+            else:
+                _log.info(
+                    "prefill_trigger.dedup_hit",
+                    game_id=game_id,
+                    existing_job_id=existing["id"],
+                )
             return JSONResponse(status_code=202, content={"job_id": int(existing["id"])})
 
         # ON CONFLICT DO NOTHING + the migration-0006 partial UNIQUE index make
@@ -73,9 +97,9 @@ async def trigger_prefill(
         # an in-flight prefill for this game, our INSERT is a no-op and we return
         # the winner's job_id below — no duplicate prefill row, no duplicate work.
         await pool.execute_write(
-            "INSERT INTO jobs (kind, game_id, platform, state, source) "
-            "VALUES ('prefill', ?, ?, 'queued', 'api') ON CONFLICT DO NOTHING",
-            (game_id, platform),
+            "INSERT INTO jobs (kind, game_id, platform, state, source, payload) "
+            "VALUES ('prefill', ?, ?, 'queued', 'api', ?) ON CONFLICT DO NOTHING",
+            (game_id, platform, _FORCE_PAYLOAD if force else None),
         )
         new_row = await pool.read_one(
             "SELECT id FROM jobs WHERE kind='prefill' AND game_id=? "

--- a/src/orchestrator/cli/client.py
+++ b/src/orchestrator/cli/client.py
@@ -100,8 +100,13 @@ class OrchClient:
         """
         return self._request("GET", "/api/v1/health", ok_extra=(503,))
 
-    def post(self, path: str, json: dict[str, Any] | None = None) -> Any:
-        return self._request("POST", path, json=json)
+    def post(
+        self,
+        path: str,
+        json: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        return self._request("POST", path, params=params, json=json)
 
     def delete(self, path: str, json: dict[str, Any] | None = None) -> Any:
         return self._request("DELETE", path, json=json)

--- a/src/orchestrator/cli/commands/game.py
+++ b/src/orchestrator/cli/commands/game.py
@@ -78,19 +78,32 @@ def game_show(ctx: click.Context, game_id: int) -> None:
         click.echo(f"{key:18} {rendered}")
 
 
-def _trigger(ctx: click.Context, game_id: int, path: str, name: str) -> None:
+def _trigger(
+    ctx: click.Context,
+    game_id: int,
+    path: str,
+    name: str,
+    params: dict[str, str] | None = None,
+) -> None:
     client = make_client(ctx)
-    resp = client.post(f"/api/v1/games/{game_id}/{path}")
+    resp = client.post(f"/api/v1/games/{game_id}/{path}", params=params)
     output.success(f"queued {name} for game {game_id} (job_id={resp['job_id']}).")
 
 
 @game.command("prefill")
 @click.argument("game_id", type=int, callback=_positive_int)
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    help="Re-request every chunk (SteamPrefill --force) to refill an evicted/partial game "
+    "that a normal prefill would skip as already complete.",
+)
 @click.pass_context
 @handles_api_errors
-def game_prefill(ctx: click.Context, game_id: int) -> None:
-    """Trigger a prefill."""
-    _trigger(ctx, game_id, "prefill", "prefill")
+def game_prefill(ctx: click.Context, game_id: int, force: bool) -> None:
+    """Trigger a prefill (use --force to refill an already-'complete' partial game)."""
+    _trigger(ctx, game_id, "prefill", "prefill", params={"force": "true"} if force else None)
 
 
 @game.command("validate")

--- a/src/orchestrator/jobs/handlers/prefill.py
+++ b/src/orchestrator/jobs/handlers/prefill.py
@@ -208,6 +208,23 @@ async def _epic_prefill_inner(
     )
 
 
+def _payload_force(job: dict[str, Any]) -> bool:
+    """Read a per-job ``force`` flag from the job ``payload`` JSON (set by the
+    prefill trigger's ``?force=true``). Robust: a missing/NULL/non-JSON payload,
+    or one without a ``force`` key, means False. Unlike the CORE-2 dead top-level
+    key, this is sourced from the ``payload`` column the worker actually selects,
+    so a force prefill genuinely re-requests every chunk (SteamPrefill ``--force``)
+    to repair lancache-evicted / partial games."""
+    raw = job.get("payload")
+    if not raw:
+        return False
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError):
+        return False
+    return bool(parsed.get("force")) if isinstance(parsed, dict) else False
+
+
 async def _steam_prefill(job: dict[str, Any], deps: Deps) -> None:
     """Prefill one Steam game through the host-installed SteamPrefill binary (F5).
 
@@ -246,8 +263,9 @@ async def _steam_prefill(job: dict[str, Any], deps: Deps) -> None:
         raise ValueError(f"game {game_id} platform is {game['platform']!r}, not steam")
 
     job_id = job.get("id")
+    force = _payload_force(job)
     await deps.pool.execute_write("UPDATE games SET status='downloading' WHERE id=?", (game_id,))
-    _log.info("prefill.started", job_id=job_id, game_id=game_id)
+    _log.info("prefill.started", job_id=job_id, game_id=game_id, force=force)
     try:
         await _steam_prefill_inner(
             job_id,
@@ -256,6 +274,7 @@ async def _steam_prefill(job: dict[str, Any], deps: Deps) -> None:
             deps,
             prefill_driver,
             agent_enabled=settings.agent_enabled,
+            force=force,
         )
     except Exception as e:
         # Never leave the game stuck in 'downloading'. The non-ok-exit path
@@ -278,6 +297,7 @@ async def _steam_prefill_inner(
     prefill_driver: SteamPrefillDriver | None,
     *,
     agent_enabled: bool,
+    force: bool = False,
 ) -> None:
     try:
         app_id_int = int(game["app_id"])
@@ -290,13 +310,13 @@ async def _steam_prefill_inner(
         # here so the type checker narrows it (mirrors the Epic seam).
         if deps.agent_client is None:
             raise RuntimeError("agent_client is required when agent_enabled")
-        agent_result = await deps.agent_client.steam_prefill([app_id_int])
+        agent_result = await deps.agent_client.steam_prefill([app_id_int], force=force)
         ok = bool(agent_result["ok"])
         raw = str(agent_result.get("raw", ""))
     else:
         if prefill_driver is None:
             raise RuntimeError("prefill_driver is required for prefill handler")
-        driver_result = await prefill_driver.prefill_apps([app_id_int])
+        driver_result = await prefill_driver.prefill_apps([app_id_int], force=force)
         ok = driver_result.ok
         raw = driver_result.raw
     _log.info(

--- a/tests/api/test_prefill_trigger_router.py
+++ b/tests/api/test_prefill_trigger_router.py
@@ -167,3 +167,78 @@ class TestPoolFailure:
                 headers={"Authorization": f"Bearer {VALID_TOKEN}"},
             )
         assert r.status_code == 503
+
+
+class TestForce:
+    async def test_force_true_sets_payload(self, client, populated_pool):
+        game_id = await _ensure_steam_game(populated_pool, app_id="force-1", title="t")
+        r = await client.post(
+            f"/api/v1/games/{game_id}/prefill?force=true",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r.status_code == 202
+        row = await populated_pool.read_one(
+            "SELECT payload FROM jobs WHERE id=?", (r.json()["job_id"],)
+        )
+        assert row["payload"] == '{"force": true}'
+
+    async def test_default_has_null_payload(self, client, populated_pool):
+        game_id = await _ensure_steam_game(populated_pool, app_id="force-2", title="t")
+        r = await client.post(
+            f"/api/v1/games/{game_id}/prefill",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r.status_code == 202
+        row = await populated_pool.read_one(
+            "SELECT payload FROM jobs WHERE id=?", (r.json()["job_id"],)
+        )
+        assert row["payload"] is None
+
+    async def test_force_upgrades_queued_nonforce_job(self, client, populated_pool):
+        """A force request that dedups onto a QUEUED non-force prefill upgrades
+        that job's payload to force, so the force is not silently dropped by the
+        in-flight dedup (migration-0006 allows only one prefill per game)."""
+        game_id = await _ensure_steam_game(populated_pool, app_id="force-3", title="t")
+        await populated_pool.execute_write(
+            "INSERT INTO jobs (kind, game_id, platform, state, source) "
+            "VALUES ('prefill', ?, 'steam', 'queued', 'api')",
+            (game_id,),
+        )
+        existing = await populated_pool.read_one(
+            "SELECT id FROM jobs WHERE kind='prefill' AND game_id=? AND state='queued'",
+            (game_id,),
+        )
+        r = await client.post(
+            f"/api/v1/games/{game_id}/prefill?force=true",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r.status_code == 202
+        assert r.json()["job_id"] == existing["id"]
+        row = await populated_pool.read_one(
+            "SELECT payload FROM jobs WHERE id=?", (existing["id"],)
+        )
+        assert row["payload"] == '{"force": true}'
+
+    async def test_force_does_not_upgrade_running_job(self, client, populated_pool):
+        """A RUNNING prefill cannot be changed mid-flight: a force request dedups
+        onto it and returns it, but its payload is left as-is (NULL)."""
+        game_id = await _ensure_steam_game(populated_pool, app_id="force-4", title="t")
+        await populated_pool.execute_write(
+            "INSERT INTO jobs (kind, game_id, platform, state, source) "
+            "VALUES ('prefill', ?, 'steam', 'running', 'api')",
+            (game_id,),
+        )
+        existing = await populated_pool.read_one(
+            "SELECT id FROM jobs WHERE kind='prefill' AND game_id=? AND state='running'",
+            (game_id,),
+        )
+        r = await client.post(
+            f"/api/v1/games/{game_id}/prefill?force=true",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r.status_code == 202
+        assert r.json()["job_id"] == existing["id"]
+        row = await populated_pool.read_one(
+            "SELECT payload FROM jobs WHERE id=?", (existing["id"],)
+        )
+        assert row["payload"] is None

--- a/tests/cli/test_cmd_game.py
+++ b/tests/cli/test_cmd_game.py
@@ -49,6 +49,25 @@ def test_game_prefill_triggers(mock):
     assert r.exit_code == 0 and "50" in r.output
 
 
+def test_game_prefill_force_sends_force_param(mock):
+    def handler(req: httpx.Request) -> httpx.Response:
+        assert req.url.path == "/api/v1/games/5/prefill"
+        assert dict(req.url.params).get("force") == "true"
+        return httpx.Response(202, json={"job_id": 52})
+
+    r = mock(["game", "prefill", "5", "--force"], handler)
+    assert r.exit_code == 0 and "52" in r.output
+
+
+def test_game_prefill_without_force_omits_param(mock):
+    def handler(req: httpx.Request) -> httpx.Response:
+        assert "force" not in dict(req.url.params)
+        return httpx.Response(202, json={"job_id": 53})
+
+    r = mock(["game", "prefill", "5"], handler)
+    assert r.exit_code == 0
+
+
 def test_game_validate_triggers(mock):
     def handler(req: httpx.Request) -> httpx.Response:
         assert req.url.path == "/api/v1/games/5/validate"

--- a/tests/jobs/test_prefill_handler.py
+++ b/tests/jobs/test_prefill_handler.py
@@ -78,6 +78,33 @@ async def test_steam_prefill_ignores_dead_force_key(pool):
     assert driver.calls == [([730], False)]
 
 
+async def test_steam_prefill_payload_force_threads_force(pool):
+    """Force-prefill: a job whose payload carries {"force": true} threads
+    force=True into the driver. This is the live re-introduction of a per-job
+    force — sourced from the job payload (which the worker selects), NOT the
+    top-level dead key the CORE-2 cleanup removed."""
+    game_id = await _seed_game(pool, app_id="730")
+    driver = _StubDriver(ok=True)
+    await prefill_handler(_job(game_id, payload='{"force": true}'), _steam_deps(pool, driver))
+    assert driver.calls == [([730], True)]
+
+
+async def test_steam_prefill_payload_without_force_is_false(pool):
+    """A payload that omits force (e.g. {}) leaves force at its default False."""
+    game_id = await _seed_game(pool, app_id="730")
+    driver = _StubDriver(ok=True)
+    await prefill_handler(_job(game_id, payload="{}"), _steam_deps(pool, driver))
+    assert driver.calls == [([730], False)]
+
+
+async def test_steam_prefill_malformed_payload_is_false(pool):
+    """A non-JSON / unexpected payload must not crash the handler — force=False."""
+    game_id = await _seed_game(pool, app_id="730")
+    driver = _StubDriver(ok=True)
+    await prefill_handler(_job(game_id, payload="not-json"), _steam_deps(pool, driver))
+    assert driver.calls == [([730], False)]
+
+
 async def test_steam_success_enqueues_validate_and_marks_cached(pool):
     game_id = await _seed_game(pool, app_id="730")
     await pool.execute_write("UPDATE games SET current_version='42' WHERE id=?", (game_id,))
@@ -178,6 +205,17 @@ async def test_steam_agent_prefill_ignores_dead_force_key(pool, monkeypatch):
     )
     await prefill_handler(_job(game_id, force=True), deps)
     assert agent.calls == [([730], False)]
+
+
+async def test_steam_agent_payload_force_threads_force(pool, monkeypatch):
+    """Force-prefill, agent seam: payload {"force": true} threads force=True to
+    agent_client.steam_prefill (matching the in-process driver path)."""
+    _agent_enabled(monkeypatch)
+    game_id = await _seed_game(pool, app_id="730")
+    agent = _FakeAgent(ok=True)
+    deps = Deps(pool=pool, prefill_driver=_ExplodingDriver(), agent_client=agent)
+    await prefill_handler(_job(game_id, payload='{"force": true}'), deps)
+    assert agent.calls == [([730], True)]
 
 
 async def test_steam_agent_success_same_db_writes(pool, monkeypatch):


### PR DESCRIPTION
## Why

You asked: *"if a game shows partial and I select prefill, will it redownload the entire game or only what's missing?"* The verified answer is **neither** — a normal prefill **skips** any app SteamPrefill's own state deems complete. So a game left `partial` by **lancache eviction** (chunks evicted from disk, but SteamPrefill still records them as downloaded) is never refilled: triggering prefill does nothing.

This adds a **force** option that re-requests every chunk (SteamPrefill `--force`): lancache serves still-cached chunks as **LAN hits** and re-fetches only the evicted/missing ones over **WAN**. It never re-downloads a whole game from the internet — only the genuinely-missing chunks cost bandwidth.

> Live example from today: A Plague Tale: Requiem validated at **45816 / 51192 = 89.5%** cached. Those 5,376 missing chunks are exactly what `--force` would repair.

## What

- **API:** `POST /api/v1/games/{id}/prefill?force=true` → writes `{"force": true}` to the job's existing `payload` column. **No migration.** Default false → fully backward-compatible.
- **Dedup upgrade:** a force request that dedups onto a still-**queued** non-force prefill upgrades that job's payload (so the in-flight dedup, migration-0006, doesn't swallow the force); a **running** prefill is returned unchanged.
- **Handler:** `_payload_force` parses `payload.force` (robust to NULL / non-JSON) and threads `force=` through the existing `SteamPrefillDriver.prefill_apps` / agent `POST /v1/steam/prefill` seam. **Steam only**; Epic ignores it.
- **CLI:** `orchestrator-cli game prefill <id> --force` / `-f`.
- Re-introduces a per-job force the 2026-06-23 CORE-2 cleanup removed as a *dead* top-level key — now sourced from the `payload` the worker actually selects, so it's live. The CORE-2 guard tests stay green.

## Test plan

- 10 new tests: handler (4 — payload force threads True; without-force / malformed payload default False; agent seam), trigger (4 — force sets payload, default NULL, queued upgrade, running not upgraded), CLI (2 — `--force` sends `?force=true`, absent omits it).
- Full suite: **1295 passed** (`--ignore=tests/scripts`; only the documented `tests/test_licenses.py` local pip-licenses failure). ruff + mypy clean.
- Security audit: `docs/security-audits/force-prefill-security-audit.md` — no findings (bearer-gated, fixed-literal payload, malformed-payload-safe, amplification bounded by per-game dedup).

## Follow-up

Game_shelf "Force / Repair" button is the natural UI surface once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)