### PR TITLE
fix(agent): resilient agent RPC + force-prefill dedup race (UAT-12)

### DIFF
--- a/.claude/build-progress.json
+++ b/.claude/build-progress.json
@@ -25,12 +25,12 @@
     "f8-block-list",
     "force-prefill"
   ],
-  "features_since_last_test": 2,
+  "features_since_last_test": 0,
   "features_since_last_health_check": 2,
   "test_interval": 2,
-  "last_test_session": "2026-06-14",
-  "testing_required": true,
+  "last_test_session": "2026-06-30",
+  "testing_required": false,
   "tester_count": 1,
   "bug_tracker": "github_issues",
-  "sessions_completed": 11
+  "sessions_completed": 12
 }

--- a/.claude/process-state.json
+++ b/.claude/process-state.json
@@ -6,7 +6,7 @@
     "started_at": null
   },
   "uat_session": {
-    "session_id": 11,
+    "session_id": 12,
     "step": 9,
     "steps_completed": [
       "agents_dispatched",
@@ -19,7 +19,7 @@
       "remediation_complete",
       "gate_passed"
     ],
-    "started_at": "2026-06-13T23:18:30Z"
+    "started_at": "2026-06-30T17:03:29Z"
   },
   "phase3_validation": {
     "steps_completed": [],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — Agent-RPC resilience: a transient connect blip no longer kills a long job (2026-06-30) — 2026-06-30
+
+UAT-12. The control plane reaches the data-plane agent over HTTP with no retry, so a single transient `ConnectTimeout` — e.g. the agent's single uvicorn listener briefly CPU-starved by a heavy `SteamPrefill --force` on the steal-bound VM, lagging `accept()` past the 10s connect timeout — failed the **entire** multi-hour job. Observed live (A Plague Tale `--force` left a residual gap until a clean re-run reached 99.998%).
+
+- **`clients/agent_client.py`:** bounded **connect-phase retry in `_request`** (`ConnectError`/`ConnectTimeout`/`PoolTimeout` mean the request never reached the agent → safe to retry any method, no duplicate side effects; default 2 retries with backoff). Connect timeout **10s → 15s** absorbs brief accept-lag in one attempt; poll interval **0.5s → 3s** cuts the connect count ~6×. One change hardens the Steam-prefill poll, Epic `pull` poll, `steam_validate`, and `library_sync`, and largely stops `/health` flapping. HTTP-status errors and `agent job failed` still propagate immediately; non-connect transport errors are not blind-retried (POST-safety).
+
+### Fixed — Force-prefill dedup-upgrade TOCTOU race (2026-06-30) — 2026-06-30
+
+UAT-12. The force dedup-upgrade `UPDATE jobs SET payload=? WHERE id=?` (from the force-prefill feature below) had no state guard: if the worker claimed the queued prefill (→ `running`, reading its non-force payload) between the API's dedup read and the UPDATE, the UPDATE rewrote the running job's payload to `force=true` — so the DB falsely recorded that force ran when it didn't. Added `AND state='queued'` + rowcount-aware logging (only log `force_upgraded` when it actually applied; otherwise a too-late dedup hit). `api/routers/prefill_trigger.py`.
+
 ### Added — Force prefill option (`--force` / `?force=true`) (2026-06-29) — 2026-06-29
 
 A normal prefill skips any app SteamPrefill's own state already considers complete, so a game left `partial` by **lancache eviction** (chunks evicted from disk, but SteamPrefill still records them as downloaded) is never refilled — triggering a plain prefill does nothing. A **forced** prefill re-requests *every* chunk (SteamPrefill `--force`): lancache serves still-cached chunks as LAN hits and re-fetches only the evicted/missing ones from the Steam CDN, repairing the partial. It never re-downloads a whole game from the internet — only the genuinely-missing chunks cost WAN.

--- a/src/orchestrator/api/routers/prefill_trigger.py
+++ b/src/orchestrator/api/routers/prefill_trigger.py
@@ -74,17 +74,27 @@ async def trigger_prefill(
             # swallowed by the in-flight dedup (migration-0006 allows only one
             # prefill per game). A RUNNING prefill can't change mid-flight, so
             # it's returned as-is.
+            upgraded = 0
             if force and existing["state"] == "queued" and existing["payload"] != _FORCE_PAYLOAD:
-                await pool.execute_write(
-                    "UPDATE jobs SET payload=? WHERE id=?",
+                # `AND state='queued'` closes a TOCTOU race: if the worker claimed
+                # this job (-> 'running') between the read above and this UPDATE,
+                # it already read the row's (non-force) payload, so rewriting the
+                # now-running row would make the DB falsely record that force ran.
+                # The guard makes the UPDATE a no-op in that race (rowcount 0).
+                upgraded = await pool.execute_write(
+                    "UPDATE jobs SET payload=? WHERE id=? AND state='queued'",
                     (_FORCE_PAYLOAD, existing["id"]),
                 )
+            if upgraded:
                 _log.info(
                     "prefill_trigger.force_upgraded",
                     game_id=game_id,
                     existing_job_id=int(existing["id"]),
                 )
             else:
+                # Plain dedup hit — either no force was requested, the job was
+                # already force, or it was claimed mid-flight (force too late;
+                # the operator can re-run --force once the current run finishes).
                 _log.info(
                     "prefill_trigger.dedup_hit",
                     game_id=game_id,

--- a/src/orchestrator/clients/agent_client.py
+++ b/src/orchestrator/clients/agent_client.py
@@ -28,15 +28,27 @@ class AgentClient:
         base_url: str,
         token: str,
         transport: httpx.AsyncBaseTransport | None = None,
-        poll_interval_sec: float = 0.5,
+        poll_interval_sec: float = 3.0,
         timeout_sec: float = 30.0,
         poll_timeout_sec: float = 7200.0,
+        connect_retries: int = 2,
+        connect_retry_backoff_sec: float = 0.5,
     ) -> None:
         self._base_url = base_url
         self._headers = {"Authorization": f"Bearer {token}"}
         self._transport = transport
+        # UAT-12: poll at 3s (was 0.5s) — a multi-hour job needs far fewer
+        # connects, cutting the chance of landing on a connect blip ~6x.
         self._poll = poll_interval_sec
-        self._timeout = httpx.Timeout(timeout_sec, connect=10.0)
+        # UAT-12: connect timeout 15s (was 10s) absorbs brief accept-lag in one
+        # attempt; the retry below is the backstop for a harder blip.
+        self._timeout = httpx.Timeout(timeout_sec, connect=15.0)
+        # UAT-12: bounded retry on connect-phase failures (see _request). The
+        # agent's single uvicorn listener can be briefly CPU-starved by a heavy
+        # SteamPrefill --force on the steal-bound VM, lagging accept() past the
+        # connect timeout; one such blip must not kill a multi-hour prefill.
+        self._connect_retries = connect_retries
+        self._connect_backoff = connect_retry_backoff_sec
         # Overall ceiling for a post-then-poll op (prefill/pull). Bounds the poll
         # loop so a job stuck 'running' can't poll forever (MEM-2). Default safely
         # above any real prefill; the orchestrator job's own timeout is the
@@ -69,10 +81,28 @@ class AgentClient:
             self._client = None
 
     async def _request(self, method: str, path: str, **kw: Any) -> httpx.Response:
-        try:
-            resp = await self._get_client().request(method, path, **kw)
-        except httpx.HTTPError as e:
-            raise AgentError(f"agent unreachable: {type(e).__name__}") from e
+        attempt = 0
+        while True:
+            try:
+                resp = await self._get_client().request(method, path, **kw)
+                break
+            except (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout) as e:
+                # UAT-12: a connect-phase failure means no connection was
+                # established, so the request never reached the agent — safe to
+                # retry for ANY method (no duplicate side effects). Bounded by
+                # _connect_retries; a transient blip mid-prefill must not fail the
+                # job, but a genuinely-down agent must still surface promptly.
+                if attempt >= self._connect_retries:
+                    raise AgentError(f"agent unreachable: {type(e).__name__}") from e
+                attempt += 1
+                _log.warning(
+                    "agent.connect_retry", path=path, attempt=attempt, error=type(e).__name__
+                )
+                await asyncio.sleep(self._connect_backoff * attempt)
+            except httpx.HTTPError as e:
+                # Non-connect transport error (e.g. ReadTimeout after the request
+                # was sent): not safe to blind-retry a POST, so surface it.
+                raise AgentError(f"agent unreachable: {type(e).__name__}") from e
         if resp.status_code >= 400:
             raise AgentError(f"agent returned {resp.status_code} for {path}")
         return resp

--- a/tests/api/test_prefill_trigger_router.py
+++ b/tests/api/test_prefill_trigger_router.py
@@ -242,3 +242,54 @@ class TestForce:
             "SELECT payload FROM jobs WHERE id=?", (existing["id"],)
         )
         assert row["payload"] is None
+
+    async def test_force_upgrade_skips_concurrently_claimed_job(self, unit_app, populated_pool):
+        """TOCTOU (UAT-12): if the worker claims the queued prefill (-> running,
+        reading its payload as non-force) between the API's dedup read and the
+        upgrade UPDATE, the state-guarded UPDATE must NOT rewrite the now-running
+        job's payload — otherwise the DB would falsely record that force ran."""
+        import httpx
+
+        from orchestrator.api.dependencies import get_pool_dep
+
+        game_id = await _ensure_steam_game(populated_pool, app_id="race-p", title="t")
+        # The real row is RUNNING (already claimed by the worker, payload NULL).
+        await populated_pool.execute_write(
+            "INSERT INTO jobs (kind, game_id, platform, state, source) "
+            "VALUES ('prefill', ?, 'steam', 'running', 'api')",
+            (game_id,),
+        )
+        running = await populated_pool.read_one(
+            "SELECT id FROM jobs WHERE kind='prefill' AND game_id=? AND state='running'",
+            (game_id,),
+        )
+
+        class _StaleReadPool:
+            """Reports the in-flight prefill as 'queued' to the dedup read (the
+            stale snapshot the API saw before the worker claimed it), but the real
+            row is 'running' — so the guarded UPDATE hits a running row."""
+
+            def __init__(self, real):
+                self._real = real
+
+            async def read_one(self, query, params=()):
+                row = await self._real.read_one(query, params)
+                if row is not None and "FROM jobs" in query and "state IN" in query:
+                    return {**row, "state": "queued"}  # stale: looked queued
+                return row
+
+            async def execute_write(self, *a, **kw):
+                return await self._real.execute_write(*a, **kw)
+
+        unit_app.dependency_overrides[get_pool_dep] = lambda: _StaleReadPool(populated_pool)
+        transport = httpx.ASGITransport(app=unit_app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as c:
+            r = await c.post(
+                f"/api/v1/games/{game_id}/prefill?force=true",
+                headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+            )
+        assert r.status_code == 202
+        assert r.json()["job_id"] == running["id"]
+        # The running job's payload was NOT rewritten — force did not falsely apply.
+        row = await populated_pool.read_one("SELECT payload FROM jobs WHERE id=?", (running["id"],))
+        assert row["payload"] is None

--- a/tests/clients/test_agent_client.py
+++ b/tests/clients/test_agent_client.py
@@ -19,6 +19,7 @@ def _client(handler) -> AgentClient:
         token=TOKEN,
         transport=transport,
         poll_interval_sec=0.0,
+        connect_retry_backoff_sec=0.0,
     )
 
 
@@ -163,6 +164,93 @@ async def test_steam_validate_single_call():
     res = await client.steam_validate(1018130)
     assert res["chunks_cached"] == 60
     assert res["outcome"] == "cached"
+
+
+# --- UAT-12: agent-call resilience (transient connect-blip tolerance) ---
+
+
+async def test_poll_tolerates_transient_connect_blip():
+    """A transient connect blip on a GET poll is retried inside _request, so a
+    single hiccup mid-prefill does not kill the whole multi-hour job. The agent's
+    uvicorn listener can be briefly CPU-starved during a heavy prefill on the
+    steal-bound VM, lagging accept() past the connect timeout."""
+    state = {"polls": 0}
+
+    def handler(request):
+        if request.method == "POST":
+            return httpx.Response(202, json={"job_id": "s1"})
+        state["polls"] += 1
+        if state["polls"] <= 2:  # two transient connect failures, then done
+            raise httpx.ConnectTimeout("listener starved")
+        return httpx.Response(200, json={"state": "done", "result": {"ok": True}})
+
+    client = _client(handler)
+    result = await client.steam_prefill([440])
+    assert result["ok"] is True
+    assert state["polls"] == 3  # 2 blips retried + 1 success
+
+
+async def test_connect_failure_exhausts_retries_then_raises():
+    """A persistent connect failure still raises AgentError, but only after the
+    bounded retries (default 2 → 3 attempts) — not on the first blip."""
+    state = {"attempts": 0}
+
+    def handler(request):
+        state["attempts"] += 1
+        raise httpx.ConnectError("refused")
+
+    client = _client(handler)
+    with pytest.raises(AgentError):
+        await client.stat(["a" * 32])
+    assert state["attempts"] == 3  # 1 initial + 2 retries
+
+
+async def test_http_status_error_is_not_retried():
+    """A real HTTP error response (e.g. 500) is NOT a transient connect blip —
+    it propagates immediately without consuming the connect-retry budget."""
+    state = {"attempts": 0}
+
+    def handler(request):
+        state["attempts"] += 1
+        return httpx.Response(500)
+
+    client = _client(handler)
+    with pytest.raises(AgentError, match="returned 500"):
+        await client.stat(["a" * 32])
+    assert state["attempts"] == 1  # not retried
+
+
+async def test_post_connect_blip_is_retried():
+    """A connect blip on the dispatch POST is safe to retry — the connection was
+    never established so the request never reached the agent (no duplicate job)."""
+    state = {"posts": 0}
+
+    def handler(request):
+        if request.method == "POST":
+            state["posts"] += 1
+            if state["posts"] == 1:
+                raise httpx.ConnectTimeout("starved")
+            return httpx.Response(202, json={"job_id": "s1"})
+        return httpx.Response(200, json={"state": "done", "result": {"ok": True}})
+
+    client = _client(handler)
+    result = await client.steam_prefill([440])
+    assert result["ok"] is True
+    assert state["posts"] == 2  # first POST blipped, retried to success
+
+
+async def test_default_connect_timeout_raised_to_15s():
+    """Default connect timeout bumped 10s -> 15s to absorb brief accept-lag on the
+    CPU-contended agent VM in a single attempt."""
+    c = AgentClient(base_url="http://agent:8780", token=TOKEN)
+    assert c._timeout.connect == 15.0
+
+
+async def test_default_poll_interval_raised_to_3s():
+    """Default poll interval bumped 0.5s -> 3s: a multi-hour job needs far fewer
+    connects, cutting the chance of hitting a connect blip ~6x."""
+    c = AgentClient(base_url="http://agent:8780", token=TOKEN)
+    assert c._poll == 3.0
 
 
 async def test_steam_validate_unreachable_raises():

--- a/tests/uat/sessions/2026-06-30-session-12/agent-results/agent-resilience.md
+++ b/tests/uat/sessions/2026-06-30-session-12/agent-results/agent-resilience.md
@@ -1,0 +1,24 @@
+# Agent: Agent-RPC resilience sibling hunt (UAT-12)
+
+No retry/backoff exists anywhere in the control-plane→agent HTTP layer (`_request`
+does one `.request()` and wraps any `httpx.HTTPError` into `AgentError`; default
+transport `retries=0`).
+
+1. **SEV-2 — `steam_prefill` poll loop** (`agent_client.py` `_post_then_poll`, called from
+   prefill.py): GET every 0.5s for up to 7200s; one ConnectTimeout/ReadTimeout/transport
+   error on any poll (or the POST) → whole multi-hour Steam prefill fails. → **FIXED** (root).
+2. **SEV-2 — Epic `pull` poll loop** (same `_post_then_poll`, called from `_epic_prefill_inner`):
+   one transient blip fails the whole Epic prefill, flips game `failed`. → **FIXED** (same change).
+3. **SEV-3 — `/health` `auth_status()` flaps `agent_reachable` + `cache_volume_mounted`** →
+   a single connect blip makes `/health` return 503/degraded; no threshold/smoothing.
+   → **Largely mitigated** by the connect-retry; full smoothing deferred.
+4. **SEV-3 — `validate` dies on a transient blip** (`steam_validate`, no try/except up the
+   stack); the post-prefill validate that assigns final status can leave a game stuck
+   `downloading`. → **FIXED** (same `_request` retry).
+5. **SEV-4 — `library_sync` dies on a transient blip** (`prefilled_apps`). Low impact
+   (cheap, re-runs on schedule). → **FIXED** (same `_request` retry).
+
+Already-safe: `sweep_handler` (per-game try/except), `validator_self_test` (catches → SKIP).
+
+**Bottom line:** bounded retry on transient httpx errors in `_request` (or the poll GET)
+covers #1, #2, #4, #5; #3 additionally wants a /health consecutive-failure threshold.

--- a/tests/uat/sessions/2026-06-30-session-12/agent-results/force-prefill-qa.md
+++ b/tests/uat/sessions/2026-06-30-session-12/agent-results/force-prefill-qa.md
@@ -1,0 +1,18 @@
+# Agent: Force-prefill QA hunt (UAT-12)
+
+Confirmed against code. `_payload_force` is robust (NULL/non-JSON/non-dict → False);
+payload is never user-controlled (bool seam only); `?force=1/yes/true` all parse;
+auto-enqueued validate correctly carries no payload.
+
+1. **SEV-3 — dedup force-upgrade UPDATE has no `state='queued'` guard → TOCTOU.**
+   `api/routers/prefill_trigger.py` UPDATE keyed on id only; worker's `claim_next_job`
+   (worker.py:55-67) flips queued→running and reads payload ONCE before the late UPDATE
+   lands → prefill runs non-force yet DB records `force=true` and logs `force_upgraded`.
+   → **FIXED** (added `AND state='queued'` + rowcount-aware logging).
+
+2. **SEV-4 — Epic `?force=true` accepted+persisted but ignored.** `_epic_prefill` never
+   calls `_payload_force`; CLI help implies it works everywhere. Harmless (Epic always
+   re-downloads). → **Deferred.**
+
+3. **SEV-4 — force onto a RUNNING prefill no-ops with a success-looking message.**
+   Documented-as-accepted but operator gets no signal to re-run. → **Deferred.**

--- a/tests/uat/sessions/2026-06-30-session-12/consolidated-findings.md
+++ b/tests/uat/sessions/2026-06-30-session-12/consolidated-findings.md
@@ -1,0 +1,44 @@
+# UAT Session 12 — Consolidated Findings & Triage (2026-06-30)
+
+**Trigger:** test-gate batch 2/2 (features since UAT-11: cache-UI Partial-badge / validator depot-scoping cluster, and force-prefill #203).
+
+**Method:** Two parallel exploratory agents (no human test template — this batch is
+backend/CLI, validated by automated tests + live box validation). Plus live
+validation of force-prefill against the real lancache (A Plague Tale: Requiem
+prefilled 89.5% → 99.998% over two `--force` runs; root-caused the residual to a
+transient agent ConnectTimeout, which led to the resilience finding below).
+
+## Findings
+
+| # | Sev | Area | Finding | Triage |
+|---|-----|------|---------|--------|
+| 1 | SEV-2 | agent RPC | A transient connect blip on any of the thousands of 0.5s prefill **poll** GETs (or the dispatch POST) fails the whole multi-hour job — `_post_then_poll` has no retry; connect timeout 10s. Same `_post_then_poll` weakness fails Epic `pull` too. | **Fix Now** |
+| 2 | SEV-3 | agent RPC | Single-call agent ops (`steam_validate`, `prefilled_apps`) and `/health` `auth_status` also die / flap on one transient blip (validate left a game stuck `downloading`; /health flips to 503). | **Fix Now** (same root fix) |
+| 3 | SEV-3 | force-prefill (#203) | Dedup force-upgrade `UPDATE … WHERE id=?` lacked `AND state='queued'` → TOCTOU: worker claims the queued job (runs non-force) before the UPDATE lands, so the DB records `force=true` but the prefill ran without it. | **Fix Now** |
+| 4 | SEV-4 | force-prefill (#203) | Epic `?force=true` is accepted + persisted but ignored (Epic path never reads it). Harmless (Epic always re-downloads) but the record/CLI text is misleading. | **Defer** |
+| 5 | SEV-4 | force-prefill (#203) | Force that dedups onto an already-**running** prefill no-ops with a success-looking "queued prefill" message; operator gets no signal to re-run. | **Defer** |
+
+## Remediation (this session — branch `fix/agent-poll-resilience`)
+
+- **#1 + #2 → `clients/agent_client.py`:** bounded **connect-phase retry in `_request`**
+  (ConnectError/ConnectTimeout/PoolTimeout — request never reached the agent, so safe
+  to retry any method; default 2 retries). Connect timeout **10s → 15s**; poll interval
+  **0.5s → 3s**. One change covers prefill poll, Epic pull, validate, library_sync, and
+  largely stops /health flapping. HTTP-status errors and `agent job failed` still
+  propagate immediately; non-connect transport errors are not blind-retried (POST-safety).
+  Tests: `tests/clients/test_agent_client.py` (+6: transient-blip tolerated, exhaust-then-raise,
+  500-not-retried, POST-blip-retried, 15s/3s defaults).
+- **#3 → `api/routers/prefill_trigger.py`:** added `AND state='queued'` to the upgrade
+  UPDATE + rowcount-aware logging (only log `force_upgraded` when it actually applied).
+  Test: `test_force_upgrade_skips_concurrently_claimed_job` (stale-read pool simulates the race).
+
+## Deferred (filed for follow-up, none SEV-1/2)
+- #4 Epic force: reject force for non-steam or store NULL + document steam-only.
+- #5 running-force no-op: surface a distinct response so the operator knows to re-run.
+- /health smoothing: a consecutive-failure threshold before flipping `agent_reachable`
+  (largely mitigated by the #1/#2 retry).
+
+## Result
+- 7 new tests; full suite 1302 passed (only the documented `tests/test_licenses.py` local
+  pip-licenses failure); ruff + mypy clean.
+- No open SEV-1/2 after remediation. Gate cleared.


### PR DESCRIPTION
## UAT-12

Triggered by the test-gate (2 features since UAT-11: cache-UI Partial-badge / validator depot-scoping, and force-prefill #203). Two parallel exploratory agents + live force-prefill validation surfaced two **Fix-Now** bugs; both fixed test-first.

## Fix 1 — transient agent connect blip killed a long job (SEV-2)

The control plane reaches the data-plane agent over HTTP with **no retry**. One `ConnectTimeout` — e.g. the agent's single uvicorn listener briefly CPU-starved by `SteamPrefill --force` on the steal-bound VM, lagging `accept()` past the 10s connect timeout — failed the **entire** multi-hour job (and the Epic `pull`, `steam_validate`, `library_sync`; and flapped `/health` to 503). This is the root cause of the residual gap we saw repairing A Plague Tale live.

- **`clients/agent_client.py`:** bounded **connect-phase retry in `_request`** — `ConnectError`/`ConnectTimeout`/`PoolTimeout` mean the request never reached the agent, so it's safe to retry any method (no duplicate side effects); default 2 retries with backoff. Connect timeout **10s → 15s** (absorb brief accept-lag in one attempt); poll interval **0.5s → 3s** (~6× fewer connects). One change hardens prefill poll, Epic pull, validate, and library_sync, and largely stops `/health` flapping. HTTP-status errors and `agent job failed` still propagate immediately; non-connect transport errors are not blind-retried (POST-safety).

## Fix 2 — force-prefill dedup-upgrade TOCTOU (SEV-3, from #203)

The force dedup-upgrade `UPDATE jobs SET payload=? WHERE id=?` had no state guard: if the worker claimed the queued prefill (→ `running`, reading its non-force payload) between the API's dedup read and the UPDATE, the UPDATE rewrote the **running** job's payload to `force=true` — so the DB falsely recorded that force ran.

- **`api/routers/prefill_trigger.py`:** added `AND state='queued'` + rowcount-aware logging (only log `force_upgraded` when it actually applied).

## Test plan
- 7 new tests: `agent_client` +6 (transient-blip tolerated, exhaust-then-raise, 500-not-retried, POST-blip-retried, 15s/3s defaults), `prefill_trigger` +1 (`test_force_upgrade_skips_concurrently_claimed_job` — stale-read pool simulates the race).
- Full suite **1302 passed** (only the documented `tests/test_licenses.py` local pip-licenses failure); ruff + mypy clean.

## Deferred (SEV-4, no open SEV-1/2)
Recorded in `tests/uat/sessions/2026-06-30-session-12/`: Epic `?force=true` accepted-but-ignored; force-onto-running no-op message; full `/health` consecutive-failure smoothing (mostly mitigated by the retry).

## Deploy
Control-plane only (LXC 1105) — same as #203; no agent rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)