### PR TITLE
fix(manifest-fetcher): enumerate selected apps + DepotDownloader IsolatedStorage HOME (go-live)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — Steam manifest fetcher: enumeration source + DepotDownloader session path (go-live, 2026-07-01) — 2026-07-01
+
+Two bugs found during live go-live (both in `platform/steam/manifest_fetcher.py`), fixed with the operator's 2FA session preserved (no re-login):
+- **Enumeration** now reads `selectedAppsToPrefill.json` (the operator's clean store app_ids) instead of unioning in `successfullyDownloadedDepots.json`, whose keys are content/depot ids DepotDownloader can't get an access token for (`Insufficient privileges`) — the `manifest_locator` module already flagged that file as an unreliable index.
+- **DepotDownloader persists its `-remember-password` session in .NET IsolatedStorage under `$HOME`** (not the working dir), so the fetcher now runs DD with `HOME=<config_dir>` (the persistent mount) and `login_from_session` checks the IsolatedStorage `account.config` there. Live-verified: the preserved session authenticates as the operator and the selected apps fetch manifests cleanly.
+
 ### Added — Steam manifest-only fetcher closes the validation-coverage gap (2026-06-30) — 2026-06-30
 
 Adds a new `fetch_manifests` job that runs DepotDownloader with `-manifest-only` to produce `.shas` sidecars (one chunk SHA per line) for every prefilled Steam app — without re-downloading any game content. This closes the validation gap where SteamPrefill only wrote a manifest `.bin` for apps with new content and pruned the rest via `clear-temp`, leaving ~747 of ~1077 prefilled apps returning `no_manifest_in_cache` and unvalidatable despite having ~13 TB of chunks on disk. The validator already reads `.shas` alongside `.bin`, so once a fetch run completes, the full prefilled set can be validated.

--- a/src/orchestrator/platform/steam/manifest_fetcher.py
+++ b/src/orchestrator/platform/steam/manifest_fetcher.py
@@ -9,6 +9,7 @@ tests/agent/test_import_isolation.py). NEVER logs/writes the Steam password,
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import tempfile
@@ -37,9 +38,12 @@ class FetchResult:
     apps: int
 
 
-# S2: the persisted login-key filename DepotDownloader writes under config_dir
-# (own-session path) — or SteamPrefill's account.config (reuse path). Confirm in S2.
-_SESSION_MARKER = "account.config"
+# DepotDownloader persists its -remember-password session in .NET IsolatedStorage
+# under $HOME (we run DD with HOME=config_dir), at a hash-named path like
+# config_dir/.local/share/IsolatedStorage/<a>/<b>/<c>/AssemFiles/account.config
+# (go-live finding 2026-07-01 — the earlier "config_dir/account.config" marker was
+# wrong; DD never writes the account store to the working dir).
+_SESSION_GLOB = ".local/share/IsolatedStorage/**/account.config"
 
 
 class DepotDownloaderManifestFetcher:
@@ -61,33 +65,35 @@ class DepotDownloaderManifestFetcher:
         self._username = username
 
     def login_from_session(self) -> None:
-        """Verify a usable persisted session exists (no password, no 2FA).
-        Raises SteamAuthError when absent so the caller surfaces 're-auth needed'
-        instead of prompting in an unattended run."""
-        if not (self._config_dir / _SESSION_MARKER).exists():
+        """Verify a usable persisted DepotDownloader session exists (no password,
+        no 2FA) — the .NET IsolatedStorage account.config under config_dir (see
+        _SESSION_GLOB). Raises SteamAuthError when absent so the caller surfaces
+        're-auth needed' instead of prompting in an unattended run."""
+        if not any(self._config_dir.glob(_SESSION_GLOB)):
             raise SteamAuthError("no DepotDownloader session — run the one-time login")
 
     def _enumerate_app_ids(self) -> list[int]:
-        """The cached app set, read LIVE each run (auto-grows; nothing hardcoded).
-        Union of successfullyDownloadedDepots.json keys (what's cached) and
-        selectedAppsToPrefill.json (selected) — S3 confirms completeness."""
+        """Store app_ids to fetch, read LIVE from SteamPrefill's SELECTION each run
+        (auto-grows; nothing hardcoded). Uses selectedAppsToPrefill.json — the
+        operator's clean store app_ids. NOT successfullyDownloadedDepots.json: its
+        keys include content/depot ids DepotDownloader can't get an access token
+        for ("Insufficient privileges", go-live finding 2026-07-01) and which the
+        locator module already flags as an unreliable index."""
+        p = self._steam_config_dir / "selectedAppsToPrefill.json"
+        if not p.exists():
+            return []
+        try:
+            data = json.loads(p.read_text())
+        except (OSError, json.JSONDecodeError):
+            return []
+        if not isinstance(data, list):
+            return []
         apps: set[int] = set()
-        for name in ("successfullyDownloadedDepots.json", "selectedAppsToPrefill.json"):
-            p = self._steam_config_dir / name
-            if not p.exists():
-                continue
+        for k in data:
             try:
-                data = json.loads(p.read_text())
-            except (OSError, json.JSONDecodeError):
+                apps.add(int(k))
+            except (TypeError, ValueError):
                 continue
