### PR TITLE
fix(jobs): surface kind='purge' in the jobs list (F18 go-live)

### DIFF
--- a/src/orchestrator/api/routers/jobs.py
+++ b/src/orchestrator/api/routers/jobs.py
@@ -89,6 +89,7 @@ class JobResponse(BaseModel):
         "sweep",
         "manifest_fetch",
         "fetch_manifests",
+        "purge",
     ]
     game_id: int | None
     platform: Literal["steam", "epic"] | None

--- a/tests/api/test_jobs_router.py
+++ b/tests/api/test_jobs_router.py
@@ -156,6 +156,24 @@ class TestJobsFilterEnums:
         kinds = {j["kind"] for j in r.json()["jobs"]}
         assert kinds.issubset({"prefill", "validate"})
 
+    async def test_purge_kind_is_listed(self, client, populated_pool):
+        """F18: a 'purge' job must serialize into JobResponse (kind Literal includes
+        'purge'), not be dropped as an out-of-allowlist row — else the Game_shelf
+        purge poll (?kind=purge) never sees the job and its spinner runs to the
+        ceiling."""
+        await populated_pool.execute_write(
+            "INSERT INTO jobs (kind, platform, state, source) "
+            "VALUES ('purge', 'steam', 'succeeded', 'api')"
+        )
+        r = await client.get(
+            "/api/v1/jobs?kind=purge&limit=500",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+        assert r.status_code == 200
+        jobs = r.json()["jobs"]
+        assert len(jobs) >= 1
+        assert all(j["kind"] == "purge" for j in jobs)
+
     async def test_state_eq_running(self, client, jobs_pool_seeded):
         r = await client.get(
             "/api/v1/jobs?state=running&limit=500",


### PR DESCRIPTION
Live F18 deploy (orch #243) surfaced this: **`GET /api/v1/jobs` silently drops `purge`-kind rows.** `JobResponse.kind` is a `Literal[...]` that didn't include `'purge'`, so every purge job failed response-model validation and was logged as `api.jobs.row_dropped` — never returned.

**Impact:** the Game_shelf CachePanel purge poll (`/api/cache/jobs?game_id=X&kind=purge`) always got an empty list, so the **"Deleting…" spinner ran to its ~90s ceiling** instead of ending when the purge job completed. The purge itself worked correctly (chunks deleted, status flipped) — only the poll UX was degraded.

**Fix:** add `'purge'` to the `JobResponse.kind` Literal + a regression test (seed a purge job → assert it's listed under `?kind=purge`).

Verified live during the #243 deploy: purge deletes chunks (a real game went 60/60 → 0/60 on disk-stat validate) and flips to `validation_failed`; this was the one rough edge. Control-plane only — I'll redeploy the LXC after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)