### PR TITLE
fix(validator): count transient mode-000 chunks as cached

### DIFF
--- a/src/orchestrator/agent/routers/steam.py
+++ b/src/orchestrator/agent/routers/steam.py
@@ -278,11 +278,12 @@ async def steam_validate(body: SteamValidateRequest, request: Request) -> dict[s
     # multi-language titles are perpetually 'partial'.
     #
     # We gate exclusion on `present`, NOT on `cached`: a depot whose files EXIST
-    # but are unreadable (mode-000, #76/#128) or empty has present > 0 and is
-    # KEPT, so that corruption stays visible as a gap instead of being silently
-    # dropped as "never prefilled". (A depot fully evicted to 0 files on disk is
-    # indistinguishable from never-prefilled and is excluded — accepted: whole-
-    # depot eviction-to-zero is rare under per-file LRU.)
+    # but are empty (size 0) has present > 0 and is KEPT, so a genuine gap stays
+    # visible instead of being silently dropped as "never prefilled". (Transient
+    # mode-000 files now count as cached — see disk_stat._stat_batch — since they
+    # self-heal in ms; a depot fully evicted to 0 files on disk is indistinguishable
+    # from never-prefilled and is excluded — accepted: whole-depot eviction-to-zero
+    # is rare under per-file LRU.)
     total = 0
     cached = 0
     included = 0

--- a/src/orchestrator/validator/disk_stat.py
+++ b/src/orchestrator/validator/disk_stat.py
@@ -1,11 +1,18 @@
 """F7 disk-stat validator engine.
 
 Counts, for a batch of nginx cache file paths, how many are cached.
-"Cached" = file exists AND size > 0 AND owner-read bit set (the cache file
-is larger than the chunk body because nginx prepends a cache-entry header —
-never size-match; see spike A4). The cache-key derivation and Steam manifest
-parsing now live in the data-plane agent (`agent/routers/steam.py`); this
-module is the shared stat engine the agent calls.
+"Cached" = file exists AND size > 0 (the cache file is larger than the chunk
+body because nginx prepends a cache-entry header — never size-match; see spike
+A4). We deliberately do NOT require the owner-read bit: a mode-000 cache file
+is a TRANSIENT nginx-over-NFS write-race artifact — nginx creates the temp file
+at mode 000, then fchmod's it to 0600 milliseconds later (audit 2026-07-02) —
+so the content IS on disk at the right size. Penalizing that momentary state
+produced false "Partial" badges; the audit confirmed there is no persistent
+mode-000 backlog for this relaxation to hide (a genuinely-unreadable file
+surfaces separately as an nginx `Permission denied` 500 in the error log).
+The cache-key derivation and Steam manifest parsing now live in the data-plane
+agent (`agent/routers/steam.py`); this module is the shared stat engine the
+agent calls.
 """
 
 from __future__ import annotations
@@ -73,10 +80,11 @@ def shutdown_cache_stat_executor() -> None:
 def _stat_batch(paths: list[Path]) -> tuple[int, int, int]:
     """Count (cached, present, errors) for a batch. Runs in a thread.
 
-    cached  = a regular file with non-empty size AND the owner-read bit set.
+    cached  = a regular file with non-empty size (mode is NOT checked — see
+              below).
     present = the file exists on disk (stat succeeds, not a symlink) regardless
               of size/mode — lets callers tell a never-prefilled chunk (absent)
-              from a prefilled-but-unreadable one (mode-000) or an empty one.
+              from an empty one.
     errors  = unexpected OSErrors (e.g. EACCES on a directory, EIO). A plain
               missing file is not an error.
     """
@@ -90,14 +98,14 @@ def _stat_batch(paths: list[Path]) -> tuple[int, int, int]:
                 continue
             st = p.stat()
             present += 1  # file exists on disk (stat() needs only dir traversal)
-            # F5/#128: lancache (www-data, the file owner) must be able to
-            # READ the file to serve it. ~1.7% of cache files are mode-000 —
-            # they exist with size>0 but are unreadable, so lancache returns
-            # 500 + re-downloads. Require the owner-read bit so those don't
-            # count as cached. stat() returns st_mode without needing read
-            # access to the content, so this works even though the
-            # orchestrator (uid 1000) can't open www-data:600 files itself.
-            if st.st_size > 0 and (st.st_mode & 0o400):
+            # A present, non-empty file is cached. We do NOT require the
+            # owner-read bit: a mode-000 file is a TRANSIENT nginx-over-NFS
+            # write-race (nginx creates the temp at mode 000, then fchmod's to
+            # 0600 ms later; audit 2026-07-02), so the content is on disk. The
+            # old read-bit gate produced false "Partial" badges; the audit found
+            # no persistent mode-000 backlog for this to hide. (stat() returns
+            # st_size without needing read access to the content.)
+            if st.st_size > 0:
                 cached += 1
         except FileNotFoundError:
             pass  # plain cache miss — expected, not an error
@@ -155,7 +163,8 @@ async def validate_chunks_scoped(paths: list[Path], *, batch_size: int = 256) ->
 def _stat_any_batch(candidate_lists: list[list[Path]]) -> tuple[int, int, int]:
     """Per chunk, cached/present if ANY candidate qualifies. Runs in a thread.
 
-    cached  = at least one candidate is a regular, non-empty, owner-readable file.
+    cached  = at least one candidate is a regular, non-empty file (mode is NOT
+              checked — a transient mode-000 file still counts; see _stat_batch).
     present = at least one candidate exists on disk (stat succeeds, not a symlink).
     errors  = unexpected OSErrors across all candidates of all chunks.
 
@@ -174,7 +183,7 @@ def _stat_any_batch(candidate_lists: list[list[Path]]) -> tuple[int, int, int]:
                     continue
                 st = p.stat()
                 p_hit = True
-                if st.st_size > 0 and (st.st_mode & 0o400):
+                if st.st_size > 0:
                     c_hit = True
                     break  # cached wins; stop checking this chunk's candidates
             except FileNotFoundError:

--- a/tests/agent/test_steam_validate.py
+++ b/tests/agent/test_steam_validate.py
@@ -314,11 +314,11 @@ def test_validate_all_depots_unprefilled_is_missing(tmp_path):
     assert body["outcome"] == "missing"
 
 
-def test_validate_mode000_depot_kept_as_gap_not_excluded(tmp_path):
-    """A depot whose chunk files EXIST on disk but are mode-000 (unreadable —
-    the #76/#128 corruption) must NOT be excluded as 'never prefilled'. Its files
-    are present, so it stays a visible gap (present>0, 0 readable -> 'missing')
-    instead of being silently dropped, which would HIDE the corruption."""
+def test_validate_mode000_depot_counted_cached(tmp_path):
+    """A depot whose chunk files EXIST on disk but are mode-000 validates as
+    CACHED: mode-000 is a transient nginx-over-NFS write-race that self-heals to
+    0600 in ms (audit 2026-07-02), so present, correct-size files count. The depot
+    is still KEPT (present>0, not excluded as 'never prefilled')."""
     client = _build_multidepot(tmp_path, depot_cached={800441: (10, 10)})
     # Strip the owner-read bit from every (otherwise fully-cached) chunk file.
     for f in (tmp_path / "lancache").rglob("*"):
@@ -326,5 +326,5 @@ def test_validate_mode000_depot_kept_as_gap_not_excluded(tmp_path):
             f.chmod(0o000)
     body = client.post("/v1/steam/validate", json={"app_id": MD_APP}).json()
     assert body["chunks_total"] == 10  # depot KEPT (files present), not excluded
-    assert body["chunks_cached"] == 0  # all unreadable -> none count as cached
-    assert body["outcome"] == "missing"
+    assert body["chunks_cached"] == 10  # transient mode-000 -> counted cached
+    assert body["outcome"] == "cached"

--- a/tests/validator/test_disk_stat.py
+++ b/tests/validator/test_disk_stat.py
@@ -42,19 +42,23 @@ async def test_empty_path_list(tmp_path):
     assert await validate_chunks([]) == (0, 0)
 
 
-async def test_unreadable_mode000_not_counted(tmp_path):
-    """F5: a mode-000 cache file is unreadable by lancache (owner www-data has
-    no read bit); it must NOT count as cached even though it exists size>0."""
+async def test_transient_mode000_counted_cached(tmp_path):
+    """A mode-000 cache file (size>0) is a TRANSIENT nginx-over-NFS write-race
+    artifact: nginx creates the temp file at mode 000, then fchmod's it to 0600
+    milliseconds later (audit 2026-07-02). The chunk IS on disk at the right size,
+    so the validator — which answers "is the game cached on disk?" — counts it
+    cached regardless of a momentary 000 read-bit. Fixes false "Partial" badges;
+    the audit proved there is no persistent mode-000 backlog for this to hide."""
     import os
 
-    f = tmp_path / "unreadable"
+    f = tmp_path / "transient000"
     f.write_bytes(b"data")
     os.chmod(f, 0o000)
     try:
         cached, missing = await validate_chunks([f])
     finally:
         os.chmod(f, 0o644)  # restore so tmp cleanup can remove it
-    assert (cached, missing) == (0, 1)
+    assert (cached, missing) == (1, 0)
 
 
 async def test_readable_mode644_counted(tmp_path):
@@ -159,11 +163,11 @@ async def test_validate_chunks_any_present_size_zero_not_cached(tmp_path):
     assert result == (0, 1)  # present=1, cached=0
 
 
-async def test_validate_chunks_any_present_mode000_not_cached(tmp_path):
-    """A non-empty candidate file with mode 000 is present but NOT cached (#76/#128).
-    The owner-read bit must be set for lancache to serve it; mode-000 files exist
-    on disk but lancache cannot read them, so they must not count as cached.
-    If the test runner is root, chmod 000 may still be readable — skip in that case."""
+async def test_validate_chunks_any_present_mode000_counted_cached(tmp_path):
+    """A non-empty candidate at mode 000 counts as CACHED: it's a transient nginx
+    write-race state that self-heals to 0600 in ms (audit 2026-07-02), and the
+    content is on disk. Mirrors the scoped-path behavior. No root-skip needed —
+    the check is now size>0 only, independent of the mode bits."""
     import os
 
     f = tmp_path / "mode000"
@@ -173,11 +177,7 @@ async def test_validate_chunks_any_present_mode000_not_cached(tmp_path):
         result = await validate_chunks_any([[f]])
     finally:
         os.chmod(f, 0o644)  # restore so tmp cleanup can remove it
-    # If running as root, stat() sees size>0 and mode 000 but root bypasses mode checks —
-    # the kernel sets all mode bits for root, so 0o400 would appear set. Skip that case.
-    if result == (1, 1):
-        pytest.skip("test runner is root; chmod 000 is readable, skipping mode-000 sub-case")
-    assert result == (0, 1)  # present=1, cached=0
+    assert result == (1, 1)  # cached=1, present=1
 
 
 async def test_validate_chunks_any_symlink_skipped(tmp_path):


### PR DESCRIPTION
## Fix false-"Partial" badges from nginx's transient mode-000 write-race

Root cause (found via the 2026-07-02 forensic audit): the mode-000 cache files aren't a static corruption backlog — they're **nginx's own atomic cache-write behavior over NFS**. nginx creates each cache temp file at mode `000`, writes + renames it, then `fchmod`s it to `0600` milliseconds later. A validation that stat'd a chunk *during* that sub-second window miscounted it "missing" → **false "Partial" badges that flickered between runs** (e.g. VOID/BREAKER 98→94→cached) even though the game was fully cached. `find -perm 000` finds **zero** files — they self-heal — confirming there's no persistent backlog.

### Change
The disk-stat validator counted a chunk cached only if present **AND size>0 AND owner-readable**. This drops the owner-read-bit requirement in both stat paths:
- `_stat_batch` (Steam) and `_stat_any_batch` (Epic): **cached = present AND size>0**.

Safe because the audit proved no persistent mode-000 backlog for this to hide — a genuinely-unreadable file surfaces separately as an nginx `Permission denied` 500 in the error log, not through the validator (clean separation: validator answers "is it on disk?", nginx log answers "is it momentarily unreadable?"). Depot-scoping is unchanged (still gated on `present==0` for never-prefilled exclusion). Fixes **both** platforms.

### Testing
- TDD: flipped the 3 tests that encoded the old "mode-000 = not cached" behavior (RED → GREEN) — `validate_chunks`, `validate_chunks_any` (Epic), and the steam_validate depot-scoping test.
- Full suite **1384 passed** (only `test_licenses.py` fails: pre-existing missing `pip-licenses`). mypy + ruff clean.
- Size-0 (empty) files still correctly count as **not** cached; symlinks still skipped.

### Note
This does not touch the transient HTTP 500s clients see during heavy prefill bursts (inherent to nginx-over-NFS, self-healing, low-impact). It fixes the user-facing symptom — the false-Partial badges — deterministically and in our own code, with zero NAS-side changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
