### PR TITLE
feat(steam): auto-prune selectedAppsToPrefill.json for classified non-games (Piece 1)

### DIFF
--- a/.claude/build-progress.json
+++ b/.claude/build-progress.json
@@ -35,13 +35,14 @@
     "epic-json-manifest",
     "epic-display-titles",
     "epic-prereq-parser",
-    "issue-225-auto-classify-block"
+    "issue-225-auto-classify-block",
+    "steam-prune-selection"
   ],
-  "features_since_last_test": 1,
+  "features_since_last_test": 2,
   "features_since_last_health_check": 1,
   "test_interval": 2,
   "last_test_session": "2026-07-04",
-  "testing_required": false,
+  "testing_required": true,
   "tester_count": 1,
   "bug_tracker": "github_issues",
   "sessions_completed": 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Added — Steam auto-prune of selectedAppsToPrefill.json (auto-classify actuator, Piece 1) — 2026-07-04
+
+The #225 auto-classify-block wrote `prefill_exclusions` rows but gated the orchestrator's *own* scheduled prefill — which is disabled on prod, where the host **SteamPrefill cron** does the prefilling from `selectedAppsToPrefill.json`. So the exclusions never actually stopped Steam re-downloads. This wires the actuator to the file the host cron reads: after `auto_classify_block` classifies, it calls a new agent endpoint that reconciles `selectedAppsToPrefill.json` — **removes** classifier-excluded non-games and **keeps/re-adds** operator-'allow' games — so the next SteamPrefill run skips them. Download-once-then-block, per the operator decision.
+
+- **`reconcile_selection`** (`platform/steam/selection_file.py`, pure/stdlib): removes exclude ids, ensures restore ids present, restore wins over exclude, drops non-integers.
+- **`POST /v1/steam/prune-selection`** (`agent/routers/steam.py`, bearer): reconciles the file, preserving the ORIGINAL curated list once in a `.bak` sidecar; no-op writes nothing.
+- **`AgentClient.prune_steam_selection`** + `enqueue_auto_classify_block` actuation (best-effort, never-raises) threaded through `SchedulerManager` / `api/main.py` (agent-enabled only).
+- Reversible: `selection allow steam/<id>` → the game is restored to the selection on the next tick. Non-destructive (never deletes cache). Import-isolation preserved; full suite 1464; security audit `docs/security-audits/piece1-steam-prune-selection-security-audit.md` (no findings).
+
+
 ### Added — Auto-classify-block: stop re-prefilling non-games after they download once (#225) — 2026-07-04
 
 The scheduled prefill downloads every owned game, so soundtracks / tools / SDKs / dedicated servers / demos got cached and re-cached on every cycle. New behavior (operator decision 2026-07-04 — "download everything, then classify and block after"): a new scheduler step, on the same interval as the prefill, runs the #229 classifier over owned Steam games that have been prefilled at least once and inserts an `exclude` row into the new `prefill_exclusions` table for flagged non-games. The scheduled prefill gains a `NOT EXISTS(... mode='exclude')` clause, so the next cycle skips them — the non-game is downloaded **once**, then never re-pulled.

