### PR TITLE
fix(platforms): source steam auth_status from the live agent/driver signal

### DIFF
--- a/.claude/build-progress.json
+++ b/.claude/build-progress.json
@@ -23,10 +23,11 @@
     "f13-scheduled-sweep",
     "f11-cli",
     "f8-block-list",
-    "force-prefill"
+    "force-prefill",
+    "steam-auth-status-live"
   ],
-  "features_since_last_test": 0,
-  "features_since_last_health_check": 2,
+  "features_since_last_test": 1,
+  "features_since_last_health_check": 3,
   "test_interval": 2,
   "last_test_session": "2026-06-30",
   "testing_required": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — Steam auth status was a stale orphaned column; now sourced live (2026-06-30) — 2026-06-30
+
+`GET /api/v1/platforms` (read by the CLI `status` and the Game_shelf cache dashboard) reported Steam's `auth_status` from the `platforms.auth_status` DB column — but that column has had **no Steam writer since re-arch ③c** (the legacy ValvePython worker that wrote it was deleted), so it was frozen at a stale `expired` and would have read `expired` forever regardless of the real SteamPrefill session (which was healthy — `--force` prefills ran fine). The fix overrides the **steam** row's `auth_status` with the same LIVE signal `/health` already uses — `agent_client.auth_status()` when `agent_enabled`, else `prefill_driver.auth_status()`, each of which stats the persisted `account.config` — and clears the equally-stale `last_error`. Defensive: when the signal can't be determined (agent down / no driver / any error) it falls back to the stored value and never raises. Epic is unchanged (it has a real writer). `api/routers/platforms.py`; 6 new tests; no migration.
+
 ### Fixed — Agent-RPC resilience: a transient connect blip no longer kills a long job (2026-06-30) — 2026-06-30
 
 UAT-12. The control plane reaches the data-plane agent over HTTP with no retry, so a single transient `ConnectTimeout` — e.g. the agent's single uvicorn listener briefly CPU-starved by a heavy `SteamPrefill --force` on the steal-bound VM, lagging `accept()` past the 10s connect timeout — failed the **entire** multi-hour job. Observed live (A Plague Tale `--force` left a residual gap until a clean re-run reached 99.998%).

