### PR TITLE
feat(agent): list manual-download game folders per launcher (#222)

### DIFF
--- a/.claude/build-progress.json
+++ b/.claude/build-progress.json
@@ -39,13 +39,14 @@
     "steam-prune-selection",
     "epic-auto-download",
     "piece3-gameshelf-exclusions",
-    "mp-only-exclusion"
+    "mp-only-exclusion",
+    "manual-download-checker-agent"
   ],
-  "features_since_last_test": 4,
-  "features_since_last_health_check": 3,
+  "features_since_last_test": 5,
+  "features_since_last_health_check": 4,
   "test_interval": 2,
   "last_test_session": "2026-07-04",
-  "testing_required": false,
+  "testing_required": true,
   "tester_count": 1,
   "bug_tracker": "github_issues",
   "sessions_completed": 15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Added — Manual-download folder listing endpoint (#222, agent + orch) — 2026-07-04
+
+Games downloaded by hand (GOG / Humble / Itch / Amazon — launchers with no prefill automation) live in per-launcher folders on the lancache host (`/lancache/lancache/cache/GOG/<game>`, …). This exposes that listing so a coverage checker can diff the owned library against what was actually downloaded.
+
+- **Added:** agent `GET /v1/manual-downloads/{launcher}` → `{launcher, present, entries}` (lists game folders under `manual_downloads_cache_path/<launcher>/`; filters non-dirs, `!*` control entries, dotfiles). New setting `manual_downloads_cache_path` (default `/data/cache` — the parent of the nginx hash cache; the agent already mounts it, so no new mount).
+- **Added:** orchestrator `GET /api/v1/manual-downloads/{launcher}` proxying the agent + `AgentClient.manual_downloads()`.
+- **Security:** the `{launcher}` path component is allowlisted (`^[A-Za-z0-9_-]+$`) at both hops and the agent re-asserts the resolved target is a direct child of the cache root — path traversal is impossible. Read-only; proxy never 500s (agent errors → 503). Audit `docs/security-audits/manual-download-checker-agent-security-audit.md` (no findings).
+- The Game_shelf slug-diff coverage report (owned library vs these folders) lands in a follow-up. Only GOG has data today; Humble/Itch/Amazon folders are added when Karl downloads them.
+
 ### Added — MP-only prefill exclusion: multiplayer-only games flagged (#366) — 2026-07-04
 
 A Steam game with a multiplayer category and NO single-player mode (e.g. Dota 2) is typed `game` by the store, so the type/name classifier couldn't catch it. Operator decision (Karl 2026-07-04): exclude multiplayer-only games from prefill — not worth the cache/WAN for a rare one-off play.

--- a/docs/security-audits/manual-download-checker-agent-security-audit.md
+++ b/docs/security-audits/manual-download-checker-agent-security-audit.md
@@ -1,0 +1,50 @@
+# Security Audit — Manual-download folder listing (agent + orch proxy, #222)
+
+**Feature:** manual-download-checker (agent side) — `GET /v1/manual-downloads/{launcher}` on the
+agent lists the game folders under `manual_downloads_cache_path/<launcher>/` (where Karl stores
+hand-downloaded GOG/Humble/Itch/Amazon games); the orchestrator proxies it at
+`GET /api/v1/manual-downloads/{launcher}` so Game_shelf can diff the owned library against what
+was actually downloaded. Read-only.
+**Modules:** `agent/routers/manual_downloads.py`, `api/routers/manual_downloads.py`,
+`clients/agent_client.py`, `core/settings.py` (new `manual_downloads_cache_path`)
+**Audit date:** 2026-07-04 · **Auditor:** self-review (Senior Security Engineer persona) + ruff (S) + mypy + full suite (1508) · **Phase:** 2, Build Loop 2.4
+
+<!-- Last Updated: 2026-07-04 -->
+
+## Methodology
+ruff `--select S` clean, mypy clean (100 files), agent + api suites + full suite green
+(1508 passed; only the pre-existing `test_licenses` tooling gap fails locally). Primary threat:
+**path traversal** (the launcher is a filesystem path component). Also checked: auth, info
+disclosure, availability, DoS.
+
+## Findings
+| # | Severity | Title | Status |
+|---|----------|-------|--------|
+| — | — | No findings. | — |
+
+## Non-findings (checked, clean)
+- **Path traversal — defended in depth.** `{launcher}` becomes a path component
+  (`manual_downloads_cache_path / launcher`), the classic traversal vector. Three layers block it:
+  (1) `_LAUNCHER_RE = ^[A-Za-z0-9_-]+$` at BOTH the orchestrator route and the agent endpoint —
+  no `.` and no `/`, so `..` and absolute paths are unrepresentable; (2) the agent additionally
+  `resolve()`s the target and rejects it unless `target.parent == cache_root.resolve()` (a direct
+  child); (3) FastAPI path params never span `/`. `test_rejects_path_traversal_launcher` exercises
+  `..`, `../cache`, `GOG/..`, `%2e%2e` → all 400/404, never a traversal.
+- **Read-only, bounded disclosure.** The endpoint only `iterdir()`s ONE launcher subfolder and
+  returns directory NAMES (game folder names — not sensitive, and the whole point). It cannot list
+  an arbitrary path (traversal blocked), read file contents, or write anything. Dotfiles, `!*`
+  control entries, and non-directories (README.md) are filtered out.
+- **Auth on both hops.** Bearer token required on the agent endpoint and the orchestrator proxy
+  (`test_requires_auth` on each). The agent is additionally source-IP-gated in the LAN deploy.
+- **Availability — never 500s.** The orchestrator proxy catches ALL agent errors (down/transport)
+  → 503; a missing agent_client → 503; a missing launcher folder → `present:false` (200, not an
+  error). The agent returns `present:false` for an absent folder rather than raising.
+- **DoS bounded.** A single `iterdir` over one launcher folder (hundreds of entries in practice);
+  no recursion, no unbounded work, no writes.
+- **No injection.** `launcher` is validated against the allowlist before any use; no SQL, no shell,
+  no format-string of untrusted data into a path beyond the sanitized single component.
+
+## Decision
+No findings. Ship. (Control-plane + agent; the agent already mounts `/lancache/lancache/cache ->
+/data/cache`, so `manual_downloads_cache_path=/data/cache` needs no new mount. The Game_shelf
+slug-diff + coverage report is a separate follow-up PR.)

--- a/src/orchestrator/agent/app.py
+++ b/src/orchestrator/agent/app.py
@@ -13,7 +13,7 @@ from fastapi import FastAPI
 
 from orchestrator.agent.jobs import AgentJobStore
 from orchestrator.agent.manifest_archive import manifest_archive_sync_loop
-from orchestrator.agent.routers import epic, health, pull, stat, steam
+from orchestrator.agent.routers import epic, health, manual_downloads, pull, stat, steam
 from orchestrator.api.middleware import BearerAuthMiddleware, SourceAllowlistMiddleware
 from orchestrator.core.net import detect_non_loopback_bind
 from orchestrator.core.settings import Settings, get_settings
@@ -130,6 +130,7 @@ def create_agent_app(*, settings: Settings | None = None) -> FastAPI:
     app.include_router(stat.router)
     app.include_router(steam.router)
     app.include_router(epic.router)
+    app.include_router(manual_downloads.router)
 
     # Security wiring (mirrors the API). Middleware added LAST is OUTERMOST, so
     # SourceAllowlist (added second) wraps BearerAuth: a request is first checked

--- a/src/orchestrator/agent/routers/manual_downloads.py
+++ b/src/orchestrator/agent/routers/manual_downloads.py
@@ -1,0 +1,51 @@
+"""Agent GET /v1/manual-downloads/{launcher} — list manually-downloaded game folders (#222).
+
+Karl stores games he downloaded by hand (GOG / Humble / Itch / Amazon — launchers
+with no prefill automation) in per-launcher folders under the cache root, e.g.
+``<manual_downloads_cache_path>/GOG/<game>``. This endpoint lists those folder
+names so the control plane can diff them against the owned library and report
+which owned games were never downloaded. Read-only.
+"""
+
+from __future__ import annotations
+
+import re
+
+from fastapi import APIRouter, HTTPException, Request, status
+from pydantic import BaseModel, ConfigDict
+
+router = APIRouter()
+
+# The launcher is a single path component (a folder name on disk, e.g. "GOG").
+# Restricting it to alnum / '_' / '-' means it can contain NO '.' or '/', so it
+# can never form '..' or escape the cache root — path-traversal is impossible by
+# construction (defense-in-depth resolve-check below regardless).
+_LAUNCHER_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+class ManualDownloadsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    launcher: str
+    present: bool
+    entries: list[str]
+
+
+@router.get("/v1/manual-downloads/{launcher}")
+async def manual_downloads(launcher: str, request: Request) -> ManualDownloadsResponse:
+    if not _LAUNCHER_RE.match(launcher):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="invalid launcher")
+    settings = request.app.state.settings
+    root = settings.manual_downloads_cache_path.resolve()
+    target = (root / launcher).resolve()
+    # Defense-in-depth: the sanitized launcher can't traverse, but re-assert the
+    # resolved target is a direct child of the cache root before touching disk.
+    if target.parent != root:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="invalid launcher")
+    if not target.is_dir():
+        return ManualDownloadsResponse(launcher=launcher, present=False, entries=[])
+    # Game folders only: skip files (README.md), lancache control entries
+    # (!downloading / !orphaned), and any dotfiles.
+    entries = sorted(
+        e.name for e in target.iterdir() if e.is_dir() and not e.name.startswith(("!", "."))
+    )
+    return ManualDownloadsResponse(launcher=launcher, present=True, entries=entries)