--- a/docs/security-audits/piece1-steam-prune-selection-security-audit.md
+++ b/docs/security-audits/piece1-steam-prune-selection-security-audit.md
@@ -1,0 +1,34 @@
+# Security Audit — Piece 1: Steam auto-prune selectedAppsToPrefill.json
+
+**Feature:** steam-prune-selection — the auto-classify-block actuator for Steam. The control plane hands the agent the Steam app_ids to remove ('exclude') / keep ('restore') and the agent reconciles SteamPrefill's `selectedAppsToPrefill.json` so the host prefill cron stops caching classifier-flagged non-games.
+**Modules:**
+- `platform/steam/selection_file.py` — pure `reconcile_selection` + `as_int`
+- `agent/routers/steam.py` — `POST /v1/steam/prune-selection` (bearer-gated)
+- `clients/agent_client.py` — `prune_steam_selection`
+- `scheduler/jobs.py` — `enqueue_auto_classify_block` actuates via the agent client; `scheduler/manager.py`, `api/main.py` thread it through
+**Audit date:** 2026-07-04
+**Auditor:** self-review + ruff (flake8-bandit `S`) + mypy + full suite (1464)
+**Phase:** 2 (Construction), Build Loop 2.4
+
+<!-- Last Updated: 2026-07-04 -->
+
+## Methodology
+1. `ruff check` (S) — clean. 2. `mypy` — clean (98 files). 3. `tests/agent/test_import_isolation.py` green — `selection_file` is stdlib-only, so the agent still imports neither `api.main` nor `db.pool`. 4. Threat cross-check: path traversal, secrets, availability, destructive-safety.
+
+## Audit findings
+
+| # | Severity | Title | Status |
+|---|----------|-------|--------|
+| — | — | No findings. | — |
+
+## Non-findings (checked, clean)
+
+- **No path traversal.** The target path is fixed: `settings.steam_prefill_config_dir / "selectedAppsToPrefill.json"`. The request body carries only integer app_ids (`list[int]`, Pydantic-validated); no request string reaches a filesystem path. The `.bak` sidecar is a fixed sibling name.
+- **Non-destructive + reversible.** Only the app_id list is rewritten — never the cache. The ORIGINAL curated list is preserved once in `selectedAppsToPrefill.json.bak` (written only if absent). `restore` (operator 'allow') wins over `exclude`, so an un-excluded game is re-added, and a no-op change writes nothing.
+- **Authz.** `/v1/steam/prune-selection` sits behind the agent bearer middleware, like every other `/v1/*` write. The control plane calls it over the same source-IP-allowlisted channel as prefill/validate.
+- **No secrets.** No credential path; the endpoint reads/writes only the app_id list.
+- **Availability.** The actuation in `enqueue_auto_classify_block` is wrapped in `try/except Exception` and never raises (scheduler-callback contract); a failed prune is logged and retried next tick. The DB `prefill_exclusions` rows are the source of truth, so a dropped prune loses no state.
+- **Malformed input tolerated.** `reconcile_selection` drops non-integer / bool entries; an unreadable or non-list JSON file returns a no-op result instead of raising.
+
+## Decision
+No findings. Ship.

--- a/src/orchestrator/agent/routers/steam.py
+++ b/src/orchestrator/agent/routers/steam.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 from typing import Any
 
@@ -13,6 +14,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from orchestrator.agent.manifest_archive import sync_manifests_to_archive
 from orchestrator.agent.manifest_locator import list_prefilled_app_ids, locate_manifest_bins
 from orchestrator.agent.manifest_parser import parse_chunk_shas, parse_shas
+from orchestrator.platform.steam.selection_file import reconcile_selection
 from orchestrator.validator.cache_key import (
     cache_key,
     cache_path,
@@ -158,6 +160,44 @@ async def downloaded_state(request: Request) -> dict[str, list[int]]:
 async def auth_status(request: Request) -> dict[str, Any]:
     st = request.app.state.prefill_driver.auth_status()
     return {"ok": st.ok, "reason": st.reason}
+
+
+class PruneSelectionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    exclude_app_ids: list[int] = Field(default_factory=list)
+    restore_app_ids: list[int] = Field(default_factory=list)
+
+
+@router.post("/v1/steam/prune-selection")
+async def prune_selection(body: PruneSelectionRequest, request: Request) -> dict[str, Any]:
+    """Reconcile SteamPrefill's selectedAppsToPrefill.json (Piece 1): remove
+    ``exclude_app_ids`` (classifier non-games) and ensure ``restore_app_ids``
+    (operator 'allow') are present, so the host SteamPrefill cron stops caching
+    the non-games. The original curated list is preserved once in a `.bak`
+    sidecar; a no-op change writes nothing. Idempotent."""
+    s = request.app.state.settings
+    path = Path(s.steam_prefill_config_dir) / "selectedAppsToPrefill.json"
+    if not path.exists():
+        return {"removed": 0, "restored": 0, "remaining": 0, "note": "no selection file"}
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {"removed": 0, "restored": 0, "remaining": 0, "note": "unreadable"}
+    current = data if isinstance(data, list) else []
+    new, removed, restored = reconcile_selection(
+        current, exclude_ids=body.exclude_app_ids, restore_ids=body.restore_app_ids
+    )
+    if removed or restored:
+        try:
+            bak = path.parent / "selectedAppsToPrefill.json.bak"
+            if not bak.exists():  # preserve the ORIGINAL curated list, once
+                bak.write_text(path.read_text())
+            path.write_text(json.dumps(new))
+        except OSError as e:
+            _log.error("agent.prune_selection.write_failed", reason=str(e)[:200])
+            raise HTTPException(status_code=500, detail="selection write failed") from e
+    _log.info("agent.prune_selection.done", removed=removed, restored=restored, remaining=len(new))
+    return {"removed": removed, "restored": restored, "remaining": len(new)}
 
 
 @router.get("/v1/steam/prefilled-apps")

--- a/src/orchestrator/api/main.py
+++ b/src/orchestrator/api/main.py
@@ -228,6 +228,9 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         auto_classify_block_enabled=settings.auto_classify_block_enabled,
         fetch_manifests_enabled=settings.fetch_manifests_enabled,
         fetch_manifests_cron=settings.fetch_manifests_cron,
+        # Piece 1: lets auto_classify_block actuate the Steam selection prune on
+        # the agent (only used when agent_enabled). None-safe when the agent is off.
+        agent_client=agent_client if settings.agent_enabled else None,
     )
     try:
         await scheduler_manager.start()