-            if not isinstance(data, (dict, list)):
-                continue  # scalar JSON (bare null/42) — skip, not a TypeError
-            keys = data.keys() if isinstance(data, dict) else data
-            for k in keys:
-                try:
-                    apps.add(int(k))
-                except (TypeError, ValueError):
-                    continue
         return sorted(apps)
 
     def _write_shas(self, app_id: int, depot_id: int, gid: str, shas: set[str]) -> bool:
@@ -108,9 +114,11 @@ class DepotDownloaderManifestFetcher:
     def _run_manifest_only(self, app_id: int) -> list[tuple[int, str, set[str]]]:
         """Shell out to DepotDownloader with -manifest-only for one app.
         Returns [(depot_id, gid, chunk_shas)] for every depot manifest written.
-        Username is taken from _SESSION_MARKER's sibling config; DD reads the
-        remembered login key from config_dir — the password is NEVER on argv."""
+        DD reads its remembered login key from the .NET IsolatedStorage under
+        HOME, so the subprocess HOME is pinned to config_dir (the persistent
+        mount) — the password is NEVER on argv and never persisted by us."""
         results: list[tuple[int, str, set[str]]] = []
+        env = {**os.environ, "HOME": str(self._config_dir)}
         with tempfile.TemporaryDirectory() as scratch:
             scratch_path = Path(scratch)
             argv = [
@@ -131,6 +139,7 @@ class DepotDownloaderManifestFetcher:
             proc = subprocess.run(  # noqa: S603
                 argv,
                 cwd=str(self._config_dir),
+                env=env,
                 capture_output=True,
                 text=True,
                 timeout=300,

--- a/tests/platform/steam/test_manifest_fetcher.py
+++ b/tests/platform/steam/test_manifest_fetcher.py
@@ -1,5 +1,6 @@
 import contextlib
 import json
+import shutil
 
 import pytest
 
@@ -11,6 +12,15 @@ from orchestrator.platform.steam.manifest_fetcher import (
 
 _SHA_A = "a" * 40
 _SHA_B = "b" * 40
+
+
+def _make_session(config_dir):
+    """Create the .NET IsolatedStorage account.config DepotDownloader persists
+    under HOME (=config_dir), so login_from_session's glob finds it."""
+    p = config_dir / ".local/share/IsolatedStorage/aa/bb/cc/AssemFiles/account.config"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(b"\x00token")
+    return p
 
 
 def _fetcher(tmp_path, **kw):
@@ -27,12 +37,11 @@ def _fetcher_with_fake_dd(tmp_path, manifests):
     """manifests: {app_id: [(depot_id, gid, [shas])]} the fake DD 'returns'."""
     cfg = tmp_path / "dd-config"
     cfg.mkdir()
-    (cfg / "account.config").write_bytes(b"\x00")
+    _make_session(cfg)
     steam_cfg = tmp_path / "Config"
     steam_cfg.mkdir()
