### PR TITLE
fix(prefill): Epic scheduled_prefill keys off validation status, not version-diff

### DIFF
--- a/.claude/build-progress.json
+++ b/.claude/build-progress.json
@@ -40,14 +40,15 @@
     "epic-auto-download",
     "piece3-gameshelf-exclusions",
     "mp-only-exclusion",
-    "manual-download-checker-agent"
+    "manual-download-checker-agent",
+    "epic-prefill-status-based"
   ],
-  "features_since_last_test": 5,
-  "features_since_last_health_check": 4,
+  "features_since_last_test": 1,
+  "features_since_last_health_check": 1,
   "test_interval": 2,
   "last_test_session": "2026-07-04",
-  "testing_required": true,
+  "testing_required": false,
   "tester_count": 1,
   "bug_tracker": "github_issues",
-  "sessions_completed": 15
+  "sessions_completed": 16
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — Epic scheduled_prefill loops (go-live fix): key off validation status, not version-diff — 2026-07-04
+
+Go-live discovery: Epic games have **no version data** (the Epic library API returns no `buildVersion`, so `current_version` is always NULL), and the Epic prefill handler sets `cached_version = current_version` (NULL). Piece 2's `enqueue_scheduled_prefill` used a version-diff (`cached_version IS NULL OR cached_version <> current_version`), which is always true for Epic and can never be cleared — enabling the Epic scheduled prefill would have re-enqueued the **entire ~532-game non-excluded Epic library every 6h forever** (an infinite loop over the steal-bound agent), not a one-time wave.
+
+- **Changed:** the Epic-scoped `enqueue_scheduled_prefill` now enqueues owned Epic games where `status <> 'up_to_date'` (not validated as cached) — bounding it to the ~19 genuinely-uncached games today. A prefill's enqueued validate flips status to `up_to_date`, removing the game from the set; the nightly disk-stat sweep re-validates so eviction/drift re-triggers. New Epic purchases (status `unknown`) are still picked up.
+- Unblocks the Epic cutover (enable `ORCH_SCHEDULED_PREFILL_ENABLED=true` + retire the host EpicPrefill cron). Security audit `docs/security-audits/epic-prefill-status-based-security-audit.md` (no findings). Caught before the cutover was enabled — no production impact.
+
 ### Added — Manual-download folder listing endpoint (#222, agent + orch) — 2026-07-04
 
 Games downloaded by hand (GOG / Humble / Itch / Amazon — launchers with no prefill automation) live in per-launcher folders on the lancache host (`/lancache/lancache/cache/GOG/<game>`, …). This exposes that listing so a coverage checker can diff the owned library against what was actually downloaded.

--- a/docs/security-audits/epic-prefill-status-based-security-audit.md
+++ b/docs/security-audits/epic-prefill-status-based-security-audit.md
@@ -1,0 +1,37 @@
+# Security Audit — Epic scheduled_prefill status-based enqueue (go-live fix)
+
+**Feature:** epic-prefill-status-based — `enqueue_scheduled_prefill` keys the Epic prefill
+decision off validation status (`status <> 'up_to_date'`) instead of the cached/current
+version-diff. Epic has no version data (the Epic library API returns no buildVersion), so the
+version-diff could never be cleared and re-enqueued the whole Epic library every tick.
+**Modules:** `scheduler/jobs.py` (one `WHERE` clause + docstring)
+**Audit date:** 2026-07-04 · **Auditor:** self-review + ruff (S) + mypy + full suite (1509) · **Phase:** 2, Build Loop 2.4
+
+<!-- Last Updated: 2026-07-04 -->
+
+## Methodology
+ruff (S) clean, mypy clean, scheduler suite + full suite green (1509; only the pre-existing
+`test_licenses` tooling gap fails). Threat cross-check: SQL injection, availability, WAN/DoS.
+
+## Findings
+| # | Severity | Title | Status |
+|---|----------|-------|--------|
+| — | — | No findings. | — |
+
+## Non-findings (checked, clean)
+- **No SQL injection / no new surface.** The change is a static literal `WHERE` predicate
+  (`g.status <> 'up_to_date'`) replacing another static predicate. No new input, endpoint, or
+  parameter. The callback keeps its never-raises contract.
+- **Availability (the point of the fix).** The old version-diff enqueued the ENTIRE non-excluded
+  Epic library (~532) every scheduler tick and the prefill could never clear it — an unbounded
+  self-perpetuating job flood on the steal-bound agent. The fix bounds enqueues to games not
+  validated as cached (~19 today), and a prefill→validate→`up_to_date` removes a game from the
+  set, so steady-state is only genuinely-uncached games. `ON CONFLICT DO NOTHING` + the in-flight
+  UNIQUE index still dedup a game already queued/running (so a `downloading`-status game can't
+  double-enqueue), and the block_list / `prefill_exclusions` guards are unchanged.
+- **WAN impact reduced, not increased.** Fewer prefills enqueued than before; the whole reason
+  for the fix is to stop a redundant/looping prefill wave.
+
+## Decision
+No findings. Ship. (Control-plane-only; unblocks the Epic cutover — after deploy, enabling
+`ORCH_SCHEDULED_PREFILL_ENABLED=true` enqueues only the ~19 not-`up_to_date` Epic games.)