--- a/src/orchestrator/clients/agent_client.py
+++ b/src/orchestrator/clients/agent_client.py
@@ -160,6 +160,23 @@ class AgentClient:
         result: dict[str, int] = resp.json()
         return result
 
+    async def prune_steam_selection(
+        self, exclude_app_ids: list[int], restore_app_ids: list[int] | None = None
+    ) -> dict[str, Any]:
+        """Reconcile SteamPrefill's selectedAppsToPrefill.json on the agent (Piece
+        1): remove exclude_app_ids (classifier non-games), keep/re-add
+        restore_app_ids (operator 'allow'). Returns {removed, restored, remaining}."""
+        resp = await self._request(
+            "POST",
+            "/v1/steam/prune-selection",
+            json={
+                "exclude_app_ids": exclude_app_ids,
+                "restore_app_ids": restore_app_ids or [],
+            },
+        )
+        result: dict[str, Any] = resp.json()
+        return result
+
     async def steam_validate(self, app_id: int) -> dict[str, Any]:
         # A big game (tens of thousands of chunks) stat's many cache files over
         # NFS and can take well over the default 30s timeout — use a generous

--- a/src/orchestrator/platform/steam/selection_file.py
+++ b/src/orchestrator/platform/steam/selection_file.py
@@ -1,0 +1,62 @@
+"""Pure reconciliation of SteamPrefill's selectedAppsToPrefill.json (Piece 1).
+
+The host SteamPrefill cron prefills every app in this file; to stop caching a
+non-game the app must be REMOVED from it. The control plane classifies (it has
+the Steam store types) and hands the agent the app_ids to remove ('exclude') and
+to keep/re-add ('restore' = operator 'allow'). This module is the pure list
+reconciliation — stdlib only, so the agent can import it (import-isolation).
+NEVER touches credentials or the cache; only the app_id list.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+def as_int(value: object) -> int | None:
+    """Parse an app_id (int or numeric str) to int, else None. Shared with the
+    scheduler's prune actuation so both sides coerce ids identically."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _int_set(values: Iterable[object]) -> set[int]:
+    out: set[int] = set()
+    for v in values:
+        i = as_int(v)
+        if i is not None:
+            out.add(i)
+    return out
+
+
+def reconcile_selection(
+    current: Iterable[object],
+    *,
+    exclude_ids: Iterable[object],
+    restore_ids: Iterable[object],
+) -> tuple[list[int], int, int]:
+    """Return (new_sorted_app_ids, removed_count, restored_count).
+
+    Removes ``exclude_ids`` from ``current`` and ensures ``restore_ids`` are
+    present. ``restore`` wins over ``exclude`` (an operator 'allow' keeps the app
+    even if it's also classifier-excluded). Non-integer entries are dropped.
+    """
+    cur = _int_set(current)
+    exclude = _int_set(exclude_ids)
+    restore = _int_set(restore_ids)
+
+    to_remove = cur & (exclude - restore)
+    to_add = restore - cur
+    new = (cur - to_remove) | restore
+    return sorted(new), len(to_remove), len(to_add)

--- a/src/orchestrator/scheduler/jobs.py
+++ b/src/orchestrator/scheduler/jobs.py
@@ -12,8 +12,10 @@ from typing import TYPE_CHECKING
 import structlog
 
 from orchestrator.db.pool import PoolError