--- a/src/orchestrator/api/main.py
+++ b/src/orchestrator/api/main.py
@@ -35,6 +35,7 @@ from orchestrator.api.routers.games import router as games_router
 from orchestrator.api.routers.health import router as health_router
 from orchestrator.api.routers.jobs import router as jobs_router
 from orchestrator.api.routers.manifests import router as manifests_router
+from orchestrator.api.routers.manual_downloads import router as manual_downloads_router
 from orchestrator.api.routers.platforms import router as platforms_router
 from orchestrator.api.routers.prefill_exclusions import router as prefill_exclusions_router
 from orchestrator.api.routers.prefill_trigger import router as prefill_trigger_router
@@ -436,6 +437,7 @@ def create_app() -> FastAPI:
     app.include_router(block_list_router)
     app.include_router(jobs_router)
     app.include_router(manifests_router)
+    app.include_router(manual_downloads_router)
     app.include_router(validate_trigger_router)
     app.include_router(sweep_trigger_router)
     app.include_router(fetch_manifests_trigger_router)

--- a/src/orchestrator/api/routers/manual_downloads.py
+++ b/src/orchestrator/api/routers/manual_downloads.py
@@ -1,0 +1,46 @@
+"""GET /api/v1/manual-downloads/{launcher} — list manually-downloaded game folders (#222).
+
+The manually-downloaded games (GOG / Humble / Itch / Amazon — launchers with no
+prefill automation) live in per-launcher folders on the lancache host, which only
+the data-plane agent can see. This proxies the agent's listing so Game_shelf can
+diff the owned library against what was actually downloaded. Read-only.
+"""
+
+from __future__ import annotations
+
+import re
+
+import structlog
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+_log = structlog.get_logger(__name__)
+
+# Same allowlist the agent enforces — a single traversal-safe path component.
+_LAUNCHER_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+router = APIRouter(prefix="/api/v1", tags=["manual-downloads"])
+
+
+@router.get(
+    "/manual-downloads/{launcher}",
+    responses={
+        200: {"description": "Folder listing {launcher, present, entries}"},
+        400: {"description": "Invalid launcher"},
+        401: {"description": "Missing or invalid bearer token"},
+        503: {"description": "Agent not configured or unavailable"},
+    },
+    summary="List manually-downloaded game folders for a launcher",
+)
+async def manual_downloads(launcher: str, request: Request) -> JSONResponse:
+    if not _LAUNCHER_RE.match(launcher):
+        return JSONResponse(content={"detail": "invalid launcher"}, status_code=400)
+    client = getattr(request.app.state, "agent_client", None)
+    if client is None:
+        return JSONResponse(content={"detail": "agent not configured"}, status_code=503)
+    try:
+        result = await client.manual_downloads(launcher)
+    except Exception as e:  # agent down / transport error — never 500
+        _log.error("api.manual_downloads.agent_error", launcher=launcher, reason=str(e)[:200])
+        return JSONResponse(content={"detail": "agent unavailable"}, status_code=503)
+    return JSONResponse(content=result)

