### PR TITLE
fix(uat-13): status-page never-raises + deterministic manifest-capture path (#210, #211)

### DIFF
--- a/.claude/build-progress.json
+++ b/.claude/build-progress.json
@@ -27,12 +27,12 @@
     "steam-auth-status-live",
     "validate-gid-match"
   ],
-  "features_since_last_test": 2,
+  "features_since_last_test": 0,
   "features_since_last_health_check": 4,
   "test_interval": 2,
   "last_test_session": "2026-06-30",
-  "testing_required": true,
+  "testing_required": false,
   "tester_count": 1,
   "bug_tracker": "github_issues",
-  "sessions_completed": 12
+  "sessions_completed": 13
 }

--- a/.claude/process-state.json
+++ b/.claude/process-state.json
@@ -6,7 +6,7 @@
     "started_at": null
   },
   "uat_session": {
-    "session_id": 12,
+    "session_id": 13,
     "step": 9,
     "steps_completed": [
       "agents_dispatched",
@@ -19,7 +19,7 @@
       "remediation_complete",
       "gate_passed"
     ],
-    "started_at": "2026-06-30T17:03:29Z"
+    "started_at": "2026-06-30T21:20:44Z"
   },
   "phase3_validation": {
     "steps_completed": [],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — UAT-13 hardening: status-page never-raises + deterministic manifest-capture path (2026-06-30) — 2026-06-30
+
+UAT-13 adversarial review of #208/#209 surfaced two verified SEV-2 silent-failure modes (both confirmed *not* breaking the live deployment — hardening, fixed test-first). See #210, #211.
+
+- **`api/routers/platforms.py` (#210):** `_live_steam_auth_status()` called `get_settings()` *outside* its try/except, so a settings failure (e.g. a future runtime reload with invalid config) would have propagated uncaught and 500'd the status page — violating the function's documented "Never raises" contract. `get_settings()` is now inside the try, so any failure falls back to the stored column value.
+- **`platform/steam/prefill_driver.py` + `agent/app.py` (#211, prevention):** the capture's source path assumed the agent's `HOME=/tmp` but nothing enforced it — a deploy that omitted the env would silently strand SteamPrefill's manifests and re-introduce the false-Partial bug. `SteamPrefillDriver` now accepts `home` and pins the SteamPrefill subprocess `HOME` (derived from the same `steam_prefill_live_cache_dir` the capture reads), so SteamPrefill writes where the capture reads *by construction*. Identical live behavior (`HOME` stays `/tmp`); the control-plane fallback driver is unchanged (it delegates to the agent).
+- **`agent/routers/steam.py` (#211, observability):** after a successful prefill, the agent now logs a `steam_prefill.live_cache_missing` **warning** if the live cache `/v1` dir is absent — the unambiguous HOME-drift symptom — so a path mismatch is loud instead of a silent `copied=0`. Does not false-positive on the normal already-archived→0-copied case. 5 new tests; no migration.
+
 ### Fixed — False "Partial" badges: validate now pins to the prefilled manifest gid + captures agent manifests (2026-06-30) — 2026-06-30
 
 A force-prefilled game (e.g. "All Hail the Orb") could sit at a stable "Partial · 71%" even though it was fully cached for its current version. Root cause (live-traced): the agent runs SteamPrefill with `HOME=/tmp`, so SteamPrefill writes its manifest to `/tmp/.cache/SteamPrefill` — **not** the host cache (`steam_manifest_cache_dir`) the durable archive-sync reads — so agent-driven (force-)prefills' manifests were never archived. The validator then fell back to the **newest archived manifest by mtime**, which for these games was a months-old build; the chunks unique to that stale version no longer exist, so they counted "missing" forever and no prefill could close the gap.

--- a/src/orchestrator/agent/app.py
+++ b/src/orchestrator/agent/app.py
@@ -62,6 +62,10 @@ def create_agent_app(*, settings: Settings | None = None) -> FastAPI:
             app.state.prefill_driver = SteamPrefillDriver(
                 binary=settings.steam_prefill_binary,
                 config_dir=settings.steam_prefill_config_dir,
+                # Pin SteamPrefill's HOME so its $HOME/.cache/SteamPrefill manifest
+                # cache is steam_prefill_live_cache_dir (the dir the capture reads),
+                # by construction — not by relying on the deploy env (UAT-13 F2).
+                home=Path(settings.steam_prefill_live_cache_dir).parent.parent,
             )
         interval = settings.manifest_archive_sync_interval_sec
         if interval > 0:
@@ -97,6 +101,7 @@ def create_agent_app(*, settings: Settings | None = None) -> FastAPI:
     app.state.prefill_driver = SteamPrefillDriver(
         binary=settings.steam_prefill_binary,
         config_dir=settings.steam_prefill_config_dir,
+        home=Path(settings.steam_prefill_live_cache_dir).parent.parent,
     )
     app.include_router(health.router)
     app.include_router(pull.router)

--- a/src/orchestrator/agent/routers/steam.py
+++ b/src/orchestrator/agent/routers/steam.py
@@ -49,6 +49,20 @@ async def start_prefill(body: SteamPrefillRequest, request: Request) -> dict[str
         try:
             result = await driver.prefill_apps(body.app_ids, force=body.force)
             if result.ok:
+                # A successful prefill always writes its manifest(s) to the HOME
+                # cache, so a MISSING live cache dir means SteamPrefill's HOME and
+                # steam_prefill_live_cache_dir have drifted apart — the capture
+                # would silently no-op and false-Partial badges would silently
+                # return. Make that loud (UAT-13 F2b). (The driver pins HOME from
+                # this same setting, so this should never fire — it's the canary.)
+                live_v1 = Path(settings.steam_prefill_live_cache_dir) / "v1"
+                if not live_v1.is_dir():
+                    _log.warning(
+                        "steam_prefill.live_cache_missing",
+                        job_id=job_id,
+                        live_cache=str(live_v1),
+                        hint="HOME/.cache path mismatch; manifests NOT captured — check agent HOME",
+                    )
                 # Capture the manifest(s) SteamPrefill just wrote to its HOME
                 # cache (the agent runs it with HOME=/tmp) into the durable
                 # archive. The periodic archive-sync only reads the host cache, so

--- a/src/orchestrator/api/routers/platforms.py
+++ b/src/orchestrator/api/routers/platforms.py
@@ -65,8 +65,8 @@ async def _live_steam_auth_status(request: Request) -> str | None:
     driver, each of which stats the persisted ``account.config``. Returns
     ``"ok"``/``"expired"``, or ``None`` when it can't be determined (agent down /
     no driver) so the caller falls back to the stored column value. Never raises."""
-    settings = get_settings()
     try:
+        settings = get_settings()
         if settings.agent_enabled:
             client = getattr(request.app.state, "agent_client", None)
             if client is None:

--- a/src/orchestrator/platform/steam/prefill_driver.py
+++ b/src/orchestrator/platform/steam/prefill_driver.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -25,9 +26,16 @@ class SteamAuthStatus:
 
 
 class SteamPrefillDriver:
-    def __init__(self, *, binary: Path, config_dir: Path) -> None:
+    def __init__(self, *, binary: Path, config_dir: Path, home: Path | None = None) -> None:
         self._binary = Path(binary)
         self._config_dir = Path(config_dir)
+        # SteamPrefill writes its manifest cache to ``$HOME/.cache/SteamPrefill``.
+        # When ``home`` is set, the subprocess HOME is pinned so manifests land
+        # where the durable-archive capture reads (steam_prefill_live_cache_dir),
+        # regardless of the container's inherited HOME — otherwise a deploy that
+        # omits ``-e HOME=/tmp`` silently strands manifests and re-introduces the
+        # false-Partial bug (UAT-13 F2 / #211). None preserves prior env-inherit.
+        self._home = None if home is None else Path(home)
 
     @property
     def _selection_path(self) -> Path:
@@ -45,9 +53,11 @@ class SteamPrefillDriver:
             # of our config_dir so ./Config maps to exactly config_dir —
             # otherwise it finds no account.config and login fails (the failure
             # is masked by a Spectre.Console crash; see the 2026-06-21 flip).
+            env = None if self._home is None else {**os.environ, "HOME": str(self._home)}
             proc = await asyncio.create_subprocess_exec(
                 *args,
                 cwd=str(self._config_dir.parent),
+                env=env,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
             )

--- a/tests/agent/test_steam.py
+++ b/tests/agent/test_steam.py
@@ -113,6 +113,66 @@ def test_prefill_capture_failure_does_not_fail_the_job(tmp_path):
     assert snap["result"]["ok"] is True
 
 
+def test_prefill_warns_when_live_cache_dir_missing(tmp_path):
+    """A successful prefill whose live cache /v1 dir is absent (the HOME-drift
+    symptom) must log a loud WARNING — otherwise the capture silently no-ops and
+    false-Partial badges silently return (UAT-13 F2b / #211)."""
+    import structlog
+
+    app = create_agent_app(
+        settings=Settings(
+            orchestrator_token="a" * 32,
+            steam_prefill_live_cache_dir=tmp_path / "missing-live",  # no /v1 subdir
+            steam_manifest_archive_dir=tmp_path / "archive",
+        )
+    )
+    app.state.prefill_driver = _FakeDriver()
+    client = TestClient(app, headers={"Authorization": "Bearer " + "a" * 32})
+    with structlog.testing.capture_logs() as logs:
+        job_id = client.post("/v1/steam/prefill", json={"app_ids": [440], "force": False}).json()[
+            "job_id"
+        ]
+        for _ in range(50):
+            snap = client.get(f"/v1/steam/prefill/{job_id}").json()
+            if snap["state"] == "done":
+                break
+            time.sleep(0.02)
+    assert snap["state"] == "done"
+    warnings = [m for m in logs if m.get("event") == "steam_prefill.live_cache_missing"]
+    assert warnings, "expected a live_cache_missing warning when the live cache dir is absent"
+    assert warnings[0]["log_level"] == "warning"
+
+
+def test_prefill_no_warning_when_live_cache_dir_present(tmp_path):
+    """The drift warning must NOT fire on the normal path (live cache dir exists,
+    even if nothing new was copied) — it is a path-mismatch signal, not a
+    nothing-to-capture signal."""
+    import structlog
+
+    live = tmp_path / "live"
+    (live / "v1").mkdir(parents=True)
+    app = create_agent_app(
+        settings=Settings(
+            orchestrator_token="a" * 32,
+            steam_prefill_live_cache_dir=live,
+            steam_manifest_archive_dir=tmp_path / "archive",
+        )
+    )
+    app.state.prefill_driver = _FakeDriver()  # writes no manifest -> 0 copied, dir present
+    client = TestClient(app, headers={"Authorization": "Bearer " + "a" * 32})
+    with structlog.testing.capture_logs() as logs:
+        job_id = client.post("/v1/steam/prefill", json={"app_ids": [440], "force": False}).json()[
+            "job_id"
+        ]
+        for _ in range(50):
+            snap = client.get(f"/v1/steam/prefill/{job_id}").json()
+            if snap["state"] == "done":
+                break
+            time.sleep(0.02)
+    assert snap["state"] == "done"
+    assert not [m for m in logs if m.get("event") == "steam_prefill.live_cache_missing"]
+
+
 def test_downloaded_state():
     client = _client(_FakeDriver())
     resp = client.get("/v1/steam/downloaded-state")

--- a/tests/api/test_platforms_router.py
+++ b/tests/api/test_platforms_router.py
@@ -436,6 +436,20 @@ class TestSteamAuthLive:
         steam = await self._steam_row(unit_app)
         assert steam["auth_status"] == "expired"  # exception -> None -> DB fallback
 
+    async def test_get_settings_error_falls_back_to_db(self, unit_app, populated_pool, monkeypatch):
+        # The docstring promises "Never raises". A get_settings() failure (e.g. a
+        # future runtime reload with invalid config) must fall back to the stored
+        # column value, NOT 500 the status page (UAT-13 F1 / #210).
+        def _boom():
+            raise RuntimeError("settings boom")
+
+        monkeypatch.setattr("orchestrator.api.routers.platforms.get_settings", _boom)
+        await populated_pool.execute_write(
+            "UPDATE platforms SET auth_status='ok' WHERE name='steam'"
+        )
+        steam = await self._steam_row(unit_app)  # asserts HTTP 200 internally
+        assert steam["auth_status"] == "ok"  # get_settings() raised -> None -> DB fallback
+
     async def test_epic_auth_status_unaffected(self, unit_app, populated_pool, monkeypatch):
         self._co_located(monkeypatch)
         await populated_pool.execute_write(

--- a/tests/platform/steam/test_prefill_driver.py
+++ b/tests/platform/steam/test_prefill_driver.py
@@ -52,6 +52,39 @@ async def test_prefill_apps_runs_from_config_parent_cwd(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_prefill_apps_pins_subprocess_home(tmp_path):
+    # SteamPrefill writes its manifest cache to $HOME/.cache/SteamPrefill; the
+    # driver must pin the subprocess HOME so manifests land where the capture
+    # reads, regardless of the container's inherited HOME (UAT-13 F2 / #211).
+    cfg = tmp_path / "Config"
+    cfg.mkdir()
+    home = tmp_path / "pinned_home"
+    marker = tmp_path / "home.txt"
+    bin_path = tmp_path / "FakeSteamPrefill"
+    bin_path.write_text(f'#!/bin/sh\nprintf %s "$HOME" > "{marker}"\nexit 0\n')
+    bin_path.chmod(bin_path.stat().st_mode | stat.S_IEXEC)
+    d = SteamPrefillDriver(binary=bin_path, config_dir=cfg, home=home)
+    await d.prefill_apps([730])
+    assert marker.read_text().strip() == str(home)
+
+
+@pytest.mark.asyncio
+async def test_prefill_apps_home_none_inherits_env(tmp_path, monkeypatch):
+    # Default home=None preserves prior behavior: the subprocess inherits the
+    # process environment's HOME (no env override).
+    cfg = tmp_path / "Config"
+    cfg.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path / "inherited"))
+    marker = tmp_path / "home.txt"
+    bin_path = tmp_path / "FakeSteamPrefill"
+    bin_path.write_text(f'#!/bin/sh\nprintf %s "$HOME" > "{marker}"\nexit 0\n')
+    bin_path.chmod(bin_path.stat().st_mode | stat.S_IEXEC)
+    d = SteamPrefillDriver(binary=bin_path, config_dir=cfg)
+    await d.prefill_apps([730])
+    assert marker.read_text().strip() == str(tmp_path / "inherited")
+
+
+@pytest.mark.asyncio
 async def test_prefill_apps_nonzero_exit_not_ok(tmp_path):
     cfg = tmp_path / "Config"
     cfg.mkdir()

--- a/tests/uat/sessions/2026-06-30-session-13/templates/test-session-13-v1.md
+++ b/tests/uat/sessions/2026-06-30-session-13/templates/test-session-13-v1.md
@@ -1,0 +1,56 @@
+# UAT Session 13 — v1
+
+**Date:** 2026-06-30
+**Tester(s):** Claude (agent-driven adversarial review + live-system validation on the boxes)
+**Features under test (2 since UAT-12):**
+- `steam-auth-status-live` (PR #208) — source the steam platform `auth_status` from the live `/health` signal instead of the stale orphaned DB column.
+- `validate-gid-match` (PR #209) — pin steam validate to the prefilled manifest gid + capture agent manifests into the durable archive (fixes false "Partial · N%" badges).
+
+---
+
+## Method
+
+1. **Automated suite** — full `pytest` run (baseline regression).
+2. **Adversarial review workflow** — 8 finder dimensions across both features (auth-status correctness, auth-status edge/malicious, locator gid-match, validate wiring, capture safety, settings, secret-exposure, regression/import-isolation), each finding then refute-verified by 2 perspective-diverse skeptics (correctness + reproduce lenses). Findings survive only if ≥1 verifier confirms the defect is real after reading the actual code.
+3. **Live-system validation** — observed both features against the deployed control plane (LXC 1105) and data-plane agent (UGREEN .40). Mandatory per the live-validation rule for credentialed integrations.
+
+---
+
+## Results
+
+### Automated suite
+- **1316 passed**, 3 deselected, 1 warning. Only failure: `tests/test_licenses.py::test_all_licenses_in_allowlist` — documented local pip-licenses tooling gap, not a code defect.
+
+### Live validation
+| Feature | Live observation | Verdict |
+|---------|------------------|---------|
+| #208 auth-status | `GET /api/v1/platforms` on 1105 → steam `auth_status='ok'` (the stale "expired" is gone); epic `ok`. | ✅ PASS |
+| #209 gid-match | "All Hail the Orb" 71%-false → **335/335 true**. Library-wide: 856 steam games full / 246 genuinely partial, all now showing *real* percentages (L4D2 2.4%, Borderlands 3 4.2%, Fallout 4 11%…). | ✅ PASS |
+| #209 capture (live) | Agent `HOME=/tmp` confirmed; `/manifest-archive/v1` at **2529 .bin**, newest = `4262310_4262310_4262311_5398521309404131186.bin` (Orb's prefilled gid, captured today 20:50). Capture working live. | ✅ PASS |
+| Sweep health | Lone `sweep failed` (job 34297) = ID6 reaper marking the in-flight sweep failed when I redeployed the control container for #209; replaced by running sweep 34299. Expected, not a defect. | ✅ benign |
+
+### Adversarial review — confirmed findings (2 of 3 raised survived verify)
+
+**F1 (SEV-2, #208) — `_live_steam_auth_status` can raise (invariant violation).**
+`get_settings()` at `platforms.py:68` sits *outside* the function's try/except, but the docstring promises "Never raises." If `get_settings()` ever raises (e.g. a future runtime `reload_settings()` / `cache_clear()` with invalid config), it propagates uncaught → HTTP 500 on the status page (CLI + Game_shelf dashboard). Latent today (no runtime reload is wired), but a real invariant violation.
+
+**F2 (SEV-2, #209) — manifest-capture HOME assumption unenforced + silent on drift.**
+SteamPrefill writes manifests to `$HOME/.cache/SteamPrefill`; the capture reads `steam_prefill_live_cache_dir` (default `/tmp/.cache/SteamPrefill`). They match *only* because the deploy script sets `HOME=/tmp` — nothing in the image or driver enforces it, and `sync_manifests_to_archive` silently returns 0 (logged only at INFO) when the source dir is absent. A future deploy that omits the env would silently re-introduce the false-Partial bug. **Verified not broken live** (HOME=/tmp is set; archive growing), so this is hardening, not live breakage.
+
+**Refuted / not surfaced:** secret-exposure (clean — only public manifest gids are logged), import-isolation (preserved), backward-compat of the locator change (prefilled_gids=None preserves prior behavior), validate 500-safety (downloaded_state wrapped), capture-never-fails-job (wrapped).
+
+---
+
+## Triage
+
+| # | Severity | Decision | Rationale |
+|---|----------|----------|-----------|
+| F1 | SEV-2 | **Fix Now** | Cheap; makes the documented "Never raises" invariant actually hold on a status-page endpoint. |
+| F2 | SEV-2 | **Fix Now** | Eliminates a silent-failure mode in the just-shipped subsystem; make the cache path deterministic by construction + loud on drift. |
+
+No SEV-1. Both fixed test-first in this session (see remediation PR).
+
+## Remediation (test-first)
+- **F1:** move `get_settings()` inside the try → returns `None` (falls back to stored value) on any settings failure.
+- **F2a (prevention):** `SteamPrefillDriver` sets the subprocess `HOME` from the same `steam_prefill_live_cache_dir` setting the capture reads, so SteamPrefill writes where capture reads regardless of container `HOME`. Identical live behavior (HOME stays `/tmp`).
+- **F2b (observability):** capture logs a WARNING when the live cache `/v1` dir is missing after a successful prefill (the unambiguous drift symptom).


### PR DESCRIPTION
## UAT-13 remediation

UAT session 13 (gate tripped 2/2 after `steam-auth-status-live` #208 + `validate-gid-match` #209). 8-dimension adversarial review + full live-system validation on the boxes. **Both shipped features PASS live:**

- **#208** — steam `auth_status='ok'` on 1105 (stale "expired" gone).
- **#209** — "All Hail the Orb" 71%-false → 335/335 true; library now shows real partial %s; agent archive at 2529 manifests with the freshly-captured Orb manifest at the correct gid.

Review surfaced **2 verified SEV-2 silent-failure modes** (3 raised, 2 survived adversarial verify). Both confirmed **not** breaking the live deployment — hardening, fixed test-first.

### Findings fixed
| # | Issue | Fix |
|---|-------|-----|
| F1 | #210 | `_live_steam_auth_status()` called `get_settings()` outside its try → could 500 the status page, violating "Never raises". Moved inside the try → falls back to stored value. |
| F2 (prevention) | #211 | Capture's HOME assumption unenforced → silent strand on drift. `SteamPrefillDriver` now pins the SteamPrefill subprocess `HOME` from the same `steam_prefill_live_cache_dir` the capture reads → writes-where-it-reads by construction. Same live behavior. |
| F2 (observability) | #211 | Agent now logs a `steam_prefill.live_cache_missing` WARNING when the live cache dir is absent after a successful prefill — loud instead of a silent `copied=0`. |

### Verification
- **5 new tests** (platforms +1, driver +2, capture +2), all test-first (red→green).
- Full suite **1321 passed** (only the documented `test_licenses.py` local-tooling failure); **mypy** clean (88 files); **ruff** clean.
- Control-plane fallback driver intentionally unchanged (it delegates to the agent).
- No migration.

UAT-13 checklist complete (9/9); gate reset. Session record: `tests/uat/sessions/2026-06-30-session-13/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)