+from orchestrator.platform.steam.selection_file import as_int
 
 if TYPE_CHECKING:
+    from orchestrator.clients.agent_client import AgentClient
     from orchestrator.db.pool import Pool
 
 _log = structlog.get_logger(__name__)
@@ -172,7 +174,7 @@ async def enqueue_scheduled_prefill(pool: Pool) -> int:
         return 0
 
 
-async def enqueue_auto_classify_block(pool: Pool) -> int:
+async def enqueue_auto_classify_block(pool: Pool, agent_client: AgentClient | None = None) -> int:
     """Auto-exclude non-games from FUTURE scheduled prefill, AFTER they've been
     downloaded once (#225/#366).
 
@@ -234,4 +236,31 @@ async def enqueue_auto_classify_block(pool: Pool) -> int:
             )
     if inserted:
         _log.info("scheduler.auto_classify_block.excluded", count=inserted)
+
+    # Piece 1 (Steam): actuate — prune SteamPrefill's selectedAppsToPrefill.json on
+    # the agent so the HOST prefill cron stops caching the excluded non-games (the
+    # orchestrator's own scheduled prefill is not the active Steam driver). The DB
+    # exclusions are the source of truth; a failed prune just retries next tick.
+    # Sends the FULL steam exclude + allow sets each run so the file converges and
+    # an operator 'allow' re-adds a game. Best-effort; never raises.
+    if agent_client is not None:
+        try:
+            excl = await pool.read_all(
+                "SELECT app_id FROM prefill_exclusions "
+                "WHERE platform = 'steam' AND mode = 'exclude'"
+            )
+            allow = await pool.read_all(
+                "SELECT app_id FROM prefill_exclusions WHERE platform = 'steam' AND mode = 'allow'"
+            )
+            exclude_ids = [i for i in (as_int(r["app_id"]) for r in excl) if i is not None]
+            restore_ids = [i for i in (as_int(r["app_id"]) for r in allow) if i is not None]
+            if exclude_ids or restore_ids:
+                res = await agent_client.prune_steam_selection(exclude_ids, restore_ids)
+                _log.info("scheduler.auto_classify_block.pruned", **res)
+        except Exception as e:
+            _log.error(
+                "scheduler.auto_classify_block.prune_failed",
+                error=type(e).__name__,
+                reason=str(e)[:200],
+            )
     return inserted

--- a/src/orchestrator/scheduler/manager.py
+++ b/src/orchestrator/scheduler/manager.py
@@ -33,6 +33,7 @@ from orchestrator.scheduler.jobs import (
 if TYPE_CHECKING:
     from apscheduler.job import Job
 
+    from orchestrator.clients.agent_client import AgentClient
     from orchestrator.db.pool import Pool
 
 _log = structlog.get_logger(__name__)
@@ -69,8 +70,10 @@ class SchedulerManager:
         auto_classify_block_enabled: bool = True,
         fetch_manifests_enabled: bool = True,
         fetch_manifests_cron: str = "0 5 * * 1",
+        agent_client: AgentClient | None = None,
     ) -> None:
         self._pool = pool
+        self._agent_client = agent_client
         self._enabled = enabled
         self._library_sync_interval_sec = library_sync_interval_sec
         self._validation_sweep_enabled = validation_sweep_enabled
@@ -164,7 +167,7 @@ class SchedulerManager:
                 scheduler.add_job(
                     enqueue_auto_classify_block,
                     trigger=IntervalTrigger(seconds=self._library_sync_interval_sec),
-                    args=(self._pool,),
+                    args=(self._pool, self._agent_client),
                     id=AUTO_CLASSIFY_BLOCK_JOB_ID,
                     name="Auto-exclude non-games from prefill (post-download)",
                     replace_existing=True,

--- a/tests/agent/test_steam.py
+++ b/tests/agent/test_steam.py
@@ -273,3 +273,59 @@ def test_prefilled_apps_lists_distinct_app_ids(tmp_path):
     resp = client.get("/v1/steam/prefilled-apps")
     assert resp.status_code == 200
     assert resp.json() == {"app_ids": [440, 730]}
+
+
+def test_prune_selection_removes_and_backs_up(tmp_path):
+    import json
+
+    (tmp_path / "selectedAppsToPrefill.json").write_text(json.dumps([1, 2, 3]))
+    app = create_agent_app(
+        settings=Settings(orchestrator_token="a" * 32, steam_prefill_config_dir=tmp_path)
+    )
+    client = TestClient(app, headers={"Authorization": "Bearer " + "a" * 32})
+    resp = client.post(
+        "/v1/steam/prune-selection", json={"exclude_app_ids": [2], "restore_app_ids": []}
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"removed": 1, "restored": 0, "remaining": 2}
+    assert json.loads((tmp_path / "selectedAppsToPrefill.json").read_text()) == [1, 3]
+    # the ORIGINAL curated list is preserved in the .bak sidecar
+    assert json.loads((tmp_path / "selectedAppsToPrefill.json.bak").read_text()) == [1, 2, 3]
+
+
+def test_prune_selection_restore_readds(tmp_path):
+    import json
+
+    (tmp_path / "selectedAppsToPrefill.json").write_text(json.dumps([1]))
+    app = create_agent_app(
+        settings=Settings(orchestrator_token="a" * 32, steam_prefill_config_dir=tmp_path)
+    )
+    client = TestClient(app, headers={"Authorization": "Bearer " + "a" * 32})
+    resp = client.post(
+        "/v1/steam/prune-selection", json={"exclude_app_ids": [], "restore_app_ids": [5]}
+    )
+    assert resp.json()["restored"] == 1
+    assert json.loads((tmp_path / "selectedAppsToPrefill.json").read_text()) == [1, 5]
+
+
+def test_prune_selection_noop_no_backup(tmp_path):
+    import json
+
+    (tmp_path / "selectedAppsToPrefill.json").write_text(json.dumps([1, 2]))
+    app = create_agent_app(
+        settings=Settings(orchestrator_token="a" * 32, steam_prefill_config_dir=tmp_path)
+    )
+    client = TestClient(app, headers={"Authorization": "Bearer " + "a" * 32})
+    resp = client.post("/v1/steam/prune-selection", json={"exclude_app_ids": [9]})
+    assert resp.json()["removed"] == 0
+    assert not (tmp_path / "selectedAppsToPrefill.json.bak").exists()
+
+
+def test_prune_selection_missing_file(tmp_path):
+    app = create_agent_app(
+        settings=Settings(orchestrator_token="a" * 32, steam_prefill_config_dir=tmp_path)
+    )
+    client = TestClient(app, headers={"Authorization": "Bearer " + "a" * 32})
+    resp = client.post("/v1/steam/prune-selection", json={"exclude_app_ids": [1]})
+    assert resp.status_code == 200
+    assert resp.json()["removed"] == 0

--- a/tests/clients/test_agent_client.py
+++ b/tests/clients/test_agent_client.py
@@ -420,3 +420,18 @@ async def test_epic_validate_single_call():
     )
     assert res["chunks_cached"] == 85
     assert res["outcome"] == "partial"
+
+
+async def test_prune_steam_selection_posts_and_returns():
+    import json as _json
+
+    def handler(request):
+        assert request.method == "POST"
+        assert request.url.path == "/v1/steam/prune-selection"
+        body = _json.loads(request.content)
+        assert body == {"exclude_app_ids": [2, 3], "restore_app_ids": [5]}
+        return httpx.Response(200, json={"removed": 2, "restored": 1, "remaining": 10})
+
+    client = _client(handler)
+    res = await client.prune_steam_selection([2, 3], [5])
+    assert res == {"removed": 2, "restored": 1, "remaining": 10}

--- a/tests/platform/steam/test_selection_file.py
+++ b/tests/platform/steam/test_selection_file.py
@@ -1,0 +1,43 @@
+"""Pure reconciliation of selectedAppsToPrefill.json (Piece 1 — Steam auto-prune)."""
+
+from __future__ import annotations
+
+from orchestrator.platform.steam.selection_file import reconcile_selection
+
+
+def test_removes_excluded_app_ids():
+    new, removed, restored = reconcile_selection([1, 2, 3], exclude_ids=[2], restore_ids=[])
+    assert new == [1, 3]
+    assert removed == 1
+    assert restored == 0
+
+
+def test_restore_wins_over_exclude():
+    # A game both excluded and restored (allow overrides) stays in the list.
+    new, removed, _ = reconcile_selection([1, 2], exclude_ids=[2], restore_ids=[2])
+    assert new == [1, 2]
+    assert removed == 0
+
+
+def test_restore_readds_missing_app():
+    # An allow'd app that was previously pruned is added back.
+    new, _, restored = reconcile_selection([1], exclude_ids=[], restore_ids=[5])
+    assert new == [1, 5]
+    assert restored == 1
+
+
+def test_idempotent_when_nothing_matches():
+    new, removed, restored = reconcile_selection([1, 2, 3], exclude_ids=[9], restore_ids=[])
+    assert new == [1, 2, 3]
+    assert (removed, restored) == (0, 0)
+
+
+def test_tolerates_string_ids_and_dedups():
+    new, removed, _ = reconcile_selection(["1", "2", 2], exclude_ids=["2"], restore_ids=[])
+    assert new == [1]
+    assert removed == 1
+
+
+def test_skips_non_integer_entries():
+    new, _, _ = reconcile_selection([1, None, "x", 3], exclude_ids=[], restore_ids=[])
+    assert new == [1, 3]

--- a/tests/scheduler/test_jobs.py
+++ b/tests/scheduler/test_jobs.py
@@ -347,3 +347,29 @@ class TestEnqueueAutoClassifyBlock:
 
         pool.read_all = AsyncMock(side_effect=PoolError("simulated"))
         assert await enqueue_auto_classify_block(pool) == 0
+
+
+class TestAutoClassifyBlockActuation:
+    async def test_prunes_selection_via_agent_client(self, pool):
+        from unittest.mock import AsyncMock
+
+        from orchestrator.scheduler.jobs import enqueue_auto_classify_block
+
+        await _seed_classified(pool, "1", "music", "OST")  # classified → exclude
+        await pool.execute_write(
+            "INSERT INTO prefill_exclusions (platform, app_id, mode, source) "
+            "VALUES ('steam','9','allow','operator')"
+        )
+        agent = AsyncMock()
+        agent.prune_steam_selection.return_value = {"removed": 1, "restored": 0, "remaining": 5}
+        await enqueue_auto_classify_block(pool, agent)
+        agent.prune_steam_selection.assert_awaited_once()
+        exclude_ids, restore_ids = agent.prune_steam_selection.await_args.args
+        assert 1 in exclude_ids  # the music app auto-excluded
+        assert 9 in restore_ids  # the operator allow
+
+    async def test_no_agent_client_skips_prune(self, pool):
+        from orchestrator.scheduler.jobs import enqueue_auto_classify_block
+
+        await _seed_classified(pool, "1", "music", "OST")
+        assert await enqueue_auto_classify_block(pool) == 1  # exclusion written, no prune, no raise


### PR DESCRIPTION
**Piece 1 of 3** for the prefill-orchestration redesign. Makes the #225 auto-classify-block actually *bite* on Steam.

## Why
#225 wrote `prefill_exclusions` and gated the orchestrator's own `enqueue_scheduled_prefill` — but that's **disabled on prod**, where the host **SteamPrefill cron** does the prefilling from `selectedAppsToPrefill.json`. So the exclusions never stopped a Steam re-download. This wires the actuator to the file the cron actually reads.

## What
- After `auto_classify_block` classifies, it calls a new agent endpoint that **reconciles `selectedAppsToPrefill.json`**: removes classifier-excluded non-games, keeps/re-adds operator-`allow` games. Next SteamPrefill run skips the non-games. Download-once-then-block.
- `POST /v1/steam/prune-selection` (agent, bearer-gated) — preserves the **original curated list once** in a `.bak` sidecar; a no-op change writes nothing.
- `reconcile_selection` is pure/stdlib (agent import-isolation preserved). `AgentClient.prune_steam_selection` + the scheduler actuation are best-effort and never-raise.
- **Reversible:** `orchestrator-cli selection allow steam/<id>` → restored to the selection next tick. **Non-destructive:** only the app-id list changes; never the cache.

## Tests
`reconcile_selection` (6), agent endpoint (4: remove+backup, restore, no-op-no-backup, missing-file), AgentClient (1), scheduler actuation (2). Full suite **1464**, ruff + mypy clean, import isolation green. Security audit: no findings.

## Next
- **Piece 2** (Epic auto-download via orchestrator) and **Piece 3** (Game_shelf pushes "Epic-copy-is-on-Steam → skip" exclusions) follow.
- Deploy: control-plane **and** agent (new endpoint on the agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)