--- a/src/orchestrator/clients/agent_client.py
+++ b/src/orchestrator/clients/agent_client.py
@@ -212,6 +212,14 @@ class AgentClient:
         result: list[int] = resp.json()["app_ids"]
         return result
 
+    async def manual_downloads(self, launcher: str) -> dict[str, Any]:
+        """List the manually-downloaded game folders under `<cache>/<launcher>/`
+        on the agent host (#222). Returns {launcher, present, entries}. The caller
+        validates `launcher` (alnum/_/-) before it reaches the path."""
+        resp = await self._request("GET", f"/v1/manual-downloads/{launcher}")
+        result: dict[str, Any] = resp.json()
+        return result
+
     async def downloaded_state(self) -> dict[str, list[int]]:
         resp = await self._request("GET", "/v1/steam/downloaded-state")
         result: dict[str, list[int]] = resp.json()

--- a/src/orchestrator/core/settings.py
+++ b/src/orchestrator/core/settings.py
@@ -155,6 +155,11 @@ class Settings(BaseSettings):
 
     # --- Lancache cache topology ------------------------------------
     lancache_nginx_cache_path: Path = Path("/data/cache/cache/")
+    # #222: root under which manually-downloaded games are stored in per-launcher
+    # folders (e.g. `<root>/GOG/<game>`). This is the PARENT of the nginx hash
+    # cache — the agent mounts /lancache/lancache/cache here, so GOG lives at
+    # /data/cache/GOG alongside the nginx `cache/` dir.
+    manual_downloads_cache_path: Path = Path("/data/cache")
     cache_slice_size_bytes: int = Field(default=10_485_760, gt=0)
     cache_levels: str = Field(default="2:2", pattern=r"^\d+(:\d+)*$")
     # F7: nginx $cacheidentifier for Steam traffic (the lancache map sets