--- a/src/orchestrator/scheduler/jobs.py
+++ b/src/orchestrator/scheduler/jobs.py
@@ -133,20 +133,24 @@ async def enqueue_fetch_manifests(pool: Pool, *, source: str = "scheduler") -> i
 
 
 async def enqueue_scheduled_prefill(pool: Pool) -> int:
-    """Enqueue 'prefill' jobs for owned EPIC games that are new, version-diverged,
-    or validation_failed — and not block-listed / prefill-excluded (F8 driver,
-    Epic-scoped per Piece 2).
+    """Enqueue 'prefill' jobs for owned EPIC games NOT validated as cached
+    (``status <> 'up_to_date'``) — and not block-listed / prefill-excluded (F8
+    driver, Epic-scoped per Piece 2).
 
     Steam is prefilled by the host SteamPrefill cron (it auto-grabs recent
     purchases); EpicPrefill never auto-downloads new games, so the orchestrator
     owns Epic. The `platform = 'epic'` filter avoids double-prefilling Steam.
 
-    One bulk INSERT...SELECT. `ON CONFLICT DO NOTHING` + the migration-0006
-    in-flight UNIQUE index dedups against a prefill already queued/running for a
-    game. The `cached_version IS NULL` disjunct makes the `<>` comparison
-    NULL-safe (a never-cached game is caught by the IS NULL arm). Returns the
-    number of rows enqueued. Never raises — a failing scheduler tick must not
-    degrade APScheduler.
+    Epic has no version data (the Epic library API returns no buildVersion —
+    ``current_version`` is always NULL), so this keys off the disk-stat
+    VALIDATION STATUS rather than a cached/current version-diff: the version-diff
+    could never be cleared for Epic and looped over the whole library (go-live
+    bug 2026-07-04). A prefill sets status via its enqueued validate; the nightly
+    sweep re-validates, so eviction/drift flips status off 'up_to_date' and
+    re-triggers. One bulk INSERT...SELECT. `ON CONFLICT DO NOTHING` + the
+    migration-0006 in-flight UNIQUE index dedups against a prefill already
+    queued/running for a game. Returns the number of rows enqueued. Never raises
+    — a failing scheduler tick must not degrade APScheduler.
     """
     try:
         inserted = await pool.execute_write(
@@ -159,9 +163,16 @@ async def enqueue_scheduled_prefill(pool: Pool) -> int:
             # the orchestrator owns Epic. Scoping to epic avoids double-prefilling
             # every Steam game.
             "WHERE g.owned = 1 AND g.platform = 'epic' "
-            "  AND (g.cached_version IS NULL "
-            "       OR g.cached_version <> g.current_version "
-            "       OR g.status = 'validation_failed') "
+            # Epic has NO version data: the Epic library API returns no
+            # buildVersion, so current_version is always NULL and the prefill
+            # handler sets cached_version = current_version (NULL). A version-diff
+            # (cached_version IS NULL / <> current_version) can therefore never be
+            # cleared — it would re-enqueue the whole Epic library every tick
+            # (go-live bug). Key off VALIDATION STATUS instead: enqueue every owned
+            # Epic game NOT validated as cached. The nightly disk-stat sweep
+            # re-validates, so eviction / content drift flips status off
+            # 'up_to_date' and re-triggers a prefill.
+            "  AND g.status <> 'up_to_date' "
             "  AND NOT EXISTS ("
             "      SELECT 1 FROM block_list b "
             "      WHERE b.platform = g.platform AND b.app_id = g.app_id) "

--- a/tests/scheduler/test_jobs.py
+++ b/tests/scheduler/test_jobs.py
@@ -173,9 +173,12 @@ class TestEnqueueValidationSweep:
 
 
 # Piece 2: the orchestrator's scheduled prefill is EPIC-scoped (Steam is handled
-# by the host SteamPrefill cron), so these tests seed epic games by default.
+# by the host SteamPrefill cron). Epic has NO version data (current_version is
+# always NULL — the Epic library API returns no buildVersion), so the prefill
+# decision keys off VALIDATION STATUS, not the cached/current version-diff. Games
+# default to status='unknown' (never validated → should be prefilled).
 async def _seed_game(
-    pool, app_id, *, owned=1, current="42", cached=None, status="up_to_date", platform="epic"
+    pool, app_id, *, owned=1, current=None, cached=None, status="unknown", platform="epic"
 ):
     await pool.execute_write(
         "INSERT INTO games "
@@ -186,61 +189,74 @@ async def _seed_game(
 
 
 class TestEnqueueScheduledPrefill:
-    async def test_enqueues_never_cached(self, pool):
+    async def test_enqueues_unknown_status(self, pool):
+        # A never-validated epic game (status 'unknown') is enqueued.
         from orchestrator.scheduler.jobs import enqueue_scheduled_prefill
 
-        await _seed_game(pool, "1", current="42", cached=None)
+        await _seed_game(pool, "1", status="unknown")
         n = await enqueue_scheduled_prefill(pool)
         assert n == 1
         row = await pool.read_one("SELECT kind, platform, state, source FROM jobs LIMIT 1")
         assert (row["kind"], row["state"], row["source"]) == ("prefill", "queued", "scheduler")
 
-    async def test_enqueues_when_version_diverged(self, pool):
+    async def test_enqueues_failed(self, pool):
+        # The live Epic 'failed' status (disk-stat found it uncached) is enqueued.
         from orchestrator.scheduler.jobs import enqueue_scheduled_prefill
 
-        await _seed_game(pool, "1", current="42", cached="41")
+        await _seed_game(pool, "1", status="failed")
         assert await enqueue_scheduled_prefill(pool) == 1
 
     async def test_enqueues_validation_failed(self, pool):
         from orchestrator.scheduler.jobs import enqueue_scheduled_prefill
 
-        await _seed_game(pool, "1", current="42", cached="42", status="validation_failed")
+        await _seed_game(pool, "1", status="validation_failed")
         assert await enqueue_scheduled_prefill(pool) == 1
 
     async def test_skips_up_to_date(self, pool):
         from orchestrator.scheduler.jobs import enqueue_scheduled_prefill
 
-        await _seed_game(pool, "1", current="42", cached="42", status="up_to_date")
+        await _seed_game(pool, "1", status="up_to_date")
+        assert await enqueue_scheduled_prefill(pool) == 0
+
+    async def test_skips_up_to_date_even_with_null_versions(self, pool):
+        # THE Epic case (go-live bug fix): a validated-cached game (up_to_date)
+        # with NO version data must SKIP. The old version-diff enqueued it
+        # (cached_version IS NULL), and the prefill handler set cached_version =
+        # current_version (also NULL) so the condition never cleared —
+        # an infinite re-prefill loop over the whole Epic library.
+        from orchestrator.scheduler.jobs import enqueue_scheduled_prefill
+
+        await _seed_game(pool, "1", status="up_to_date", current=None, cached=None)
         assert await enqueue_scheduled_prefill(pool) == 0
 
     async def test_skips_unowned(self, pool):
         from orchestrator.scheduler.jobs import enqueue_scheduled_prefill
 
-        await _seed_game(pool, "1", owned=0, current="42", cached=None)
+        await _seed_game(pool, "1", owned=0, status="failed")
         assert await enqueue_scheduled_prefill(pool) == 0
 
     async def test_skips_steam_platform(self, pool):
         # Piece 2: the orchestrator leaves Steam to the host SteamPrefill cron.
         from orchestrator.scheduler.jobs import enqueue_scheduled_prefill
 
-        await _seed_game(pool, "1", current="42", cached=None, platform="steam")
+        await _seed_game(pool, "1", status="failed", platform="steam")
         assert await enqueue_scheduled_prefill(pool) == 0
 
     async def test_skips_blocked(self, pool):
         from orchestrator.scheduler.jobs import enqueue_scheduled_prefill
 
-        await _seed_game(pool, "1", current="42", cached=None)
+        await _seed_game(pool, "1", status="failed")
         await pool.execute_write(
             "INSERT INTO block_list (platform, app_id, source) VALUES ('epic','1','api')"
         )
         assert await enqueue_scheduled_prefill(pool) == 0
 
     async def test_skips_prefill_excluded(self, pool):
-        # #225: a prefill_exclusions 'exclude' row (auto-classified non-game) is
-        # skipped by the scheduled prefill, so it isn't re-downloaded.
+        # #225: a prefill_exclusions 'exclude' row (auto-classified non-game, or a
+        # gameshelf Steam-covered copy) is skipped by the scheduled prefill.
         from orchestrator.scheduler.jobs import enqueue_scheduled_prefill
 
-        await _seed_game(pool, "1", current="42", cached=None)
+        await _seed_game(pool, "1", status="failed")
         await pool.execute_write(
             "INSERT INTO prefill_exclusions (platform, app_id, mode, source) "
             "VALUES ('epic','1','exclude','classifier')"
@@ -248,11 +264,10 @@ class TestEnqueueScheduledPrefill:
         assert await enqueue_scheduled_prefill(pool) == 0
 
     async def test_allow_row_does_not_skip(self, pool):
-        # #225: an operator 'allow' override does NOT suppress prefill — the game
-        # keeps being cached.
+        # #225: an operator 'allow' override does NOT suppress prefill.
         from orchestrator.scheduler.jobs import enqueue_scheduled_prefill
 
-        await _seed_game(pool, "1", current="42", cached=None)
+        await _seed_game(pool, "1", status="failed")
         await pool.execute_write(
             "INSERT INTO prefill_exclusions (platform, app_id, mode, source) "
             "VALUES ('epic','1','allow','operator')"
@@ -262,11 +277,11 @@ class TestEnqueueScheduledPrefill:
     async def test_dedups_inflight_prefill(self, pool):
         from orchestrator.scheduler.jobs import enqueue_scheduled_prefill
 
-        await _seed_game(pool, "1", current="42", cached=None)
+        await _seed_game(pool, "1", status="failed")
         gid = (await pool.read_one("SELECT id FROM games LIMIT 1"))["id"]
         await pool.execute_write(
             "INSERT INTO jobs (kind, game_id, platform, state, source)"
-            " VALUES ('prefill', ?, 'steam', 'queued', 'api')",
+            " VALUES ('prefill', ?, 'epic', 'queued', 'api')",
             (gid,),
         )
         assert await enqueue_scheduled_prefill(pool) == 0


### PR DESCRIPTION
## Go-live fix — Epic prefill would loop (caught before the cutover was enabled; no prod impact)

While completing the Epic cutover I found that Piece 2's `enqueue_scheduled_prefill` cannot work for Epic:

- **Epic has no version data.** The Epic library API returns no `buildVersion`, so `current_version` is NULL for all 666 Epic games (verified live — still NULL even after a fresh `library_sync`).
- The Epic prefill handler sets `cached_version = current_version` (NULL).
- The version-diff condition (`cached_version IS NULL OR cached_version <> current_version`) is therefore **always true for Epic and can never be cleared** — enabling the Epic scheduled prefill would have re-enqueued the **entire ~532-game non-excluded Epic library every 6h forever**, hammering the steal-bound agent. I did **not** enable it.

### Fix
The Epic-scoped enqueue now keys off **validation status** — `g.status <> 'up_to_date'` — instead of the (inoperative) version-diff:
- Bounds enqueues to the **~19 genuinely-uncached** Epic games today (647/666 are validated `up_to_date`).
- A prefill's enqueued validate flips status → `up_to_date`, removing the game from the set; the nightly disk-stat sweep re-validates, so eviction/content-drift flips it back and re-triggers.
- New Epic purchases (status `unknown`) are still picked up — the whole point.

### Testing
- TDD: reworked `TestEnqueueScheduledPrefill` to status-based semantics. Key new test **`test_skips_up_to_date_even_with_null_versions`** — the exact Epic case (validated-cached + NULL versions must SKIP); it's RED under the old version-diff (wrongly enqueues) and GREEN under the fix.
- Full suite **1509 pass** (only the pre-existing `test_licenses` gap). mypy + ruff incl. `--select S` clean. Security audit: `docs/security-audits/epic-prefill-status-based-security-audit.md` (no findings — availability fix, no new surface).

### After merge
I deploy this, then complete the **Epic cutover**: `ORCH_SCHEDULED_PREFILL_ENABLED=true` (enqueues only the ~19) + retire the host EpicPrefill cron. Everything else in the redesign (Piece 3 exclusions, MP-only, #222) is already live and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)