--- a/docs/security-audits/steam-auth-status-live-security-audit.md
+++ b/docs/security-audits/steam-auth-status-live-security-audit.md
@@ -1,0 +1,46 @@
+# Security Audit — Steam auth_status live signal
+
+**Feature:** steam-auth-status-live
+**Module:** `src/orchestrator/api/routers/platforms.py` (`_live_steam_auth_status` + steam-row override in `list_platforms`)
+**Audit date:** 2026-06-30
+**Auditor:** self-review (Senior Security Engineer persona) + ruff (flake8-bandit `S`) + mypy --strict + full suite
+**Phase:** 2 (Construction), Build Loop step 2.4
+
+<!-- Last Updated: 2026-06-30 -->
+
+## Scope
+
+`GET /api/v1/platforms` (read by CLI `status` and the Game_shelf cache dashboard) reported Steam's `auth_status` from the `platforms.auth_status` DB column, which has had **no Steam writer since re-arch ③c** (the legacy ValvePython worker that wrote it was deleted), so it was frozen at a stale "expired". The fix overrides the **steam** row's `auth_status` with the live agent/driver signal `/health` already uses (`agent_client.auth_status()` when `agent_enabled`, else `prefill_driver.auth_status()` — each stats the persisted `account.config`), and clears the equally-stale `last_error`. Epic is unchanged (it has a real writer). 6 new tests.
+
+## Methodology
+
+1. **SAST-lite.** `ruff check src/orchestrator tests` (flake8-bandit `S`) — clean.
+2. **Type safety.** `mypy src/orchestrator` — clean (88 files).
+3. **Threat-model cross-check:** secret exposure, auth boundary, DoS/availability, information disclosure.
+4. **Tests.** Full suite 1308 passed (only the documented `tests/test_licenses.py` local pip-licenses failure). 6 new tests cover override-ok, override-expired, no-signal fallback, live-check-error fallback, epic-unaffected, and the agent-enabled path.
+
+## Audit findings
+
+| # | Severity | Title | Status |
+|---|----------|-------|--------|
+| — | — | No findings. | — |
+
+## Non-findings (explicitly checked, clean)
+
+- **No secret exposure.** The live check returns only an `ok`/`expired` boolean-derived string; `prefill_driver.auth_status()` / `agent_client.auth_status()` never return or log token bytes (they stat `account.config`). The override additionally **clears** the steam `last_error`, removing any stale operator string from the response rather than adding data.
+- **Auth boundary unchanged.** `/api/v1/platforms` stays bearer-gated; no new endpoint or unauthenticated surface. `auth_status` (ok/expired) was already exposed by this endpoint — the change makes it *accurate*, not more revealing.
+- **Availability / DoS.** The added agent call is wrapped so it **never raises** (`except Exception → None`), and on any failure (agent down, no client/driver, transport error) it falls back to the stored column value — a broken/unreachable agent cannot 500 or hang the platforms read beyond the agent client's own bounded timeout+retry (PR #207). No unbounded work; the call runs once per request against a fixed 2-row endpoint.
+- **No injection / no new SQL.** No new query; the override is in-memory on the already-read row. Epic's row is never touched.
+- **Defensive parsing.** `bool(st["ok"])` tolerates truthy/falsy; a malformed agent response that lacks `ok` raises `KeyError` → caught → `None` → DB fallback (no 500).
+- **Information accuracy (positive).** Previously the column could only ever read "expired" for Steam (false negative) — now a genuinely-expired token will correctly read "expired" and a healthy one "ok", so the operator gets a truthful signal instead of a permanently-stale one.
+
+## Decision
+
+**Cleared to advance.** No SEV-1/2/3/4 findings. The change is additive, bearer-gated, secret-free, crash-safe (never raises, falls back to the stored value), and makes a previously-dead status field truthful. Covered by 6 new tests; ruff + mypy clean; full suite green.
+
+## Sign-off
+
+- Implementation: commit `<pending>` (appended after the green-phase commit lands)
+- Test suite: 1308 passed (`--ignore=tests/scripts`); 6 new platforms tests
+- ruff + mypy clean on `platforms.py`
+- No new dependency; no migration

--- a/src/orchestrator/api/routers/platforms.py
+++ b/src/orchestrator/api/routers/platforms.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ConfigDict, ValidationError
 
 from orchestrator.api._query_helpers import ERROR_TRUNCATE_BYTES
 from orchestrator.api.dependencies import get_pool_dep
+from orchestrator.core.settings import get_settings
 from orchestrator.db.pool import PoolError
 
 if TYPE_CHECKING:
@@ -54,6 +55,30 @@ class PlatformListResponse(BaseModel):
 
 
 router = APIRouter(prefix="/api/v1", tags=["platforms"])
