### PR TITLE
fix(steam): exclude shared Steamworks redist depots from validate/purge (false-partial)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — Steam validate/purge exclude shared Steamworks Common Redistributables depots (false-partial fix) — 2026-07-05
+
+Go-live investigation: ~50 fully-cached Steam games flipped `cached → partial` on 2026-07-04 with **no game update**. Root cause: the DepotDownloader manifest fetcher (PR #213) started writing `.shas` sidecars that include the **shared Steamworks Common Redistributables depots** (app 228980 — VC++/DirectX runtime, depots 228981–228990) into each game's manifest. Those depots are shared across games and only ever *partially* cached, so the depot-scoping "drop depots with zero files present" rule couldn't exclude them (present > 0) — they dragged each game's percentage below 100%. A manifest containing depot 228990 (in 40 of the affected games) had never once validated as cached. The games' own content was fully cached the whole time.
+
+- **Changed:** the shared steam validate/purge enumeration (`agent/routers/steam.py::_steam_chunk_paths`) now skips depots in the new `steam_shared_redist_depots` setting (default = the app-228980 set `228981..228990`, env-overridable via `ORCH_STEAM_SHARED_REDIST_DEPOTS`). Cache status now reflects a game's OWN content. Purge also skips them — it must never delete chunks other games share.
+- Reversible + immediate: the next validation sweep re-marks the affected games `cached` with no re-fetch or WAN cost. A follow-up will fix the fetcher to stop writing redist `.shas` at the source.
+
 ### Added — F18 operator-driven cache purge (#37) — 2026-07-05
 
 A reversible, operator-driven per-game cache purge: delete a game's cached chunk files, then let the existing validate/re-prefill path re-download a clean copy. Covers the failure modes the disk-stat validator can't (silent bit-corruption, crash-orphan partials, operator "wipe and re-fetch") without a proactive full-SHA-verification scheduler. Per ADR-0015 (`docs/ADR documentation/0015-operator-driven-cache-purge.md`, Accepted). Mirrors the validate flow: control enqueues a `purge` job → the data-plane agent (which alone holds the cache filesystem) enumerates the game's chunk paths exactly as validate does and `unlink`s the present ones → control sets `status='validation_failed'` so F5/F6 re-prefills.

--- a/src/orchestrator/agent/routers/steam.py
+++ b/src/orchestrator/agent/routers/steam.py
@@ -269,9 +269,11 @@ def _steam_chunk_paths(
     identifier = settings.steam_cache_identifier
     levels = settings.cache_levels
 
+    shared_redist = settings.steam_shared_redist_depots
     seen: set[tuple[int, str]] = set()
     depot_paths: dict[int, list[Path]] = {}
     versions: list[str] = []
+    skipped_redist: set[int] = set()
     parsed_ok = 0
     for binpath in bins:
         try:
@@ -290,6 +292,14 @@ def _steam_chunk_paths(
             )
             continue
         parsed_ok += 1
+        if depot_id in shared_redist:
+            # Shared Steamworks Common Redistributables (app 228980) — runtime
+            # content shared across many games, only ever partially cached. Skip it
+            # so it doesn't drag a fully-cached game to 'partial', and so purge
+            # never deletes chunks other games depend on. The manifest still parsed
+            # (parsed_ok counts it) so an all-redist enumeration isn't a false error.
+            skipped_redist.add(depot_id)
+            continue
         versions.append(f"{depot_id}:{gid}")
         dpaths = depot_paths.setdefault(depot_id, [])
         for sha in chunk_shas:
@@ -300,6 +310,12 @@ def _steam_chunk_paths(
             uri = steam_chunk_uri(depot_id, sha)
             h = cache_key(identifier, uri, slice_range)
             dpaths.append(cache_path(cache_root, h, levels))
+    if skipped_redist:
+        _log.info(
+            "steam_validate.shared_redist_skipped",
+            app_id=app_id,
+            depots=sorted(skipped_redist),
+        )
     return depot_paths, versions, parsed_ok, True
 
 

--- a/src/orchestrator/core/settings.py
+++ b/src/orchestrator/core/settings.py
@@ -172,6 +172,18 @@ class Settings(BaseSettings):
     epic_cache_identifiers: Annotated[list[str], NoDecode] = Field(
         default_factory=lambda: ["epicgames", "egs-cloudfront-chunks.epicgamescdn.com"]
     )
+    # Shared Steamworks Common Redistributables depots (app 228980) — VC++ /
+    # DirectX / etc. runtime redistributables referenced by MANY games via
+    # `depotfromapp`. The manifest fetcher enumerates them per game, but they are
+    # shared runtime content, not a game's own data, and are only ever PARTIALLY
+    # cached — counting them made ~50 fully-cached games read as "partial"
+    # (2026-07-04). steam validate + purge skip these depots so cache status
+    # reflects a game's OWN content (and purge never deletes chunks shared with
+    # other games). Comma-separated env (ORCH_STEAM_SHARED_REDIST_DEPOTS) or a real
+    # list; default = the app-228980 depot set 228981..228990.
+    steam_shared_redist_depots: Annotated[frozenset[int], NoDecode] = Field(
+        default_factory=lambda: frozenset(range(228981, 228991))
+    )
     # Prefill (F5) chunk-download concurrency. Pre-staged generic name; F5
     # uses it as the per-game parallel-chunk cap.
     chunk_concurrency: int = Field(default=32, ge=1, le=256)
@@ -325,6 +337,17 @@ class Settings(BaseSettings):
         if isinstance(v, str):
             return [s.strip() for s in v.split(",") if s.strip()]
         return v
+
+    @field_validator("steam_shared_redist_depots", mode="before")
+    @classmethod
+    def _parse_shared_redist_depots(cls, v: Any) -> Any:
+        """Accept a comma-separated env string or a real iterable of depot ids;
+        empty/unset falls back to the app-228980 redist depot set."""
+        if v is None or v == "":
+            return frozenset(range(228981, 228991))
+        if isinstance(v, str):
+            return frozenset(int(s.strip()) for s in v.split(",") if s.strip())
+        return frozenset(int(x) for x in v)
 
     @field_validator("allowed_source_ips", mode="after")
     @classmethod

--- a/tests/agent/test_steam_purge.py
+++ b/tests/agent/test_steam_purge.py
@@ -108,3 +108,55 @@ def test_steam_purge_bad_app_id(tmp_path):
     client, _, _ = _seed(tmp_path)
     r = client.post("/v1/steam/purge", json={"app_id": -5})
     assert r.status_code == 422
+
+
+def test_steam_purge_skips_shared_redist_depot(tmp_path):
+    """Purge deletes the game's OWN depot chunks but NEVER the shared Steamworks
+    Common Redistributables depot (228990) — those chunks are shared with other
+    games (2026-07-04 fix). Both depots are cached; only the own depot is deleted."""
+    redist = 228990
+    mcache = tmp_path / "spcache"
+    (mcache / "v1").mkdir(parents=True)
+    (mcache / "v1" / f"{APP}_{APP}_{DEPOT}_{GID}.shas").write_text("\n".join(CHUNKS) + "\n")
+    redist_chunks = [f"{i:040x}" for i in range(10, 13)]  # distinct from CHUNKS
+    (mcache / "v1" / f"{APP}_{APP}_{redist}_{GID}.shas").write_text("\n".join(redist_chunks) + "\n")
+    cfg = tmp_path / "Config"
+    cfg.mkdir()
+    (cfg / "successfullyDownloadedDepots.json").write_text("{}")
+
+    cache_root = tmp_path / "lancache"
+    slice_range = slice_range_zero(SLICE)
+    own_files = []
+    for sha in CHUNKS:
+        p = cache_path(
+            cache_root, cache_key(IDENT, steam_chunk_uri(DEPOT, sha), slice_range), LEVELS
+        )
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(CHUNK_BODY)
+        own_files.append(p)
+    redist_files = []
+    for sha in redist_chunks:
+        p = cache_path(
+            cache_root, cache_key(IDENT, steam_chunk_uri(redist, sha), slice_range), LEVELS
+        )
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(CHUNK_BODY)
+        redist_files.append(p)
+
+    settings = Settings(
+        orchestrator_token=TOKEN,
+        lancache_nginx_cache_path=cache_root,
+        cache_levels=LEVELS,
+        steam_cache_identifier=IDENT,
+        cache_slice_size_bytes=SLICE,
+        steam_manifest_cache_dir=mcache,
+        steam_prefill_config_dir=cfg,
+    )
+    client = TestClient(create_agent_app(settings=settings))
+    client.headers.update({"Authorization": f"Bearer {TOKEN}"})
+
+    body = client.post("/v1/steam/purge", json={"app_id": APP}).json()
+
+    assert body["deleted"] == len(CHUNKS)  # only the game's own depot
+    assert all(not p.exists() for p in own_files)
+    assert all(p.exists() for p in redist_files)  # shared redist preserved

--- a/tests/agent/test_steam_validate.py
+++ b/tests/agent/test_steam_validate.py
@@ -314,6 +314,20 @@ def test_validate_all_depots_unprefilled_is_missing(tmp_path):
     assert body["outcome"] == "missing"
 
 
+def test_validate_excludes_shared_redist_depot(tmp_path):
+    """A game with its OWN depot fully cached + a shared Steamworks Common
+    Redistributables depot (228990) only partially cached must validate as CACHED —
+    the shared redist is runtime content, not the game's own data (2026-07-04
+    false-partial fix). Before this fix the partial redist depot (present>0, so not
+    dropped by the never-prefilled rule) dragged the game to 'partial'."""
+    client = _build_multidepot(tmp_path, depot_cached={800441: (10, 10), 228990: (8, 4)})
+    body = client.post("/v1/steam/validate", json={"app_id": MD_APP}).json()
+    assert body["chunks_total"] == 10  # only the game's own depot counts
+    assert body["chunks_cached"] == 10
+    assert body["outcome"] == "cached"
+    assert "228990" not in body["versions"]  # redist depot excluded from versions
+
+
 def test_validate_mode000_depot_counted_cached(tmp_path):
     """A depot whose chunk files EXIST on disk but are mode-000 validates as
     CACHED: mode-000 is a transient nginx-over-NFS write-race that self-heals to


### PR DESCRIPTION
## The bug you spotted
~50 fully-cached Steam games flipped **cached → partial on 2026-07-04 with no game update.**

## Root cause (investigated live)
The DepotDownloader manifest fetcher (PR #213) started writing `.shas` sidecars that include the **shared Steamworks Common Redistributables** depots (app **228980** — VC++/DirectX runtime, depots **228981–228990**) into each game's manifest. Those depots are shared across many games and only ever *partially* cached, so the depot-scoping "drop depots with zero files present" rule couldn't exclude them (present > 0). They dragged each game below 100% even though its own content was fully cached.

**Evidence:** depot 228990 appears in **40** of the affected games; a manifest containing it has **never once validated as cached**; the cache is 43% full (32 TB free) so it's not eviction. Just Cause 2 was `4991/4991 cached`, then `+255` redist chunks appeared → `5019/5246 partial`.

## Fix
Skip the shared-redist depots in the shared `_steam_chunk_paths` enumeration, so **both validate and purge** ignore them (purge must never delete chunks other games share). Gated by a new `steam_shared_redist_depots` setting (default `228981..228990`, env `ORCH_STEAM_SHARED_REDIST_DEPOTS`). Cache status now reflects a game's OWN content.

- Reversible + immediate: the next validation sweep re-marks the affected games `cached` — **no re-fetch, no WAN.**
- Tests: `test_validate_excludes_shared_redist_depot` (own depot cached + partial redist depot → still `cached`) and `test_steam_purge_skips_shared_redist_depot` (purge deletes own chunks, preserves shared redist). Full agent suite 141 green.

## After merge
I redeploy the **agent** (this runs agent-side) + the LXC for image parity, then trigger a full sweep so the ~50 games flip back to cached. A follow-up will fix the fetcher to stop writing redist `.shas` at the source (your "fetcher fix later").

🤖 Generated with [Claude Code](https://claude.com/claude-code)