### PR TITLE
feat(epic): parse JSON (legacy) manifests

### DIFF
--- a/src/orchestrator/platform/epic/manifest.py
+++ b/src/orchestrator/platform/epic/manifest.py
@@ -8,6 +8,7 @@ EpicManifestError on malformed input (never sys.exit / never silently truncates)
 from __future__ import annotations
 
 import base64
+import json
 import re
 import struct
 import zlib
@@ -75,16 +76,89 @@ def _read_array(bio: BytesIO, count: int, fmt: str) -> list[int]:
 
 
 def parse_manifest(raw: bytes, *, max_decompressed: int = _MAX_DECOMPRESSED_BYTES) -> EpicManifest:
-    """Parse an Epic binary manifest into version + chunk list.
+    """Parse an Epic manifest into version + chunk list.
 
-    ``max_decompressed`` caps the inflated body to defuse a decompression bomb.
+    Epic serves two manifest formats: the binary format (magic 0x44BEC00C) and,
+    for some older games, a JSON/legacy format (starts with ``{``). Both produce
+    the same EpicManifest/EpicChunk so the shared chunk-path derivation works
+    unchanged. ``max_decompressed`` caps the inflated binary body (bomb guard).
     """
+    if raw[:1] == b"{":
+        return _parse_json(raw)
     try:
         return _parse(raw, max_decompressed)
     except EpicManifestError:
         raise
     except (struct.error, zlib.error, ValueError, IndexError) as e:
         raise EpicManifestError(f"malformed Epic manifest: {type(e).__name__}: {e}") from e
+
+
+def _blob_to_num(s: str) -> int:
+    """Decode Epic's 'blob' number encoding used in JSON manifests: the number is
+    stored as 3 decimal digits per byte, little-endian (first triplet = low byte).
+    E.g. "090" -> 90; "013000000000" -> 13."""
+    if len(s) % 3 != 0:
+        raise EpicManifestError(f"malformed blob number: {s!r}")
+    num = 0
+    for i in range(0, len(s), 3):
+        num |= int(s[i : i + 3]) << (8 * (i // 3))
+    return num
+
+
+def _guid_from_hex(h: str) -> tuple[int, int, int, int]:
+    """A JSON manifest keys chunks by their 32-hex GUID (four uint32s, the same
+    rendering `_guid_hex` produces from the binary form)."""
+    if len(h) != 32:
+        raise EpicManifestError(f"malformed chunk GUID: {h!r}")
+    return (int(h[0:8], 16), int(h[8:16], 16), int(h[16:24], 16), int(h[24:32], 16))
+
+
+def _parse_json(raw: bytes) -> EpicManifest:
+    """Parse an Epic JSON (legacy) manifest into the same EpicManifest the binary
+    parser returns. Chunk GUIDs are 32-hex keys; numbers are blob-encoded. The
+    resulting chunk paths are proven against Epic's CDN (Palila spike 2026-07-03,
+    5/5 HEAD 200). Raises EpicManifestError on anything malformed — never a bare
+    KeyError/ValueError that would crash the prefill/validate loop."""
+    try:
+        doc = json.loads(raw)
+    except (json.JSONDecodeError, ValueError) as e:
+        raise EpicManifestError(f"malformed Epic JSON manifest: {e}") from e
+    if not isinstance(doc, dict) or "ChunkHashList" not in doc or "DataGroupList" not in doc:
+        raise EpicManifestError("Epic JSON manifest missing ChunkHashList/DataGroupList")
+    try:
+        version = _blob_to_num(str(doc["ManifestFileVersion"]))
+        chunk_hashes = doc["ChunkHashList"]
+        data_groups = doc["DataGroupList"]
+        filesizes = doc.get("ChunkFilesizeList", {})
+        shas = doc.get("ChunkShaList", {})
+        if not isinstance(chunk_hashes, dict) or not isinstance(data_groups, dict):
+            raise EpicManifestError("Epic JSON manifest ChunkHashList/DataGroupList not objects")
+        if len(chunk_hashes) > _MAX_CHUNKS:
+            raise EpicManifestError(f"implausible chunk_count {len(chunk_hashes)}")
+        chunks: list[EpicChunk] = []
+        for guid_hex, hash_blob in chunk_hashes.items():
+            if guid_hex not in data_groups:
+                raise EpicManifestError(f"chunk {guid_hex} missing from DataGroupList")
+            sha_hex = str(shas.get(guid_hex, ""))
+            try:
+                sha_hash = bytes.fromhex(sha_hex) if sha_hex else b""
+            except ValueError:
+                sha_hash = b""
+            chunks.append(
+                EpicChunk(
+                    guid=_guid_from_hex(guid_hex),
+                    hash=_blob_to_num(str(hash_blob)),
+                    sha_hash=sha_hash,
+                    group_num=_blob_to_num(str(data_groups[guid_hex])),
+                    file_size=_blob_to_num(str(filesizes.get(guid_hex, "000"))),
+                    window_size=0,  # absent in JSON; chunk_path (v<22) doesn't use it
+                )
+            )
+    except EpicManifestError:
+        raise
+    except (KeyError, ValueError, TypeError) as e:
+        raise EpicManifestError(f"malformed Epic JSON manifest: {type(e).__name__}: {e}") from e
+    return EpicManifest(version=version, chunks=chunks)
 
 
 def _decompress_capped(body_raw: bytes, max_bytes: int) -> bytes:

--- a/tests/platform/epic/test_manifest_parse.py
+++ b/tests/platform/epic/test_manifest_parse.py
@@ -110,3 +110,44 @@ def test_read_fstring_utf16():
     payload = (s + "\x00").encode("utf-16-le")
     buf = BytesIO(struct.pack("<i", -(len(s) + 1)) + payload)
     assert _read_fstring(buf) == s
+
+
+def test_parse_json_legacy_manifest():
+    """Epic serves some (older) games' manifests as JSON, not the binary format.
+    Numbers are blob-encoded (3 decimal digits per byte, little-endian) and GUID
+    keys are 32-hex. They parse into the same EpicChunk shape. Values + the
+    resulting CDN chunk path are proven live against Epic's CDN (Palila spike
+    2026-07-03: 5/5 HEAD 200)."""
+    import json
+
+    guid = "E3BEF01544B75CE12E44DA83C705CE57"
+    manifest = {
+        "ManifestFileVersion": "013000000000",  # blob -> 13 (ChunksV3)
+        "bIsFileData": False,
+        "AppNameString": "Palila",
+        "FileManifestList": [],  # not needed to enumerate/validate chunks
+        "ChunkHashList": {guid: "180065099141255040004083"},
+        "DataGroupList": {guid: "090"},
+        "ChunkFilesizeList": {guid: "155136003000000000000000"},
+        "ChunkShaList": {guid: "0517E2128E0E8825665E80E2" + "00" * 8},
+    }
+    m = parse_manifest(json.dumps(manifest).encode())
+    assert m.version == 13
+    assert len(m.chunks) == 1
+    c = m.chunks[0]
+    assert c.guid == (0xE3BEF015, 0x44B75CE1, 0x2E44DA83, 0xC705CE57)
+    assert c.group_num == 90
+    # End-to-end: this exact path returned HTTP 200 from Epic's CDN in the spike.
+    assert (
+        chunk_path(c, m.version)
+        == "ChunksV3/90/530428FF8D6341B4_E3BEF01544B75CE12E44DA83C705CE57.chunk"
+    )
+
+
+def test_parse_json_missing_chunklist_raises():
+    """A JSON manifest without ChunkHashList is malformed -> EpicManifestError
+    (never a bare KeyError that would crash the prefill/validate loop)."""
+    import json
+
+    with pytest.raises(EpicManifestError):
+        parse_manifest(json.dumps({"ManifestFileVersion": "013000000000"}).encode())


### PR DESCRIPTION
## Parse Epic JSON (legacy) manifests

72 owned Epic games failed prefill+validate with `bad manifest magic: 0x614d227b` (that hex = `{"Ma`). Epic serves some older games' manifests as **JSON**, not the binary format our parser knew.

### Change
`parse_manifest` now dispatches on a leading `{` to a new `_parse_json` that decodes the JSON/legacy format into the **same** `EpicManifest`/`EpicChunk` the binary path returns — so the shared, already-proven chunk-path derivation works unchanged:
- Numbers are Epic **"blob"-encoded** (3 decimal digits per byte, little-endian) → `_blob_to_num` (ManifestFileVersion, ChunkHashList, DataGroupList, ChunkFilesizeList).
- Chunk GUIDs are 32-hex keys → `_guid_from_hex` (four uint32s).
- Malformed input raises `EpicManifestError` (never a bare KeyError/ValueError that would crash the prefill/validate loop); DoS-capped by `_MAX_CHUNKS`.

Fixes **both** prefill (can now download these games) and validation (can now validate them). Same fix serves control-plane prefill and the agent validator (both call `parse_manifest`).

### Proof (live, not guessed)
Spike against a real failing game (**Palila**, 2026-07-03): fetched its JSON manifest, decoded it, built chunk paths, and HEAD'd them against Epic's CDN → **5/5 return HTTP 200** (version 13 → ChunksV3). The unit test pins that exact proven path as a regression fixture.

### Testing
- TDD: RED first (`bad manifest magic: 0x614d227b`), GREEN after. New tests cover the legacy parse (end-to-end to the CDN-proven chunk path) + malformed-JSON → `EpicManifestError`.
- Full suite **1386 passed** (only `test_licenses.py` fails: pre-existing missing `pip-licenses`). mypy + ruff clean.

### Deploy (post-merge)
Rebuild + recreate agent (.40) and control (1105) — both call `parse_manifest`. Then re-prefill the 72 JSON-manifest games; they'll download + validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
