### PR TITLE
feat(epic): resolve real display titles via catalog API (#140)

### DIFF
--- a/src/orchestrator/core/settings.py
+++ b/src/orchestrator/core/settings.py
@@ -233,6 +233,15 @@ class Settings(BaseSettings):
             "/app/{app_name}/label/{label}"
         )
     )
+    # Catalog bulk-items endpoint — resolves an item's real display title from its
+    # namespace + catalog_item_id (#140). The library/assets response often omits
+    # metadata.title, leaving only the codename (appName); this backfills it.
+    epic_catalog_url_template: str = Field(
+        default=(
+            "https://catalog-public-service-prod06.ol.epicgames.com"
+            "/catalog/api/shared/namespace/{namespace}/bulk/items"
+        )
+    )
     # Public legendary launcher client creds — the well-known EGS launcher app
     # credentials used by every Epic CLI client; NOT operator secrets.
     epic_client_id: str = Field(default="34a02cf8f4414e29b15921876da36f9a")

--- a/src/orchestrator/platform/epic/library.py
+++ b/src/orchestrator/platform/epic/library.py
@@ -6,6 +6,8 @@ Paginated GET of the operator's owned items. Pure async httpx; the caller
 
 from __future__ import annotations
 
+import asyncio
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -21,6 +23,11 @@ _log = structlog.get_logger(__name__)
 # COR-4: bound pagination so a misbehaving/hostile API can't loop forever.
 # A real Epic library is a handful of pages; this is a generous backstop.
 _MAX_PAGES = 10_000
+
+# Bound concurrent catalog title lookups (#140): each item usually has its own
+# namespace, so a full library is hundreds of calls — cap the fan-out so we don't
+# open hundreds of sockets or hammer Epic's catalog API at once.
+_TITLE_CONCURRENCY = 10
 
 
 class EpicLibraryError(Exception):
@@ -67,6 +74,63 @@ def _to_item(rec: dict[str, Any]) -> EpicLibraryItem | None:
     )
 
 
+async def _resolve_titles(
+    client: httpx.AsyncClient,
+    access_token: str,
+    items: list[EpicLibraryItem],
+    settings: Settings,
+) -> dict[str, str]:
+    """Resolve real display titles for items left on the appName codename (#140).
+
+    An item whose ``title == app_name`` had no ``metadata.title`` in the library
+    response, so it carries the codename (e.g. 'Fangtooth'). Look up the real
+    title from Epic's catalog bulk-items API, grouped by namespace (the endpoint
+    is namespace-scoped and accepts multiple ids). Returns ``{catalog_item_id:
+    title}`` for every item resolved. Best-effort: any lookup that errors or omits
+    a title is simply absent from the map (the caller keeps the codename), so a
+    title backfill never fails the library sync.
+    """
+    by_ns: dict[str, list[EpicLibraryItem]] = {}
+    for item in items:
+        if item.title == item.app_name:  # codename fallback -> needs a real title
+            by_ns.setdefault(item.namespace, []).append(item)
+    resolved: dict[str, str] = {}
+    if not by_ns:
+        return resolved
+    headers = {"Authorization": f"bearer {access_token}"}
+    sem = asyncio.Semaphore(_TITLE_CONCURRENCY)
+
+    async def _resolve_ns(namespace: str, ns_items: list[EpicLibraryItem]) -> None:
+        url = settings.epic_catalog_url_template.format(namespace=namespace)
+        # Repeated `id` keys (one per catalog item) need a tuple list, not a dict.
+        qp: list[tuple[str, str | int | float | bool | None]] = [
+            ("id", it.catalog_item_id) for it in ns_items
+        ]
+        qp += [("country", "US"), ("locale", "en-US")]
+        params = httpx.QueryParams(qp)
+        async with sem:
+            try:
+                resp = await client.get(url, headers=headers, params=params)
+                if resp.status_code != 200:
+                    return
+                data = resp.json()
+            except (httpx.HTTPError, ValueError) as e:
+                _log.warning("epic.title_resolve_failed", namespace=namespace, reason=str(e))
+                return
+        if not isinstance(data, dict):
+            return
+        for it in ns_items:
+            entry = data.get(it.catalog_item_id)
+            title = entry.get("title") if isinstance(entry, dict) else None
+            if title:
+                # No await between here and the dict write, so the single-threaded
+                # event loop makes these concurrent tasks' writes race-free.
+                resolved[it.catalog_item_id] = str(title)
+
+    await asyncio.gather(*(_resolve_ns(ns, its) for ns, its in by_ns.items()))
+    return resolved
+
+
 async def enumerate_library(access_token: str, settings: Settings) -> list[EpicLibraryItem]:
     """Enumerate owned library items, following the cursor to the last page."""
     headers = {"Authorization": f"bearer {access_token}"}
@@ -88,6 +152,14 @@ async def enumerate_library(access_token: str, settings: Settings) -> list[EpicL
                     items.append(item)
             cursor = (data.get("responseMetadata") or {}).get("nextCursor")
             if not cursor:
+                resolved = await _resolve_titles(client, access_token, items, settings)
+                if resolved:
+                    items = [
+                        replace(it, title=resolved[it.catalog_item_id])
+                        if it.catalog_item_id in resolved
+                        else it
+                        for it in items
+                    ]
                 return items
             # COR-4: a repeated cursor means the API is looping us — fail loudly
             # rather than paginate forever.

--- a/tests/platform/epic/test_library.py
+++ b/tests/platform/epic/test_library.py
@@ -39,8 +39,10 @@ async def test_enumerate_paginates(monkeypatch):
     }
 
     def handler(req: httpx.Request) -> httpx.Response:
