### PR TITLE
fix(steam): drop 'advertising' from selection classifier exclude types (#229)

### DIFF
--- a/.claude/build-progress.json
+++ b/.claude/build-progress.json
@@ -28,13 +28,14 @@
     "validate-gid-match",
     "issue-228-fetcher-transient-retry",
     "issue-141-games-detail-endpoint",
-    "issue-229-selection-classifier"
+    "issue-229-selection-classifier",
+    "issue-229-drop-advertising-type"
   ],
-  "features_since_last_test": 1,
+  "features_since_last_test": 2,
   "features_since_last_health_check": 1,
   "test_interval": 2,
   "last_test_session": "2026-06-30",
-  "testing_required": false,
+  "testing_required": true,
   "tester_count": 1,
   "bug_tracker": "github_issues",
   "sessions_completed": 13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Changed — Selection classifier: drop `advertising` from the exclude types (#229 follow-up) — 2026-07-04
+
+The first live `selection classify` run flagged real games — **Darksiders II** (50650) and **Eufloria** (41210) — because Steam types some real games' app_ids as `advertising`. Removed `advertising` from `_NON_GAME_TYPES` so the classifier stops producing those false positives. A genuine MP-only/promo entry typed `advertising` (e.g. COD BO2 Zombies) is now an operator judgement call, like a utility Steam types as `game`. Strictly reduces flagging — the parent-feature security audit still applies. (`platform/steam/selection_classifier.py`)
+
 ### Added — Prefill-selection exclusion classifier + `selection classify` CLI (#229) — 2026-07-03
 
 Scheduled prefill pulls every app in the operator's `selectedAppsToPrefill.json`; soundtracks, dedicated servers, SDKs, tools, demos, and videos waste WAN pulls and cache space. New read-only review flags them as **candidates** to remove — it never edits the curated selection (the issue's own gate).

--- a/docs/security-audits/issue-229-drop-advertising-type-security-audit.md
+++ b/docs/security-audits/issue-229-drop-advertising-type-security-audit.md
@@ -1,0 +1,27 @@
+# Security Audit — #229 follow-up: drop `advertising` from exclude types
+
+**Feature:** issue-229-drop-advertising-type
+**Module:** `src/orchestrator/platform/steam/selection_classifier.py` — remove `"advertising"` from `_NON_GAME_TYPES`
+**Audit date:** 2026-07-04
+**Auditor:** self-review + ruff + mypy + suite
+**Phase:** 2 (Construction), Build Loop step 2.4
+
+<!-- Last Updated: 2026-07-04 -->
+
+## Scope
+
+The live `selection classify` run flagged real games (Darksiders II 50650, Eufloria 41210) because Steam types some real games' app_ids as `advertising`. Dropping `advertising` from the exclude set removes those false positives. Behavior-only change to a read-only, advisory classifier; no new inputs, I/O, or surface.
+
+## Audit findings
+
+| # | Severity | Title | Status |
+|---|----------|-------|--------|
+| — | — | No findings. | — |
+
+## Non-findings
+
+- **Strictly reduces flagging.** Removing a member from the exclude frozenset can only make `classify()` return `None` for more inputs — it never flags anything new and never widens any surface. The full parent-feature audit (`issue-229-selection-classifier-security-audit.md`) still applies: read-only, no ReDoS, the selection is never mutated.
+
+## Decision
+
+No findings. Ship.

--- a/src/orchestrator/platform/steam/selection_classifier.py
+++ b/src/orchestrator/platform/steam/selection_classifier.py
@@ -30,7 +30,11 @@ _NON_GAME_TYPES = frozenset(
         "media",
         "series",
         "episode",
-        "advertising",
+        # NOTE: `advertising` intentionally EXCLUDED from this set (#229 follow-up).
+        # Steam types some real games' app_ids as `advertising` (seen live:
+        # Darksiders II 50650, Eufloria 41210), so flagging it produced false
+        # positives. A genuine MP-only/promo entry typed `advertising` (e.g. COD
+        # BO2 Zombies) is now an operator judgement call, like game-typed tools.
         "hardware",
         "config",
         "comic",

--- a/tests/platform/steam/test_selection_classifier.py
+++ b/tests/platform/steam/test_selection_classifier.py
@@ -31,6 +31,11 @@ def test_non_game_types_are_candidates(app_type, name, expected_prefix):
         ("dlc", "Portal 2 - DLC Pack"),  # DLC is real content — kept
         ("mod", "Garry's Mod thing"),
         ("game", ""),  # no name, game type -> keep
+        # #229 follow-up: Steam types some REAL games' app_ids as `advertising`
+        # (seen live: Darksiders II 50650, Eufloria 41210). Dropped from the
+        # exclude set so the classifier stops flagging real games.
+        ("advertising", "Darksiders II"),
+        ("advertising", "Eufloria"),
     ],
 )
 def test_real_games_are_not_candidates(app_type, name):


### PR DESCRIPTION
Follow-up to #229 (PR #233). The first live `selection classify` run flagged **real games** — Darksiders II (50650) and Eufloria (41210) — because Steam types some real games' app_ids as `advertising`. Removes `advertising` from `_NON_GAME_TYPES` so the classifier stops producing those false positives.

Tradeoff (intended): a genuine MP-only/promo entry typed `advertising` (e.g. COD BO2 Zombies) is now an operator judgement call — like a utility Steam types as `game`. Net: fewer false flags, at the cost of one manual call on the odd MP-only promo entry.

Test-first (2 new cases: `advertising` → not a candidate). 28 selection tests pass, ruff + mypy clean. Security audit: `docs/security-audits/issue-229-drop-advertising-type-security-audit.md` (strictly reduces flagging).

Control-plane only — I'll redeploy LXC 1105 the moment this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)