+
+
+async def _live_steam_auth_status(request: Request) -> str | None:
+    """Steam's ``platforms.auth_status`` column has had NO writer since re-arch
+    ③c (the legacy ValvePython worker that wrote it was deleted), so it's frozen
+    at a stale value. Source Steam auth from the same LIVE signal ``/health``
+    uses — the data-plane agent (``agent_enabled``) or the local SteamPrefill
+    driver, each of which stats the persisted ``account.config``. Returns
+    ``"ok"``/``"expired"``, or ``None`` when it can't be determined (agent down /
+    no driver) so the caller falls back to the stored column value. Never raises."""
+    settings = get_settings()
+    try:
+        if settings.agent_enabled:
+            client = getattr(request.app.state, "agent_client", None)
+            if client is None:
+                return None
+            st = await client.auth_status()
+            return "ok" if bool(st["ok"]) else "expired"
+        driver = getattr(request.app.state, "prefill_driver", None)
+        if driver is None:
+            return None
+        return "ok" if driver.auth_status().ok else "expired"
+    except Exception:  # a live-check failure must never break the platforms read
+        return None
 
 
 @router.get(
@@ -106,19 +131,26 @@ async def list_platforms(
     # UAT-5 U5-2 parity: defensive per-row construction. Out-of-Literal
     # values in `name`/`auth_status`/`auth_method` would otherwise raise
     # ValidationError → 500.
+    live_steam = await _live_steam_auth_status(request)
     items: list[PlatformResponse] = []
     for row in rows:
+        auth_status = row["auth_status"]
+        last_error = row["last_error"]
+        # Steam's stored auth_status is orphaned (no writer since re-arch ③c) —
+        # override it with the live agent/driver signal when determinable, and
+        # clear the equally-stale last_error. Epic keeps its real DB value.
+        if row["name"] == "steam" and live_steam is not None:
+            auth_status = live_steam
+            last_error = None
         try:
             items.append(
                 PlatformResponse(
                     name=row["name"],
-                    auth_status=row["auth_status"],
+                    auth_status=auth_status,
                     auth_method=row["auth_method"],
                     auth_expires_at=row["auth_expires_at"],
                     last_sync_at=row["last_sync_at"],
-                    last_error=(
-                        row["last_error"][:ERROR_TRUNCATE_BYTES] if row["last_error"] else None
-                    ),
+                    last_error=(last_error[:ERROR_TRUNCATE_BYTES] if last_error else None),
                 )
             )
         except ValidationError as e:

--- a/tests/api/test_platforms_router.py
+++ b/tests/api/test_platforms_router.py
@@ -357,3 +357,116 @@ class TestPlatformsOrdering:
         )
         names = [p["name"] for p in r.json()["platforms"]]
         assert names == ["steam", "epic"]
+
+
+# ---------------------------------------------------------------------------
+# Steam auth_status sourced from the live agent/driver signal (the platforms
+# column has had NO Steam writer since re-arch ③c — it's orphaned/stale).
+# ---------------------------------------------------------------------------
+
+
+class TestSteamAuthLive:
+    class _StubDriver:
+        def __init__(self, ok):
+            self._ok = ok
+
+        def auth_status(self):
+            from types import SimpleNamespace
+
+            return SimpleNamespace(ok=self._ok)
+
+    def _co_located(self, monkeypatch):
+        from orchestrator.core.settings import Settings
+
+        monkeypatch.setattr(
+            "orchestrator.api.routers.platforms.get_settings",
+            lambda: Settings(orchestrator_token="a" * 32, agent_enabled=False),
+        )
+
+    async def _steam_row(self, unit_app):
+        import httpx
+
+        transport = httpx.ASGITransport(app=unit_app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as c:
+            r = await c.get("/api/v1/platforms", headers={"Authorization": f"Bearer {VALID_TOKEN}"})
+        assert r.status_code == 200
+        return next(p for p in r.json()["platforms"] if p["name"] == "steam")
+
+    async def test_live_driver_ok_overrides_stale_expired_column(
+        self, unit_app, populated_pool, monkeypatch
+    ):
+        self._co_located(monkeypatch)
+        await populated_pool.execute_write(
+            "UPDATE platforms SET auth_status='expired', last_error='stale' WHERE name='steam'"
+        )
+        unit_app.state.prefill_driver = self._StubDriver(ok=True)
+        steam = await self._steam_row(unit_app)
+        assert steam["auth_status"] == "ok"
+        assert steam["last_error"] is None  # stale last_error cleared on override
+
+    async def test_live_driver_not_ok_reports_expired(self, unit_app, populated_pool, monkeypatch):
+        self._co_located(monkeypatch)
+        await populated_pool.execute_write(
+            "UPDATE platforms SET auth_status='ok' WHERE name='steam'"
+        )
+        unit_app.state.prefill_driver = self._StubDriver(ok=False)
+        steam = await self._steam_row(unit_app)
+        assert steam["auth_status"] == "expired"
+
+    async def test_no_live_signal_falls_back_to_db(self, unit_app, populated_pool, monkeypatch):
+        # agent_enabled but no agent_client (or no driver) -> indeterminate -> DB value.
+        self._co_located(monkeypatch)  # co-located, but no prefill_driver on app.state
+        await populated_pool.execute_write(
+            "UPDATE platforms SET auth_status='expired' WHERE name='steam'"
+        )
+        steam = await self._steam_row(unit_app)
+        assert steam["auth_status"] == "expired"  # unchanged (defensive fallback)
+
+    async def test_live_check_error_falls_back_to_db(self, unit_app, populated_pool, monkeypatch):
+        self._co_located(monkeypatch)
+
+        class _BoomDriver:
+            def auth_status(self):
+                raise RuntimeError("driver boom")
+
+        await populated_pool.execute_write(
+            "UPDATE platforms SET auth_status='expired' WHERE name='steam'"
+        )
+        unit_app.state.prefill_driver = _BoomDriver()
+        steam = await self._steam_row(unit_app)
+        assert steam["auth_status"] == "expired"  # exception -> None -> DB fallback
+
+    async def test_epic_auth_status_unaffected(self, unit_app, populated_pool, monkeypatch):
+        self._co_located(monkeypatch)
+        await populated_pool.execute_write(
+            "UPDATE platforms SET auth_status='ok' WHERE name='epic'"
+        )
+        unit_app.state.prefill_driver = self._StubDriver(ok=False)  # would flip steam expired
+        import httpx
+
+        transport = httpx.ASGITransport(app=unit_app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as c:
+            r = await c.get("/api/v1/platforms", headers={"Authorization": f"Bearer {VALID_TOKEN}"})
+        epic = next(p for p in r.json()["platforms"] if p["name"] == "epic")
+        assert epic["auth_status"] == "ok"  # epic read from DB, never overridden
+
+    async def test_live_agent_signal_overrides_when_agent_enabled(
+        self, unit_app, populated_pool, monkeypatch
+    ):
+        from orchestrator.core.settings import Settings
+
+        monkeypatch.setattr(
+            "orchestrator.api.routers.platforms.get_settings",
+            lambda: Settings(orchestrator_token="a" * 32, agent_enabled=True),
+        )
+
+        class _StubAgent:
+            async def auth_status(self):
+                return {"ok": True}
+
+        await populated_pool.execute_write(
+            "UPDATE platforms SET auth_status='expired' WHERE name='steam'"
+        )
+        unit_app.state.agent_client = _StubAgent()
+        steam = await self._steam_row(unit_app)
+        assert steam["auth_status"] == "ok"


### PR DESCRIPTION
## Why

`AUTH:STEAM ✗ EXPIRED` from `orchestrator-cli status` was **false**. The `platforms.auth_status` column has had **no Steam writer since re-arch ③c** (the legacy ValvePython worker that wrote it was deleted — verified: every remaining `auth_status` writer is Epic-only). So the column was frozen at a stale `expired` and the CLI `status` + Game_shelf cache dashboard (both read `GET /api/v1/platforms`) showed Steam as EXPIRED **forever**, regardless of the real SteamPrefill session — which was healthy (the `--force` prefills ran fine hours earlier).

The SteamPrefill refresh token is long-lived (~200‑day JWT) — it *does* time-expire and can be invalidated early (password change / deauthorize-all / Steam Guard change), but **not** by routine concurrent logins. This case wasn't an expiry at all — just a dead status field.

## What

`GET /api/v1/platforms` now overrides the **steam** row's `auth_status` with the same LIVE signal `/health` already uses:
- `agent_client.auth_status()` when `agent_enabled`, else `prefill_driver.auth_status()` — each stats the persisted `account.config`.
- Clears the equally-stale `last_error` for steam.
- **Defensive:** when the signal can't be determined (agent down / no client / any exception) it falls back to the stored column value and **never raises** — a broken agent can't 500 the platforms read.
- **Epic unchanged** (it has a real writer).

One change fixes both surfaces (CLI `status` and the Game_shelf dashboard read this endpoint).

## Test plan
- 6 new tests: override-ok, override-expired, no-signal fallback, live-check-error fallback, epic-unaffected, agent-enabled path.
- Full suite **1308 passed** (only the documented `tests/test_licenses.py` local pip-licenses failure); ruff + mypy clean.
- Security audit: `docs/security-audits/steam-auth-status-live-security-audit.md` — no findings (bearer-gated, secret-free, crash-safe).

## Deploy
Control-plane only (LXC 1105); no agent rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)