-        cur = dict(req.url.params).get("cursor")
         assert req.headers.get("authorization", "").lower().startswith("bearer ")
+        if "bulk/items" in req.url.path:  # catalog title lookup — no title for A
+            return httpx.Response(200, json={})
+        cur = dict(req.url.params).get("cursor")
         return httpx.Response(200, json=pages[cur])
 
     monkeypatch.setattr(ep_lib, "_build_transport", lambda: httpx.MockTransport(handler))
@@ -48,8 +50,52 @@ async def test_enumerate_paginates(monkeypatch):
     assert [i.app_name for i in items] == ["A", "B"]
     assert items[0].namespace == "ns"
     assert items[0].catalog_item_id == "c1"
-    assert items[0].title == "A"  # falls back to appName
-    assert items[1].title == "Game B"  # from metadata
+    assert items[0].title == "A"  # codename fallback kept (catalog returned no title)
+    assert items[1].title == "Game B"  # from metadata (no catalog lookup needed)
+
+
+async def test_enumerate_resolves_codename_titles(monkeypatch):
+    """#140: when the library record has no metadata.title, the item falls back to
+    the appName codename; enumerate_library then backfills the real display title
+    from the catalog bulk-items API. Proven live (spike 2026-07-03: Fangtooth ->
+    'City of Gangsters' etc.)."""
+    library = {
+        "records": [
+            {"appName": "Fangtooth", "namespace": "ns1", "catalogItemId": "cat1"},
+            {"appName": "Goby", "namespace": "ns1", "catalogItemId": "cat2"},
+        ],
+        "responseMetadata": {},
+    }
+    catalog = {"cat1": {"title": "City of Gangsters"}, "cat2": {"title": "Mortal Shell"}}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if "bulk/items" in req.url.path:
+            ids = req.url.params.get_list("id")
+            return httpx.Response(200, json={i: catalog[i] for i in ids if i in catalog})
+        return httpx.Response(200, json=library)
+
+    monkeypatch.setattr(ep_lib, "_build_transport", lambda: httpx.MockTransport(handler))
+    items = await ep_lib.enumerate_library("TOK", _settings())
+    titles = {i.app_name: i.title for i in items}
+    assert titles == {"Fangtooth": "City of Gangsters", "Goby": "Mortal Shell"}
+
+
+async def test_enumerate_title_resolution_failure_keeps_codename(monkeypatch):
+    """A catalog lookup that errors (or returns no title) must leave the appName
+    fallback intact — title resolution is best-effort, never fails the sync."""
+    library = {
+        "records": [{"appName": "Fangtooth", "namespace": "ns1", "catalogItemId": "cat1"}],
+        "responseMetadata": {},
+    }
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if "bulk/items" in req.url.path:
+            return httpx.Response(500, json={})
+        return httpx.Response(200, json=library)
+
+    monkeypatch.setattr(ep_lib, "_build_transport", lambda: httpx.MockTransport(handler))
+    items = await ep_lib.enumerate_library("TOK", _settings())
+    assert items[0].title == "Fangtooth"  # fallback kept on catalog failure
 
 
 async def test_enumerate_error_raises(monkeypatch):


### PR DESCRIPTION
Closes #140.

## Resolve real Epic display titles via the catalog API

Epic library records often omit `metadata.title`, so games fell back to the appName **codename** (e.g. "Fangtooth", "Hoki", "Goby") — ugly, unsearchable card titles in Game_shelf.

### Change
`enumerate_library` now backfills the real display title from Epic's **catalog bulk-items API** for any item still on the codename fallback (`title == app_name`):
- Group codename items by namespace → one namespace-scoped bulk lookup per group (bounded to `_TITLE_CONCURRENCY = 10` concurrent).
- Map `catalog_item_id → title`, rebuild the (frozen) `EpicLibraryItem` list with resolved titles via `dataclasses.replace`.
- `library_sync` already stores `item.title` and refreshes it on re-sync (`title = excluded.title`), so titles heal on the next Epic sync — no migration, no backfill job.

**Best-effort by design:** any lookup that errors or omits a title leaves the codename intact — a title backfill must never fail the library sync.

### Proof (live)
Spike against Epic's catalog API (2026-07-03): codenames resolve to **City of Gangsters, Mortal Shell, Zero Hour, Ghostwire Tokyo, Electrician Simulator, Rogue Legacy**.

### Testing
- TDD: resolves-codename-titles (RED→GREEN), keeps-codename-on-catalog-failure, and the existing pagination test updated to route the new catalog call.
- Full suite **1388 passed** (only `test_licenses.py` fails: pre-existing missing `pip-licenses`). mypy + ruff clean.
- New setting `epic_catalog_url_template`.

### Deploy (post-merge)
Rebuild + recreate control (1105 — library_sync runs there). Then trigger an Epic `library sync` to refresh titles library-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
