### PR TITLE
fix(epic): finish validation parity (go-live gaps)

### DIFF
--- a/src/orchestrator/api/routers/validate_trigger.py
+++ b/src/orchestrator/api/routers/validate_trigger.py
@@ -29,7 +29,7 @@ router = APIRouter(prefix="/api/v1/games", tags=["validate"])
     "/{game_id}/validate",
     responses={
         202: {"description": "Validate job queued or existing in-flight job returned"},
-        400: {"description": "Game is on a non-steam platform"},
+        400: {"description": "Game is on an unsupported platform (not steam/epic)"},
         401: {"description": "Missing/invalid bearer"},
         404: {"description": "Game not found"},
         503: {"description": "Database unavailable"},
@@ -43,10 +43,11 @@ async def trigger_validate(
         game = await pool.read_one("SELECT id, platform FROM games WHERE id=?", (game_id,))
         if game is None:
             raise HTTPException(status_code=404, detail=f"game {game_id} not found")
-        if game["platform"] != "steam":
+        platform = game["platform"]
+        if platform not in ("steam", "epic"):
             raise HTTPException(
                 status_code=400,
-                detail=f"validate only supports steam (got {game['platform']!r})",
+                detail=f"validate only supports steam/epic (got {platform!r})",
             )
 
         existing = await pool.read_one(
@@ -69,8 +70,8 @@ async def trigger_validate(
         # this game makes our INSERT a no-op and we return the winner's job_id.
         await pool.execute_write(
             "INSERT INTO jobs (kind, game_id, platform, state, source) "
-            "VALUES ('validate', ?, 'steam', 'queued', 'api') ON CONFLICT DO NOTHING",
-            (game_id,),
+            "VALUES ('validate', ?, ?, 'queued', 'api') ON CONFLICT DO NOTHING",
+            (game_id, platform),
         )
         new_row = await pool.read_one(
             "SELECT id FROM jobs WHERE kind='validate' AND game_id=? "

--- a/src/orchestrator/cli/commands/cache.py
+++ b/src/orchestrator/cli/commands/cache.py
@@ -35,7 +35,7 @@ def cache_fetch_manifests(ctx: click.Context) -> None:
 @click.pass_context
 @handles_api_errors
 def cache_validate_all(ctx: click.Context) -> None:
-    """Enqueue a full validation sweep over EVERY steam game (backfill).
+    """Enqueue a full validation sweep over ALL games across platforms (backfill).
 
     Use after seeding the durable manifest archive so genuinely-cached games are
     re-checked and flip to up_to_date."""

--- a/src/orchestrator/jobs/handlers/prefill.py
+++ b/src/orchestrator/jobs/handlers/prefill.py
@@ -202,11 +202,21 @@ async def _epic_prefill_inner(
             game_id=game_id,
             hit_ratio=round(hit_ratio, 3),
         )
+    # Parity with steam (ID5): enqueue a real disk-stat validate — it sets the
+    # accurate status (a "complete" prefill can be a true Partial). Do NOT
+    # optimistically pre-set status='up_to_date' from the sample HIT-check above;
+    # let the validate decide. ON CONFLICT DO NOTHING dedups against an in-flight
+    # validate for this game (migration-0006 partial UNIQUE index).
+    await deps.pool.execute_write(
+        "INSERT INTO jobs (kind, game_id, platform, state, source) "
+        "VALUES ('validate', ?, 'epic', 'queued', 'scheduler') ON CONFLICT DO NOTHING",
+        (game_id,),
+    )
     # F8: Epic prefill always fetches a FRESH manifest (signed URLs expire), so
     # the cache now reflects current_version — adopt it so the scheduled diff
-    # stops re-enqueuing this game every cycle.
+    # stops re-enqueuing this game every cycle (the validate above re-affirms).
     await deps.pool.execute_write(
-        "UPDATE games SET status='up_to_date', last_prefilled_at=CURRENT_TIMESTAMP, "
+        "UPDATE games SET last_prefilled_at=CURRENT_TIMESTAMP, "
         "cached_version=current_version WHERE id=?",
         (game_id,),
     )

--- a/src/orchestrator/scheduler/jobs.py
+++ b/src/orchestrator/scheduler/jobs.py
@@ -62,7 +62,8 @@ async def enqueue_validation_sweep(
 ) -> int:
     """Insert a `sweep` job row if none is queued/running (F13).
 
-    ``full=True`` validates EVERY steam game (the validate-all backfill), carried
+    ``full=True`` validates EVERY game across all platforms (the validate-all
+    backfill), carried
     on the job payload `{"full": true}`; the weekly cron uses the default
     (status-gated) sweep. Mirrors `enqueue_library_sync`: at most one in-flight
     sweep, DB-enforced by `idx_jobs_sweep_inflight` (migration 0005) via

--- a/tests/api/test_validate_trigger_router.py
+++ b/tests/api/test_validate_trigger_router.py
@@ -42,6 +42,29 @@ class TestQueueJob:
             "source": "api",
         }
 
+    async def test_epic_game_queues_with_epic_platform(self, client, populated_pool):
+        """Epic parity: a per-game validate trigger for an epic game must queue a
+        validate job carrying platform='epic' (Game_shelf's Validate button hits
+        this endpoint). The job's real platform is what validate_game dispatches on."""
+        row = await populated_pool.read_one("SELECT id FROM games WHERE platform='epic' LIMIT 1")
+        assert row is not None
+        r = await client.post(
+            f"/api/v1/games/{row['id']}/validate",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r.status_code == 202
+        jrow = await populated_pool.read_one(
+            "SELECT kind, game_id, platform, state, source FROM jobs WHERE id=?",
+            (r.json()["job_id"],),
+        )
+        assert jrow == {
+            "kind": "validate",
+            "game_id": row["id"],
+            "platform": "epic",
+            "state": "queued",
+            "source": "api",
+        }
+
 
 class TestDedup:
     async def test_concurrent_calls_return_same_job_id(self, client, populated_pool):
@@ -123,15 +146,31 @@ class TestErrors:
         assert r.status_code == 404
         assert "not found" in r.json()["detail"]
 
-    async def test_non_steam_game_returns_400(self, client, populated_pool):
-        row = await populated_pool.read_one("SELECT id FROM games WHERE platform='epic' LIMIT 1")
-        assert row is not None
-        r = await client.post(
-            f"/api/v1/games/{row['id']}/validate",
-            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
-        )
+    async def test_unsupported_platform_returns_400(self, unit_app):
+        """A platform outside steam/epic is rejected (defensive; the games CHECK
+        constrains to steam/epic, so this uses a mock pool to reach the branch)."""
+        import httpx
+
+        from orchestrator.api.dependencies import get_pool_dep
+
+        class _GogPool:
+            async def read_one(self, query, *_a, **_kw):
+                if "FROM games" in query:
+                    return {"id": 7, "platform": "gog"}
+                return None
+
+            async def execute_write(self, *_a, **_kw):
+                return 1
+
+        unit_app.dependency_overrides[get_pool_dep] = lambda: _GogPool()
+        transport = httpx.ASGITransport(app=unit_app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as c:
+            r = await c.post(
+                "/api/v1/games/7/validate",
+                headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+            )
         assert r.status_code == 400
-        assert "steam" in r.json()["detail"]
+        assert "gog" in r.json()["detail"]
 
 
 class TestAuthBoundary:

--- a/tests/jobs/test_epic_handlers.py
+++ b/tests/jobs/test_epic_handlers.py
@@ -69,7 +69,7 @@ def _manifest():
     return EpicManifest(version=22, chunks=chunks, cdn_base="/base", raw=b"BINARY-MANIFEST")
 
 
-async def test_epic_prefill_downloads_stores_manifest_marks_up_to_date(pool, monkeypatch):
+async def test_epic_prefill_downloads_stores_manifest_enqueues_validate(pool, monkeypatch):
     gid = await _seed_epic_game(pool)
     stub = _StubEpic(manifest=_manifest())
 
@@ -85,8 +85,14 @@ async def test_epic_prefill_downloads_stores_manifest_marks_up_to_date(pool, mon
     await prefill_handler(_job("prefill", gid), Deps(pool=pool, epic_client=stub))
 
     g = await pool.read_one("SELECT status, size_bytes FROM games WHERE id=?", (gid,))
-    assert g["status"] == "up_to_date"
+    # Parity with steam: a disk-stat validate (enqueued below) finalizes status;
+    # prefill no longer optimistically marks up_to_date from the sample check.
+    assert g["status"] == "downloading"
     assert g["size_bytes"] == 500
+    vj = await pool.read_one(
+        "SELECT platform, state FROM jobs WHERE kind='validate' AND game_id=?", (gid,)
+    )
+    assert vj == {"platform": "epic", "state": "queued"}
     m = await pool.read_one(
         "SELECT version, chunk_count, total_bytes FROM manifests WHERE game_id=?", (gid,)
     )
@@ -97,7 +103,8 @@ async def test_epic_prefill_downloads_stores_manifest_marks_up_to_date(pool, mon
 async def test_epic_prefill_low_hit_ratio_is_non_gating(pool, monkeypatch):
     """A low post-prefill HIT ratio logs a warning but does NOT fail the job —
     lancache caches asynchronously, so an immediate re-request can legitimately
-    MISS; download success is the success signal (UAT-10 #8)."""
+    MISS; download success is the success signal (UAT-10 #8). The disk-stat
+    validate is still enqueued regardless of the sample ratio."""
     gid = await _seed_epic_game(pool, app_id="AppE")
     stub = _StubEpic(manifest=_manifest())
 
@@ -112,7 +119,9 @@ async def test_epic_prefill_low_hit_ratio_is_non_gating(pool, monkeypatch):
 
     await prefill_handler(_job("prefill", gid), Deps(pool=pool, epic_client=stub))
     g = await pool.read_one("SELECT status FROM games WHERE id=?", (gid,))
-    assert g["status"] == "up_to_date"  # informational, not a failure
+    assert g["status"] != "failed"  # non-gating: a low sample ratio doesn't fail prefill
+    vj = await pool.read_one("SELECT id FROM jobs WHERE kind='validate' AND game_id=?", (gid,))
+    assert vj is not None  # validate enqueued regardless of the sample hit ratio
 
 
 async def test_epic_prefill_failed_chunks_marks_failed(pool, monkeypatch):

--- a/tests/jobs/test_prefill_handler.py
+++ b/tests/jobs/test_prefill_handler.py
@@ -376,10 +376,12 @@ async def test_epic_agent_path_pulls_through_agent_not_downloader(pool, monkeypa
     assert len(verify_calls) == 1
 
 
-async def test_epic_agent_success_same_db_writes(pool, monkeypatch):
-    """The Epic agent happy path produces the SAME final DB writes as the flag-off
-    Epic path: status up_to_date, cached_version=current_version, last_prefilled_at,
-    and the manifest upsert + size_bytes."""
+async def test_epic_agent_success_enqueues_validate(pool, monkeypatch):
+    """Parity with steam (ID5): a successful Epic prefill ENQUEUES a disk-stat
+    validate (which sets the real status) instead of optimistically pre-setting
+    status='up_to_date' from the 20-chunk sample HIT-check. It still adopts
+    cached_version=current_version + last_prefilled_at (F8 diff-skip) and upserts
+    the manifest + size_bytes. Status stays 'downloading' until the validate runs."""
     import orchestrator.jobs.handlers.prefill as ph
 
     settings = Settings(orchestrator_token="a" * 32, agent_enabled=True)
@@ -402,10 +404,16 @@ async def test_epic_agent_success_same_db_writes(pool, monkeypatch):
     g = await pool.read_one(
         "SELECT status, size_bytes, cached_version, last_prefilled_at FROM games WHERE id=?", (gid,)
     )
-    assert g["status"] == "up_to_date"
+    # No optimistic up_to_date: the enqueued validate finalizes status.
+    assert g["status"] == "downloading"
     assert g["size_bytes"] == 500
     assert g["cached_version"] == "bv-1"
     assert g["last_prefilled_at"] is not None
+    vj = await pool.read_one(
+        "SELECT kind, game_id, platform, state FROM jobs WHERE kind='validate' AND game_id=?",
+        (gid,),
+    )
+    assert vj == {"kind": "validate", "game_id": gid, "platform": "epic", "state": "queued"}
     m = await pool.read_one(
         "SELECT chunk_count, total_bytes FROM manifests WHERE game_id=?", (gid,)
     )


### PR DESCRIPTION
## Finish Epic validation parity (go-live gaps)

Follow-up to #216. Epic disk-stat validation is **live-proven** (Grackle: **3891/3891 chunks cached** via the real chain). But go-live surfaced that #216 un-scoped the validate **job handler** + **sweep** to epic, yet missed the **per-game entry points** operators and Game_shelf actually touch. This closes them.

### Changes
1. **`validate_trigger.py`** — `POST /api/v1/games/{id}/validate` rejected epic (guard + hard-coded `platform='steam'` in the job INSERT). **This is the endpoint Game_shelf's Validate button calls**, so it was broken for epic. Now mirrors the already-correct `prefill_trigger`: allow steam/epic + insert the game's real platform.
2. **`prefill.py::_epic_prefill_inner`** — on success now **enqueues a real disk-stat validate** (parity with steam's ID5) instead of optimistically setting `up_to_date` from the 20-chunk sample HIT-check. The disk-stat validate sets the accurate status (a "complete" prefill can be a true `Partial` — which is correct). Keeps `cached_version` + `last_prefilled_at` (F8 diff-skip).
3. **Docs** — `cache validate-all` help + `enqueue_validation_sweep` docstring no longer claim "EVERY steam game" (the sweep is platform-agnostic).

### Audit
A full sweep for remaining steam-only scoping confirmed **nothing else** breaks epic parity: `library_sync` (separate steam/epic routes + handlers by design), `fetch_manifests` (DepotDownloader is steam-only by nature; epic gets manifests inline at prefill), and the steam-only library-sync cron (epic sync is manual/post-auth) are all intentional. `GET /api/v1/games` cache status has no platform filter.

### Testing
- TDD: `test_validate_trigger_router.py` (epic queues platform='epic'; unsupported→400), `test_prefill_handler.py` + `test_epic_handlers.py` (epic prefill enqueues validate, no premature up_to_date, low-hit-ratio still non-gating).
- Full suite **1384 passed** (only `test_licenses.py` fails: pre-existing missing `pip-licenses`). mypy + ruff clean.

### Deploy (control-plane only, no 2FA)
Rebuild + recreate control on LXC 1105 (no agent change). Then verify `game validate <epic_id>` → 202 and an epic prefill leaves a validate queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