--- a/tests/agent/test_manual_downloads.py
+++ b/tests/agent/test_manual_downloads.py
@@ -1,0 +1,82 @@
+"""Tests for the agent GET /v1/manual-downloads/{launcher} endpoint (#222).
+
+Lists the manually-downloaded game folders under
+``manual_downloads_cache_path/<launcher>/`` so the control plane can diff them
+against the owned library (Game_shelf). Read-only; the launcher path component is
+strictly sanitized against traversal.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi.testclient import TestClient
+
+from orchestrator.agent.app import create_agent_app
+from orchestrator.core.settings import Settings
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+AUTH = {"Authorization": "Bearer " + "a" * 32}
+
+
+def _settings(root: Path) -> Settings:
+    return Settings(orchestrator_token="a" * 32, manual_downloads_cache_path=root)
+
+
+def _seed_gog(root: Path) -> None:
+    gog = root / "GOG"
+    for name in ("alien_breed_2_assault", "akalabeth_world_of_doom", "trine_2"):
+        (gog / name).mkdir(parents=True)
+    # Special entries that must be filtered out.
+    (gog / "!downloading").mkdir()
+    (gog / "!orphaned").mkdir()
+    (gog / "README.md").write_text("notes")
+
+
+def test_lists_game_folders(tmp_path):
+    _seed_gog(tmp_path)
+    app = create_agent_app(settings=_settings(tmp_path))
+    client = TestClient(app, headers=AUTH)
+    r = client.get("/v1/manual-downloads/GOG")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["launcher"] == "GOG"
+    assert body["present"] is True
+    assert body["entries"] == ["akalabeth_world_of_doom", "alien_breed_2_assault", "trine_2"]
+
+
+def test_filters_special_entries_and_files(tmp_path):
+    _seed_gog(tmp_path)
+    app = create_agent_app(settings=_settings(tmp_path))
+    client = TestClient(app, headers=AUTH)
+    entries = client.get("/v1/manual-downloads/GOG").json()["entries"]
+    assert "!downloading" not in entries
+    assert "!orphaned" not in entries
+    assert "README.md" not in entries  # a file, not a game folder
+
+
+def test_missing_launcher_folder_is_present_false(tmp_path):
+    # Humble not downloaded yet -> folder absent -> present false, no error.
+    app = create_agent_app(settings=_settings(tmp_path))
+    client = TestClient(app, headers=AUTH)
+    r = client.get("/v1/manual-downloads/Humble")
+    assert r.status_code == 200
+    assert r.json() == {"launcher": "Humble", "present": False, "entries": []}
+
+
+def test_rejects_path_traversal_launcher(tmp_path):
+    _seed_gog(tmp_path)
+    app = create_agent_app(settings=_settings(tmp_path))
+    client = TestClient(app, headers=AUTH)
+    # A dot/slash launcher must never escape the cache root.
+    for bad in ("..", "../cache", "GOG/..", "%2e%2e"):
+        r = client.get(f"/v1/manual-downloads/{bad}")
+        assert r.status_code in (400, 404), bad  # rejected or not-matched, never traversed
+
+
+def test_requires_auth(tmp_path):
+    app = create_agent_app(settings=_settings(tmp_path))
+    client = TestClient(app)
+    assert client.get("/v1/manual-downloads/GOG").status_code == 401

--- a/tests/api/test_manual_downloads_router.py
+++ b/tests/api/test_manual_downloads_router.py
@@ -1,0 +1,67 @@
+"""Tests for the orchestrator GET /api/v1/manual-downloads/{launcher} proxy (#222)."""
+
+from __future__ import annotations
+
+import pytest
+
+VALID_TOKEN = "a" * 32
+AUTH = {"Authorization": f"Bearer {VALID_TOKEN}"}
+
+
+class _FakeAgent:
+    def __init__(self, result=None, exc=None):
+        self._result = result
+        self._exc = exc
+        self.calls: list[str] = []
+
+    async def manual_downloads(self, launcher: str):
+        self.calls.append(launcher)
+        if self._exc is not None:
+            raise self._exc
+        return self._result
+
+
+async def test_proxies_agent_listing(client, unit_app):
+    unit_app.state.agent_client = _FakeAgent(
+        result={"launcher": "GOG", "present": True, "entries": ["trine_2", "portal"]}
+    )
+    r = await client.get("/api/v1/manual-downloads/GOG", headers=AUTH)
+    assert r.status_code == 200
+    assert r.json() == {"launcher": "GOG", "present": True, "entries": ["trine_2", "portal"]}
+    assert unit_app.state.agent_client.calls == ["GOG"]
+
+
+async def test_invalid_launcher_400(client, unit_app):
+    unit_app.state.agent_client = _FakeAgent(result={})
+    # A dot is not allowed (traversal-safe allowlist) — rejected before the agent.
+    r = await client.get("/api/v1/manual-downloads/a.b", headers=AUTH)
+    assert r.status_code == 400
+    assert unit_app.state.agent_client.calls == []  # never reached the agent
+
+
+async def test_no_agent_configured_503(client, unit_app):
+    # unit_app has no agent_client on state.
+    if hasattr(unit_app.state, "agent_client"):
+        del unit_app.state.agent_client
+    r = await client.get("/api/v1/manual-downloads/GOG", headers=AUTH)
+    assert r.status_code == 503
+
+
+async def test_agent_error_503(client, unit_app):
+    unit_app.state.agent_client = _FakeAgent(exc=RuntimeError("agent down"))
+    r = await client.get("/api/v1/manual-downloads/GOG", headers=AUTH)
+    assert r.status_code == 503
+
+
+async def test_missing_launcher_present_false(client, unit_app):
+    unit_app.state.agent_client = _FakeAgent(
+        result={"launcher": "Humble", "present": False, "entries": []}
+    )
+    r = await client.get("/api/v1/manual-downloads/Humble", headers=AUTH)
+    assert r.status_code == 200
+    assert r.json()["present"] is False
+
+
+@pytest.mark.parametrize("path", ["/api/v1/manual-downloads/GOG"])
+async def test_requires_auth(client, path):
+    assert (await client.get(path)).status_code == 401


### PR DESCRIPTION
## #222 — foundation (agent + orchestrator)

Games downloaded **by hand** (GOG / Humble / Itch / Amazon — launchers with no prefill automation and no manifests) live in per-launcher folders on the lancache host: `/lancache/lancache/cache/GOG/<game>`, etc. (probed live — GOG has 269 game folders in snake_case). This exposes that listing so a coverage checker can diff the owned library against what was actually downloaded, per your choice of the **library-vs-filesystem-presence** approach.

### Changes
- **Agent** `GET /v1/manual-downloads/{launcher}` → `{launcher, present, entries}` — lists game folders under `manual_downloads_cache_path/<launcher>/`, filtering non-dirs, `!*` control entries (`!downloading`/`!orphaned`), and dotfiles.
- **New setting** `manual_downloads_cache_path` (default `/data/cache` — the parent of the nginx hash cache). The `orchestrator-agent` container **already mounts** `/lancache/lancache/cache → /data/cache`, so GOG is visible at `/data/cache/GOG` with **no new mount**.
- **Orchestrator** `GET /api/v1/manual-downloads/{launcher}` proxies the agent + `AgentClient.manual_downloads()`. The proxy never 500s (agent down/error → 503; missing folder → `present:false`).

### Security (path traversal is the key threat here)
`{launcher}` becomes a filesystem path component. Three layers block traversal: (1) `^[A-Za-z0-9_-]+$` allowlist at **both** the orchestrator route and the agent (no `.` / `/` → no `..`); (2) the agent `resolve()`s the target and rejects it unless it's a direct child of the cache root; (3) FastAPI path params never span `/`. Read-only, auth-gated on both hops. Audit `docs/security-audits/manual-download-checker-agent-security-audit.md` (no findings).

### Testing
- TDD, **RED verified** by stashing the implementation (8 core tests failed without it). Agent: list / filter-special-and-files / missing-folder-present-false / path-traversal-rejection / auth. Orch proxy: proxies-listing / invalid-launcher-400 / no-agent-503 / agent-error-503 / missing-present-false / auth.
- Full suite **1508 pass** (only the pre-existing `test_licenses` local tooling gap). mypy clean (100 files); ruff incl. `--select S` clean.

### Follow-up
The **Game_shelf slug-diff coverage report** (owned GOG/Humble/Itch/Amazon editions vs these folders → owned-but-not-downloaded list + UI) is a separate Game_shelf PR. Only **GOG** has data today; Humble/Itch/Amazon folders get added when you download them (the endpoint is launcher-generic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)