-    (steam_cfg / "successfullyDownloadedDepots.json").write_text(
-        json.dumps({str(a): [g for _d, g, _s in v] for a, v in manifests.items()})
-    )
+    # Enumeration reads selectedAppsToPrefill.json (a list of clean store app_ids).
+    (steam_cfg / "selectedAppsToPrefill.json").write_text(json.dumps([int(a) for a in manifests]))
     f = DepotDownloaderManifestFetcher(
         binary=tmp_path / "DepotDownloader",
         config_dir=cfg,
@@ -54,10 +63,10 @@ def test_login_from_session_raises_when_no_session(tmp_path):
         f.login_from_session()
 
 
-def test_login_from_session_ok_when_session_present(tmp_path):
+def test_login_from_session_ok_when_isolated_storage_present(tmp_path):
     cfg = tmp_path / "dd-config"
     cfg.mkdir()
-    (cfg / "account.config").write_bytes(b"\x00token")  # S2: the persisted login key
+    _make_session(cfg)  # the .NET IsolatedStorage account.config DD persists
     _fetcher(tmp_path, config_dir=cfg).login_from_session()  # no raise
 
 
@@ -97,7 +106,7 @@ def test_fetch_all_isolates_per_app_failure(tmp_path):
 
 def test_fetch_all_raises_auth_when_no_session(tmp_path):
     f = _fetcher_with_fake_dd(tmp_path, {440: []})
-    (f._config_dir / "account.config").unlink()
+    shutil.rmtree(f._config_dir / ".local")  # remove the IsolatedStorage session
     with pytest.raises(SteamAuthError):
         f.fetch_all()
 
@@ -154,6 +163,35 @@ def test_run_manifest_only_includes_username_in_argv(tmp_path, monkeypatch):
     assert argv[argv.index("-username") + 1] == "steamjoe"
 
 
+def test_run_manifest_only_pins_home_to_config_dir(tmp_path, monkeypatch):
+    """DD's -remember-password session lives in .NET IsolatedStorage under HOME,
+    so the subprocess HOME is pinned to config_dir (the persistent mount)."""
+    captured: dict = {}
+
+    def _fake_run(argv, **kw):
+        captured["env"] = kw.get("env")
+
+        class _R:
+            returncode = 0
+            stderr = ""
+
+        return _R()
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    cfg = tmp_path / "dd-config"
+    f = DepotDownloaderManifestFetcher(
+        binary=tmp_path / "DepotDownloader",
+        config_dir=cfg,
+        steam_config_dir=tmp_path / "Config",
+        archive_dir=tmp_path / "archive",
+        delay_sec=0.0,
+        username="steamjoe",
+    )
+    with contextlib.suppress(RuntimeError):
+        f._run_manifest_only(440)
+    assert captured["env"]["HOME"] == str(cfg)
+
+
 def test_write_shas_empty_returns_false_no_file(tmp_path):
     """_write_shas returns False and writes NO file when the SHA set has no valid SHAs."""
     f = _fetcher(tmp_path)
@@ -192,11 +230,33 @@ def test_fetch_all_skipped_all_archived_no_raise(tmp_path):
 
 
 def test_enumerate_app_ids_skips_scalar_json(tmp_path):
-    """A successfullyDownloadedDepots.json that contains bare null/42 (scalar)
-    must not raise TypeError — the file is silently skipped (Minor fix)."""
+    """A selectedAppsToPrefill.json that contains bare null/42 (scalar) must not
+    raise TypeError — the file is silently treated as empty."""
     cfg = tmp_path / "Config"
     cfg.mkdir()
-    (cfg / "successfullyDownloadedDepots.json").write_text("null")
+    (cfg / "selectedAppsToPrefill.json").write_text("null")
     f = _fetcher(tmp_path, steam_config_dir=cfg)
-    # Must return an empty list, not raise TypeError
     assert f._enumerate_app_ids() == []
+
+
+def test_enumerate_reads_selected_not_downloaded_depots(tmp_path):
+    """Go-live fix: enumerate the clean store app_ids in selectedAppsToPrefill.json
+    and IGNORE successfullyDownloadedDepots.json (whose keys are content/depot ids
+    DepotDownloader can't token)."""
+    cfg = tmp_path / "Config"
+    cfg.mkdir()
+    (cfg / "selectedAppsToPrefill.json").write_text(json.dumps([258090, 207650, 92300]))
+    # A successfullyDownloadedDepots.json with different (content/depot) keys must
+    # NOT be picked up.
+    (cfg / "successfullyDownloadedDepots.json").write_text(
+        json.dumps({"1968731": [1], "2900140": [2]})
+    )
+    f = _fetcher(tmp_path, steam_config_dir=cfg)
+    assert f._enumerate_app_ids() == [92300, 207650, 258090]
+
+
+def test_enumerate_missing_selection_returns_empty(tmp_path):
+    """No selectedAppsToPrefill.json -> empty (no raise)."""
+    cfg = tmp_path / "Config"
+    cfg.mkdir()
+    assert _fetcher(tmp_path, steam_config_dir=cfg)._enumerate_app_ids() == []


### PR DESCRIPTION
## Go-live findings (both live-diagnosed on the agent host)
Deploying #213 and doing the one-time DepotDownloader login surfaced two real bugs in `platform/steam/manifest_fetcher.py`. **Your 2FA session is preserved** (copied into the persistent volume) — no re-login needed.

### 1. Enumeration source
`_enumerate_app_ids` unioned `successfullyDownloadedDepots.json` keys — but those aren't clean store app_ids (they're content/depot ids), so DepotDownloader returns **"Insufficient privileges to get access token"** for them. The `manifest_locator` module already flags that file as an unreliable index. **Fix:** enumerate from `selectedAppsToPrefill.json` only (the operator's clean store app_ids; auto-grows).

**Live proof:** testing the `successfullyDownloadedDepots` keys → 4/6 "insufficient privileges"; testing the `selectedAppsToPrefill` apps (258090, 1182900, 207650, 92300, 15560) → all fetch manifests cleanly.

### 2. DepotDownloader session persistence
DD stores its `-remember-password` session in **.NET IsolatedStorage under `$HOME`** (`$HOME/.local/share/IsolatedStorage/…/account.config`) — **not** the working dir, as the original S2 spike assumed (anonymous spikes never persist a session, so only the live authenticated login exposed it). **Fix:** run DD with `HOME=<config_dir>` (the persistent mount) so the session lands durably, and `login_from_session` checks the IsolatedStorage `account.config` there.

**Live proof:** with `HOME=/depotdownloader-config` + the preserved session, DD logs in as `kraulerson` (no prompt, "Got 1257 licenses") and fetches owned-app manifests.

## Tests
7 fetcher tests updated + 3 new (enumeration reads selected/ignores downloaded-depots; IsolatedStorage session glob; DD subprocess pins `HOME`). **1360 pass**; mypy + ruff + import-isolation clean. Agent-only change (control plane unaffected).

## Deploy (after merge — agent only)
Rebuild the agent image + set `ORCH_STEAM_USERNAME=kraulerson` + recreate; the preserved session in the `depotdownloader-config` volume carries over. Then `cache fetch-manifests` → `cache validate-all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)