### PR TITLE
feat: auto-cover newly-purchased Steam games (sweep unknown + fetcher + selection persist)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — newly-purchased Steam games stuck at `unknown` (new-purchase auto-coverage) — 2026-07-07
+
+A Steam game bought and cached by the host `SteamPrefill prefill --recently-purchased` cron stayed `status='unknown'` in the orchestrator indefinitely (Game_shelf showed "Unknown"). Root cause: the scheduled *gated* validation sweep enumerated only `up_to_date`/`validation_failed` games, and there is **no scheduled *full* sweep** — so a row inserted at the default `unknown` (library_sync writes title+owned only) was never auto-validated by any cron. (`games.metadata` being NULL was a red herring: the validator reads the on-disk `.bin`/`.shas`, which the host had already written; the legacy depot metadata on older rows is vestigial pre-③ data.)
+
+- **Fixed:** the gated validation sweep (`jobs/handlers/sweep.py::_CANDIDATE_SQL`) now also validates `unknown` **owned** games, so a recent purchase is auto-validated off its already-cached manifest within one 6h cycle (an uncovered `unknown` game returns `outcome='error'`, which validate leaves untouched — non-clobbering).
+- **Changed:** the Steam manifest fetcher (`platform/steam/manifest_fetcher.py`) now also covers apps with a live `.bin` but no durable `.shas` — recent purchases downloaded outside the SteamPrefill selection — bounded to that delta so the first run never triggers a full-library DepotDownloader logon burst (#228). Wired via `manifest_cache_dir=steam_manifest_cache_dir` in `agent/app.py`.
+- **Changed:** the selection reconcile (`scheduler/jobs.py::auto_classify_block`) now re-adds prefilled-but-not-excluded apps to `selectedAppsToPrefill.json`, so a recently-purchased download persists in `SteamPrefill --select-apps` and the durable prefill set (operator deselects, tracked as DB excludes, are still honored). No host-cron edit, no schema change, no 2FA; `games.metadata` untouched.
+
 ### Fixed — Steam validate/purge exclude shared Steamworks Common Redistributables depots (false-partial fix) — 2026-07-05
 
 Go-live investigation: ~50 fully-cached Steam games flipped `cached → partial` on 2026-07-04 with **no game update**. Root cause: the DepotDownloader manifest fetcher (PR #213) started writing `.shas` sidecars that include the **shared Steamworks Common Redistributables depots** (app 228980 — VC++/DirectX runtime, depots 228981–228990) into each game's manifest. Those depots are shared across games and only ever *partially* cached, so the depot-scoping "drop depots with zero files present" rule couldn't exclude them (present > 0) — they dragged each game's percentage below 100%. A manifest containing depot 228990 (in 40 of the affected games) had never once validated as cached. The games' own content was fully cached the whole time.

--- a/docs/superpowers/plans/2026-07-07-steam-new-purchase-auto-coverage.md
+++ b/docs/superpowers/plans/2026-07-07-steam-new-purchase-auto-coverage.md
@@ -1,0 +1,307 @@
+# Steam New-Purchase Auto-Coverage — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A newly-purchased Steam game (downloaded by the host `SteamPrefill --recently-purchased` cron) automatically gets validated (status off `unknown`), gets a durable `.shas` sidecar, and persists into the SteamPrefill selection — with no manual step.
+
+**Architecture:** Three independent orchestrator-side changes: (1) the gated validation sweep enumerates `unknown` owned games; (2) the manifest fetcher also covers apps that have a `.bin` in the cache but no `.shas`; (3) the selection reconcile re-adds prefilled-non-excluded apps. No host-cron edit, no agent RPC change (Piece 3 reuses `restore_ids`), no 2FA, no schema change.
+
+**Tech Stack:** Python 3.12, asyncio, aiosqlite pool, FastAPI agent, pytest/mypy/ruff.
+
+## Global Constraints
+
+- **Repo:** `/Users/karl/Documents/Claude Projects/lancache_orchestrator`, branch `feat/steam-new-purchase-auto-coverage` (created, spec committed). Framework hooks ACTIVE — before editing any source file, a plan task must be `in_progress` (TaskUpdate); new third-party imports need a Context7 lookup first (none expected here); pre-commit runs ruff+mypy+semgrep.
+- **Do NOT** populate `games.metadata`/`current_version` for steam (vestigial). **Do NOT** add a near-immediate `library_sync` validate-enqueue (immediacy = ≤6h, locked). **Do NOT** change the `fetch_manifests` cadence (weekly, locked). **Do NOT** edit the host cron / `selectedAppsToPrefill.json` host-side. **No** new agent selection RPC.
+- **Import isolation:** the agent package (`src/orchestrator/agent/**`, `platform/steam/manifest_fetcher.py`) must NOT import `orchestrator.db.*` / `orchestrator.api.*` — `tests/agent/test_import_isolation.py` enforces this. Inline the manifest glob; do not import `manifest_locator` if it would pull disallowed deps (it's in `agent/` so it's safe to reference for the pattern, but inline to stay minimal).
+- **Verify commands:** `.venv/bin/python -m pytest <path> -q`; full suite `.venv/bin/python -m pytest -q --ignore=tests/scripts`; `.venv/bin/python -m mypy src` ; `.venv/bin/ruff check src tests`.
+- One PR. Karl merges (never `gh pr merge`).
+
+## File map
+- `src/orchestrator/jobs/handlers/sweep.py` — Piece 1 (`_CANDIDATE_SQL`).
+- `src/orchestrator/platform/steam/manifest_fetcher.py` — Piece 2 (`__init__` + `_enumerate_app_ids`).
+- `src/orchestrator/agent/app.py` — Piece 2 wiring (two fetcher constructions).
+- `src/orchestrator/scheduler/jobs.py` — Piece 3 (`auto_classify_block` restore set).
+- `CHANGELOG.md`, `FEATURES.md` — docs.
+
+---
+
+### Task 1: Piece 1 — sweep validates `unknown` owned games
+
+**Files:**
+- Modify: `src/orchestrator/jobs/handlers/sweep.py` (`_CANDIDATE_SQL`, ~line 25)
+- Test: `tests/jobs/test_sweep_handler.py`
+
+**Interfaces:**
+- Produces: the gated sweep's candidate set now includes `status='unknown' AND owned=1` steam/epic games. `_CANDIDATE_SQL_FULL` unchanged.
+
+Current code (`sweep.py`):
+```python
+_CANDIDATE_SQL = (
+    "SELECT id, status FROM games WHERE status IN ('up_to_date','validation_failed') ORDER BY id"
+)
+```
+
+- [ ] **Step 1: Write the failing test** — add to `tests/jobs/test_sweep_handler.py` (mirror the existing harness in that file — it builds a Deps with a real/temp pool + a stub agent_client and a patched `validator_self_test`/`validate_one_game`; copy that fixture setup). Assert the gated sweep enumerates an `unknown, owned=1` game and skips an `unknown, owned=0` game:
+
+```python
+async def test_gated_sweep_includes_unknown_owned_game(...):
+    # seed games: A(status='unknown',owned=1), B(status='unknown',owned=0),
+    #             C(status='up_to_date',owned=1)
+    # run sweep_handler with an empty payload (gated), capturing validate_one_game calls
+    validated_ids = [...]  # collected from the patched validate_one_game
+    assert A_id in validated_ids
+    assert C_id in validated_ids
+    assert B_id not in validated_ids     # owned=0 unknown is NOT swept
+```
+
+Add a second test asserting a no-manifest `unknown` game's error does not clobber status (mirror how the file already asserts non-clobbering / uses `validate_one_game` returning `outcome='error'`):
+```python
+async def test_uncovered_unknown_stays_unknown(...):
+    # validate_one_game for the unknown game raises/returns outcome='error'
+    # assert the game's status is still 'unknown' after the sweep (non-clobbering)
+```
+
+- [ ] **Step 2: Run to verify it fails** — `.venv/bin/python -m pytest tests/jobs/test_sweep_handler.py -q` → the new test FAILS (`unknown` game not enumerated).
+- [ ] **Step 3: Implement** — in `sweep.py`:
+```python
+_CANDIDATE_SQL = (
+    "SELECT id, status FROM games "
+    "WHERE status IN ('unknown','up_to_date','validation_failed') AND owned = 1 "
+    "ORDER BY id"
+)
+```
+(The `owned = 1` guard bounds churn — only owned games are swept. `validate_one_game` already leaves status unchanged on `outcome='error'`, so an uncovered `unknown` game is safe.)
+
+- [ ] **Step 4: Run to verify it passes** — same command → PASS; also run the file's existing gated + full sweep tests → still green.
+- [ ] **Step 5: Commit**
+```bash
+git add src/orchestrator/jobs/handlers/sweep.py tests/jobs/test_sweep_handler.py
+git commit -m "fix(sweep): gated sweep validates 'unknown' owned games (auto-cover new purchases)"
+```
+
+---
+
+### Task 2: Piece 2 — fetcher covers has-.bin-but-no-.shas apps
+
+**Files:**
+- Modify: `src/orchestrator/platform/steam/manifest_fetcher.py` (`__init__` + `_enumerate_app_ids`)
+- Test: `tests/platform/steam/test_manifest_fetcher.py` (mirror the existing path — check the actual test file location for the fetcher; adjust if it lives elsewhere)
+
+**Interfaces:**
+- Consumes: `settings.steam_manifest_cache_dir` (`/steamprefill-cache`, the live `.bin` cache), `steam_manifest_archive_dir` (`/manifest-archive`, where `.shas` are written).
+- Produces: `DepotDownloaderManifestFetcher(..., manifest_cache_dir: Path | None = None)`. `_enumerate_app_ids()` returns `sorted(selection ∪ {apps with a .bin in manifest_cache_dir/v1 and no .shas in archive_dir/v1})`.
+
+Current `__init__` signature keywords: `binary, config_dir, steam_config_dir, archive_dir, delay_sec=0.0, username="", max_retries=3, retry_backoff_sec=15.0`. Current `_enumerate_app_ids` reads `self._steam_config_dir / "selectedAppsToPrefill.json"` (a JSON list of ints). Manifest filenames are `{app}_{...}.{bin|shas}` under `<dir>/v1/`; the app_id is `stem.split("_",1)[0]` when `.isdigit()`.
+
+- [ ] **Step 1: Write the failing test** — add to the fetcher test:
+```python
+def test_enumerate_unions_uncovered_cache_apps(tmp_path):
+    steam_cfg = tmp_path / "steamcfg"; steam_cfg.mkdir()
+    (steam_cfg / "selectedAppsToPrefill.json").write_text("[111]")   # selection
+    cache = tmp_path / "cache"; (cache / "v1").mkdir(parents=True)
+    archive = tmp_path / "archive"; (archive / "v1").mkdir(parents=True)
+    # 222 has a .bin but no .shas -> must be enumerated (a recent purchase)
+    (cache / "v1" / "222_222_2221_gidA.bin").write_bytes(b"x")
+    # 333 has a .bin AND a matching .shas -> already covered, must be skipped
+    (cache / "v1" / "333_333_3331_gidB.bin").write_bytes(b"x")
+    (archive / "v1" / "333_333_3331_gidB.shas").write_text("")
+    f = DepotDownloaderManifestFetcher(
+        binary=tmp_path/"dd", config_dir=tmp_path/"cfg", steam_config_dir=steam_cfg,
+        archive_dir=archive, manifest_cache_dir=cache,
+    )
+    assert f._enumerate_app_ids() == [111, 222]   # selection + uncovered; NOT 333
+
+def test_enumerate_selection_only_when_no_cache_dir(tmp_path):
+    steam_cfg = tmp_path / "steamcfg"; steam_cfg.mkdir()
+    (steam_cfg / "selectedAppsToPrefill.json").write_text("[111]")
+    f = DepotDownloaderManifestFetcher(
+        binary=tmp_path/"dd", config_dir=tmp_path/"cfg", steam_config_dir=steam_cfg,
+        archive_dir=tmp_path/"a", manifest_cache_dir=None,
+    )
+    assert f._enumerate_app_ids() == [111]
+```
+
+- [ ] **Step 2: Run to verify it fails** — `.venv/bin/python -m pytest tests/platform/steam/test_manifest_fetcher.py -q` → FAIL (`__init__` has no `manifest_cache_dir`; selection-only enumeration).
+- [ ] **Step 3: Implement** — in `manifest_fetcher.py`:
+
+Add the param to `__init__` (keyword-only, after `retry_backoff_sec`):
+```python
+        retry_backoff_sec: float = 15.0,
+        manifest_cache_dir: Path | None = None,
+    ) -> None:
+        ...
+        self._retry_backoff_sec = retry_backoff_sec
+        self._manifest_cache_dir = Path(manifest_cache_dir) if manifest_cache_dir else None
+```
+
+Add an inlined glob helper + widen `_enumerate_app_ids` (keep the existing selection parse; append the union):
+```python
+    @staticmethod
+    def _app_ids_with_ext(directory: Path | None, ext: str) -> set[int]:
+        """app_ids that have a `<dir>/v1/{app}_*.{ext}` manifest. Inlined (no
+        manifest_locator import) to preserve agent import-isolation."""
+        apps: set[int] = set()
+        if directory is None:
+            return apps
+        v1 = directory / "v1"
+        if not v1.is_dir():
+            return apps
+        for path in v1.glob(f"*.{ext}"):
+            first = path.stem.split("_", 1)[0]
+            if first.isdigit():
+                apps.add(int(first))
+        return apps
+```
+At the end of `_enumerate_app_ids`, replace `return sorted(apps)` with:
+```python
+        # Durability (#213 follow-up): also cover apps that were prefilled outside
+        # the selection (e.g. a --recently-purchased game) — a `.bin` in the live
+        # cache with no `.shas` in the archive yet. Bounded to that delta so the
+        # first run never triggers a full-library DepotDownloader logon burst (#228).
+        have_bin = self._app_ids_with_ext(self._manifest_cache_dir, "bin")
+        have_shas = self._app_ids_with_ext(self._archive_dir, "shas")
+        uncovered = have_bin - have_shas
+        return sorted(apps | uncovered)
+```
+(The existing `delay_sec` throttle at the `fetch_all` loop and `_TRANSIENT_RE` backoff are untouched — they still bound Steam-logon rate.)
+
+- [ ] **Step 4: Run to verify it passes** — same command → PASS. Then `.venv/bin/python -m pytest tests/agent/test_import_isolation.py -q` → still green (no new imports).
+- [ ] **Step 5: Commit**
+```bash
+git add src/orchestrator/platform/steam/manifest_fetcher.py tests/platform/steam/test_manifest_fetcher.py
+git commit -m "feat(fetcher): also cover prefilled apps missing a .shas (durable coverage for new purchases)"
+```
+
+---
+
+### Task 3: Piece 2 wiring — pass `manifest_cache_dir` in the agent
+
+**Files:**
+- Modify: `src/orchestrator/agent/app.py` (two `DepotDownloaderManifestFetcher(...)` constructions, ~lines 72-81 and 118-127)
+- Test: `tests/agent/test_app.py` (or wherever agent-app construction is tested; else add a focused test)
+
+**Interfaces:**
+- Consumes: `DepotDownloaderManifestFetcher(manifest_cache_dir=...)` (Task 2).
+- Produces: both fetcher instances built with `manifest_cache_dir=settings.steam_manifest_cache_dir`.
+
+- [ ] **Step 1: Write the failing test** — assert the constructed fetcher carries the cache dir (mirror any existing agent-app construction test; if none, build the app/state and check `app.state.manifest_fetcher._manifest_cache_dir == settings.steam_manifest_cache_dir`). Keep it minimal.
+- [ ] **Step 2: Run to verify it fails** — FAIL (`_manifest_cache_dir` is None).
+- [ ] **Step 3: Implement** — in BOTH constructions in `agent/app.py`, add the line after `retry_backoff_sec=...`:
+```python
+                retry_backoff_sec=settings.manifest_fetch_retry_backoff_sec,
+                manifest_cache_dir=settings.steam_manifest_cache_dir,
+            )
+```
+- [ ] **Step 4: Run to verify it passes** — PASS.
+- [ ] **Step 5: Commit**
+```bash
+git add src/orchestrator/agent/app.py tests/agent/test_app.py
+git commit -m "feat(agent): wire steam_manifest_cache_dir into the manifest fetcher"
+```
+
+---
+
+### Task 4: Piece 3 — selection reconcile re-adds prefilled-non-excluded apps
+
+**Files:**
+- Modify: `src/orchestrator/scheduler/jobs.py` (`auto_classify_block`, the block that computes `restore_ids` and calls `agent_client.prune_steam_selection`)
+- Test: `tests/scheduler/test_jobs.py`
+
+**Interfaces:**
+- Consumes: `agent_client.prefilled_apps() -> list[int]`, `agent_client.prune_steam_selection(exclude_app_ids, restore_app_ids)`.
+- Produces: `restore_ids` sent to the agent = `(DB allow set) ∪ (prefilled_apps() − DB exclude set)`. Best-effort; a `prefilled_apps()` error leaves `restore_ids` as the allow set only.
+
+Current code (`scheduler/jobs.py`, in `auto_classify_block`):
+```python
+            excl = await pool.read_all("SELECT app_id FROM prefill_exclusions WHERE platform = 'steam' AND mode = 'exclude'")
+            allow = await pool.read_all("SELECT app_id FROM prefill_exclusions WHERE platform = 'steam' AND mode = 'allow'")
+            exclude_ids = [i for i in (as_int(r["app_id"]) for r in excl) if i is not None]
+            restore_ids = [i for i in (as_int(r["app_id"]) for r in allow) if i is not None]
+            if exclude_ids or restore_ids:
+                res = await agent_client.prune_steam_selection(exclude_ids, restore_ids)
+```
+
+- [ ] **Step 1: Write the failing test** — add to `tests/scheduler/test_jobs.py` (mirror its existing `auto_classify_block` test harness: a fake pool + a stub `agent_client` recording `prune_steam_selection` args). Seed `prefill_exclusions`: 900='exclude'. Stub `prefilled_apps() -> [648800, 900]`:
+```python
+async def test_reconcile_readds_prefilled_non_excluded():
+    # DB: 900 excluded (mode='exclude'); agent prefilled_apps -> [648800, 900]
+    ...
+    call = stub_agent.prune_calls[-1]      # (exclude_ids, restore_ids)
+    assert 648800 in call.restore_ids      # prefilled + not excluded -> re-added
+    assert 900 not in call.restore_ids     # excluded -> not re-added
+    assert 900 in call.exclude_ids
+
+async def test_reconcile_survives_prefilled_apps_error():
+    # prefilled_apps() raises -> restore_ids falls back to the DB allow set, no raise
+    ...
+```
+
+- [ ] **Step 2: Run to verify it fails** — `.venv/bin/python -m pytest tests/scheduler/test_jobs.py -q` → FAIL (648800 not in restore_ids).
+- [ ] **Step 3: Implement** — replace the `restore_ids` computation with the union (keep everything inside the existing best-effort `try`):
+```python
+            restore_ids = [i for i in (as_int(r["app_id"]) for r in allow) if i is not None]
+            # #NEW: recently-purchased/prefilled games (a `.bin` in the agent cache)
+            # that are not excluded should be (re)added to the selection so they
+            # persist in --select-apps and the durable prefill set. prefilled_apps()
+            # is the same .bin-cache source library_sync uses.
+            try:
+                prefilled = await agent_client.prefilled_apps()
+            except Exception as e:
+                prefilled = []
+                _log.warning("scheduler.auto_classify_block.prefilled_apps_failed", reason=str(e)[:200])
+            exclude_set = set(exclude_ids)
+            restore_ids = sorted({*restore_ids, *(a for a in prefilled if a not in exclude_set)})
+            if exclude_ids or restore_ids:
+                res = await agent_client.prune_steam_selection(exclude_ids, restore_ids)
+```
+(`_log` is already imported in the module. The whole block is already inside `try/except Exception` so a failure never crashes the scheduler tick.)
+
+- [ ] **Step 4: Run to verify it passes** — same command → PASS; existing `auto_classify_block` tests → green.
+- [ ] **Step 5: Commit**
+```bash
+git add src/orchestrator/scheduler/jobs.py tests/scheduler/test_jobs.py
+git commit -m "feat(selection): reconcile re-adds prefilled-non-excluded apps (recent purchases persist in the selection)"
+```
+
+---
+
+### Task 5: Docs + governance
+
+**Files:** `CHANGELOG.md`, `FEATURES.md` (+ process scripts).
+
+- [ ] **Step 1** — CHANGELOG.md, under a new dated entry:
+  - **Fixed:** "Newly-purchased Steam games stayed `unknown` forever — the gated validation sweep never enumerated `unknown` games (and there is no scheduled full sweep). The sweep now validates `unknown` owned games, so a recent purchase is auto-validated within one 6h cycle off its already-cached manifest."
+  - **Changed:** "The Steam manifest fetcher now also covers apps that have a live `.bin` but no durable `.shas` (recent purchases outside the SteamPrefill selection), bounded to that delta. The selection reconcile now re-adds prefilled-non-excluded apps to `selectedAppsToPrefill.json` so recent purchases persist in `--select-apps` and the durable prefill set."
+- [ ] **Step 2** — FEATURES.md: note the new-purchase auto-coverage behavior.
+- [ ] **Step 3** — run the build-loop process checklist per CLAUDE.md (`scripts/process-checklist.sh --complete-step build_loop:...` for the steps completed) and `scripts/test-gate.sh --record-feature "steam-new-purchase-auto-coverage"`.
+- [ ] **Step 4: Commit**
+```bash
+git add CHANGELOG.md FEATURES.md
+git commit -m "docs: steam new-purchase auto-coverage (sweep unknown + fetcher + selection persist)"
+```
+
+---
+
+### Task 6: Full verification + PR + deploy + live verify
+
+**Files:** none (verification/deploy only).
+
+- [ ] **Step 1: Full suite** — `.venv/bin/python -m pytest -q --ignore=tests/scripts` (only pre-existing failures, e.g. `test_licenses.py`); `.venv/bin/python -m mypy src`; `.venv/bin/ruff check src tests`.
+- [ ] **Step 2: Push + PR**
+```bash
+git push -u origin feat/steam-new-purchase-auto-coverage
+gh pr create --base main --title "feat: auto-cover newly-purchased Steam games (sweep unknown + fetcher + selection persist)" --body "..."
+```
+PR body: the 3 pieces + the Raft root-cause; **no schema change, no host-cron edit, no 2FA**; per spec `docs/superpowers/specs/2026-07-07-steam-new-purchase-auto-coverage-design.md`. Karl merges.
+- [ ] **Step 3: Deploy (after merge, no 2FA).** Control plane (Pieces 1+3) → LXC 1105: tag rollback `docker tag orchestrator:dpa orchestrator:dpa-pre-newpurchase`; then `cd /root/lancache-orchestrator && git fetch && git reset --hard origin/main && docker build -t orchestrator:dpa . && bash /root/deploy-orchestrator-lxc.sh` (build FIRST — the script only recreates). Agent (Piece 2) → UGREEN: rebuild the agent image and **recreate** the agent container (not restart — env reload).
+- [ ] **Step 4: Live verify.** Within one 6h gated sweep, `games.status` for `648800` → `up_to_date` (query the LXC DB `/var/lib/orchestrator/orchestrator.db` via `python3` in the `orchestrator` container). After the next `auto_classify_block` tick, `648800` appears in `selectedAppsToPrefill.json` on the agent (host-root read on .40). On the next weekly `fetch_manifests`, a `648800_*_648801_*.shas` lands in the `/manifest-archive/v1` volume. Confirm `validation_sweep` + `fetch_manifests` scheduled jobs are enabled live. Confirm no regression on the other legacy `unknown` rows (validate or stay `unknown` via non-clobbering error).
+
+---
+
+## Self-Review
+
+**Spec coverage:** Piece 1 (sweep unknown) → Task 1 ✓; Piece 2 (fetcher widen) → Tasks 2+3 ✓; Piece 3 (selection persist) → Task 4 ✓; docs → Task 5 ✓; deploy+verify → Task 6 ✓. Non-goals respected — no `games.metadata` write, no `library_sync` validate-enqueue, no cadence change, no host edit, no schema change, no new agent RPC.
+
+**Placeholder scan:** implementation steps carry real code (the exact `_CANDIDATE_SQL`, the `_app_ids_with_ext` helper + enumeration union, the two `agent/app.py` lines, the `restore_ids` union). The handler/scheduler TEST bodies name the exact seed + assertions and point to the existing test file's fixture to mirror (the pool/Deps/stub-agent harness differs per file and must match what's there) — that's a harness-reuse instruction, not a placeholder.
+
+**Type consistency:** `manifest_cache_dir: Path | None` (Task 2) matches the wiring `settings.steam_manifest_cache_dir` (Task 3) and the enumeration read (Task 2). `prefilled_apps() -> list[int]` and `prune_steam_selection(exclude_app_ids, restore_app_ids)` (Task 4) match the real `agent_client` signatures. `_CANDIDATE_SQL` string (Task 1) is the only sweep change; `_CANDIDATE_SQL_FULL` untouched.

--- a/docs/superpowers/specs/2026-07-07-steam-new-purchase-auto-coverage-design.md
+++ b/docs/superpowers/specs/2026-07-07-steam-new-purchase-auto-coverage-design.md
@@ -1,0 +1,72 @@
+# Design — auto-coverage for newly-purchased Steam games
+
+<!-- 2026-07-07 -->
+
+**Repo:** lancache_orchestrator (orchestrator-only — NO host-cron edits, NO 2FA). Branch `feat/steam-new-purchase-auto-coverage`.
+
+## Problem
+
+A newly-purchased Steam game is downloaded by the **host** SteamPrefill `prefill --recently-purchased` midnight cron (confirmed live: Raft, app 648800 / depot 648801, 2.09 GiB pulled through the lancache at 12:47 AM). But the orchestrator shows `games.status='unknown'` indefinitely, so Game_shelf shows "Unknown". The host downloader and the orchestrator (status/coverage) are separate systems, and the orchestrator's automatic pipeline never catches a game that arrives outside the SteamPrefill *selection*.
+
+### Root causes (due-diligence workflow, adversarially verified SOUND)
+
+1. **Load-bearing bug — `unknown` games are never auto-validated.** A new steam row is inserted at the schema default `status='unknown'` (`library_sync.py::_NAMED_UPSERT_SQL` writes `title`+`owned` only). The scheduled *gated* validation sweep (`sweep.py::_CANDIDATE_SQL`) enumerates only `status IN ('up_to_date','validation_failed')`, and there is **no scheduled full sweep** (`manager.py` registers `enqueue_validation_sweep` with `full=False`; `full=True` is on-demand API/CLI only). So no cron ever enqueues a validate for an `unknown` game → it stays `unknown` forever.
+   - `games.metadata`/`current_version` being NULL is a **red herring**: the validator (`disk_stat.validate_game` → agent `locate_manifest_bins` over the manifest cache roots) reads on-disk `.bin`/`.shas` only, never `games.metadata` (the ~2485 rows that have depot metadata are legacy pre-③ ValvePython data; no current code writes steam `games.metadata`/`current_version`). **Raft's `.bin` is already on the agent-visible cache root**, so a validate resolves it to cached immediately.
+   - A validate with no manifest returns `outcome='error'`, which is **non-clobbering** (`validate.py` leaves status unchanged) — so enumerating `unknown` rows is safe even for genuinely-uncovered ones.
+
+2. **Durability gap — recent purchases get no durable `.shas`.** `manifest_fetcher.py::_enumerate_app_ids` reads **only** `selectedAppsToPrefill.json`. Recently-purchased games are downloaded outside the selection, so they never get a durable `.shas` sidecar. The `.bin` cache is prunable; the `.shas` in the archive volume is the durable coverage record `PR #213` introduced.
+
+3. **Operator enhancement (Karl).** A recently-purchased download should persist into `selectedAppsToPrefill.json` so it shows checked in `SteamPrefill --select-apps` and joins the durable prefill set (survives future `prefill` passes).
+
+## Locked decisions
+
+- **Immediacy = within 6h** (sweep only). Do NOT add a near-immediate `library_sync` validate-enqueue.
+- **Durable `.shas` cadence = leave weekly.** Do NOT change the `fetch_manifests` cron.
+- **Do NOT populate `games.metadata`/`current_version` for steam** (vestigial).
+
+## Architecture — three independent pieces
+
+### Piece 1 — sweep validates `unknown` games (control plane; the load-bearing fix)
+`src/orchestrator/jobs/handlers/sweep.py::_CANDIDATE_SQL`: extend the gated predicate to
+`WHERE status IN ('unknown','up_to_date','validation_failed') AND owned = 1`
+(the `owned = 1` guard bounds churn to owned games). The existing every-6h gated sweep (`manager.py` cron `0 3,9,15,21`) then enqueues a `validate` for any newly-discovered game. `validate.py` reads the on-disk `.bin` and flips status via `_STATUS_FOR` (cached→`up_to_date`, partial/missing→`validation_failed`); a no-manifest app returns `outcome='error'` and is left `unknown` (non-clobbering). **Zero agent change.** Raft → `up_to_date` within one sweep cycle post-deploy.
+
+### Piece 2 — bounded fetcher widening (agent; durability)
+`src/orchestrator/platform/steam/manifest_fetcher.py`: add a `manifest_cache_dir` param to `DepotDownloaderManifestFetcher.__init__`, and widen `_enumerate_app_ids` from selection-only to the **union of the selection with the BOUNDED subset** of app_ids that have a `.bin` in the manifest cache roots **but no matching-gid `.shas`**. Enumeration reference: `manifest_locator.list_prefilled_app_ids` glob over the cache roots — **inline the glob**; do NOT `import orchestrator.db.*` / `orchestrator.api.*` (keeps `tests/agent/test_import_isolation.py` green). Keep the existing `delay_sec` throttle + `_TRANSIENT_RE` backoff — the **first run** is the rate-limit spike to guard (#228 hazard); the bounded "has `.bin`, no matching `.shas`" subset is precisely what prevents a naive ~330–1077-app logon burst. `_write_shas` is already idempotent (already-covered depots skip). Wiring: pass `manifest_cache_dir=settings.steam_manifest_cache_dir` into **both** `DepotDownloaderManifestFetcher` constructions in `src/orchestrator/agent/app.py`.
+
+### Piece 3 — recently-purchased persist into the selection (control plane)
+`src/orchestrator/scheduler/jobs.py::auto_classify_block` already reconciles `selectedAppsToPrefill.json` via `agent_client.prune_steam_selection(exclude_ids, restore_ids)`. Verified: the agent's `reconcile_selection` (`selection_file.py`) treats `restore_ids` as **"ensure present"** — `to_add = restore - cur; new = (cur - to_remove) | restore` — so `restore_ids` **adds** app_ids even if never previously selected. Therefore Piece 3 is **control-plane-only, no agent/RPC change**: expand the `restore_ids` the reconcile sends to include the set of **prefilled** steam app_ids (from `agent_client.prefilled_apps()`, the `.bin` cache — the same source `library_sync` already uses) that are **not** in `prefill_exclusions(mode='exclude')`. The DB exclude set stays the source of truth, so an operator deselect (→ DB `exclude`) is honored and not re-added (`exclude - restore` still removes it because it won't be in the prefilled-restore set once excluded). Best-effort, never raises, converges each 6h tick. Net: a game the host `--recently-purchased` cron downloads appears in the `.bin` cache → next reconcile tick adds it to the selection → it shows checked in `--select-apps` and stays in the durable prefill set.
+
+## Data flow (buy a game → fully covered, no manual steps)
+```
+Purchase → host 'SteamPrefill prefill --recently-purchased' (midnight) caches it through lancache + writes its .bin
+  → library_sync (6h): prefilled_apps() sees the new .bin → upserts games row (title, status defaults 'unknown')
+  → auto_classify_block reconcile (6h) [PIECE 3]: adds the prefilled-non-excluded app_id to restore_ids
+     → agent reconcile_selection adds it to selectedAppsToPrefill.json (now checked in --select-apps)
+  → gated validation_sweep (6h) [PIECE 1]: enumerates the 'unknown' owned row → enqueues validate
+     → validate reads the on-disk .bin → status flips to up_to_date (or validation_failed if partial)
+  → fetch_manifests (weekly) [PIECE 2]: app now has a .bin but no matching .shas → fetches → durable .shas written
+```
+
+## Error handling
+- Piece 1: uncovered `unknown` rows → `validate` `outcome='error'`, status untouched (bounded to owned rows; ~a handful today). No cascade — `enqueue_scheduled_prefill` is Epic-only, so a steam `validation_failed` never triggers a prefill.
+- Piece 2: DepotDownloader logon reuses the persisted IsolatedStorage session (no 2FA); transient failures ride the existing `_TRANSIENT_RE` backoff; first-run burst bounded by the "no matching `.shas`" subset + `delay_sec`.
+- Piece 3: best-effort inside `auto_classify_block` (already `try/except`, never raises); a failed prune retries next tick; `prefilled_apps()` unreachable → skip, no selection change.
+
+## Testing (TDD, test-first per piece)
+- **Piece 1** (`tests/jobs/test_sweep_handler.py`): the gated sweep enumerates a `status='unknown', owned=1` steam game (and does NOT enumerate a not-owned `unknown` row); an uncovered `unknown` game's `outcome='error'` does not clobber its status. Existing gated/full sweep tests stay green.
+- **Piece 2** (`tests/…/test_manifest_fetcher.py`): app_ids present in the manifest cache but absent from `selectedAppsToPrefill.json` (e.g. Raft) ARE enumerated; app_ids already covered by a matching-gid `.shas` are skipped; selection-only apps still enumerated. `tests/agent/test_import_isolation.py` stays green (glob inlined). Fetcher-construction test in `agent/app.py` wiring.
+- **Piece 3** (`tests/scheduler/test_jobs.py` or the auto_classify_block test): `restore_ids` sent to `prune_steam_selection` includes a prefilled-non-excluded app_id and EXCLUDES a `prefill_exclusions(mode='exclude')` app_id; never raises when `prefilled_apps()` errors.
+- Full suite `pytest -q --ignore=tests/scripts`; mypy + ruff clean.
+
+## Non-goals
+- No `games.metadata`/`current_version` population for steam (vestigial).
+- No near-immediate `library_sync` validate-enqueue (Karl chose ≤6h).
+- No `fetch_manifests` cadence change.
+- No host-cron / `selectedAppsToPrefill.json` host-side edits, no new agent selection RPC (`restore_ids` already adds).
+- No schema/migration change (no new columns).
+
+## Deploy + live verification (no 2FA)
+- Control plane (Pieces 1+3) → LXC 1105: `git reset --hard origin/main; docker build -t orchestrator:dpa .; bash /root/deploy-orchestrator-lxc.sh` (build first — the script only recreates). Tag a rollback image first.
+- Agent (Piece 2) → UGREEN: rebuild + **recreate** the agent container (not restart — env reload).
+- Verify: within one 6h gated sweep, `games.status` for 648800 → `up_to_date`; after the reconcile tick, `648800` appears in `selectedAppsToPrefill.json`; the next weekly `fetch_manifests` writes a `648800_*_648801_*.shas` into the archive volume. Confirm no regression on the ~8 legacy NULL-metadata `unknown` rows (validate or stay `unknown` via non-clobbering error). Confirm `validation_sweep` + `fetch_manifests` scheduled jobs are enabled live (defaults True).

--- a/src/orchestrator/agent/app.py
+++ b/src/orchestrator/agent/app.py
@@ -78,6 +78,7 @@ def create_agent_app(*, settings: Settings | None = None) -> FastAPI:
                 username=settings.steam_username,
                 max_retries=settings.manifest_fetch_max_retries,
                 retry_backoff_sec=settings.manifest_fetch_retry_backoff_sec,
+                manifest_cache_dir=settings.steam_manifest_cache_dir,
             )
         interval = settings.manifest_archive_sync_interval_sec
         if interval > 0:
@@ -124,6 +125,7 @@ def create_agent_app(*, settings: Settings | None = None) -> FastAPI:
         username=settings.steam_username,
         max_retries=settings.manifest_fetch_max_retries,
         retry_backoff_sec=settings.manifest_fetch_retry_backoff_sec,
+        manifest_cache_dir=settings.steam_manifest_cache_dir,
     )
     app.include_router(health.router)
     app.include_router(pull.router)

--- a/src/orchestrator/jobs/handlers/sweep.py
+++ b/src/orchestrator/jobs/handlers/sweep.py
@@ -22,8 +22,15 @@ if TYPE_CHECKING:
 
 _log = structlog.get_logger(__name__)
 
+# Includes 'unknown' so a newly-purchased game (inserted at the default 'unknown'
+# by library_sync, then cached by the host SteamPrefill cron) is auto-validated by
+# the scheduled gated sweep — there is no scheduled FULL sweep, so without this an
+# 'unknown' game would never be validated. `owned = 1` bounds the churn; an
+# uncovered 'unknown' game returns outcome='error' which validate leaves untouched.
 _CANDIDATE_SQL = (
-    "SELECT id, status FROM games WHERE status IN ('up_to_date','validation_failed') ORDER BY id"
+    "SELECT id, status FROM games "
+    "WHERE status IN ('unknown','up_to_date','validation_failed') AND owned = 1 "
+    "ORDER BY id"
 )
 
 # `full` mode (validate-all backfill, 2026-06-24): validate EVERY game across

--- a/src/orchestrator/platform/steam/manifest_fetcher.py
+++ b/src/orchestrator/platform/steam/manifest_fetcher.py
@@ -83,6 +83,7 @@ class DepotDownloaderManifestFetcher:
         username: str = "",
         max_retries: int = 3,
         retry_backoff_sec: float = 15.0,
+        manifest_cache_dir: Path | None = None,
     ) -> None:
         self._binary = Path(binary)
         self._config_dir = Path(config_dir)
@@ -92,6 +93,9 @@ class DepotDownloaderManifestFetcher:
         self._username = username
         self._max_retries = max_retries
         self._retry_backoff_sec = retry_backoff_sec
+        # Live SteamPrefill .bin manifest cache (e.g. /steamprefill-cache). When
+        # set, enumeration also covers apps prefilled outside the selection.
+        self._manifest_cache_dir = Path(manifest_cache_dir) if manifest_cache_dir else None
 
     def login_from_session(self) -> None:
         """Verify a usable persisted DepotDownloader session exists (no password,
@@ -123,7 +127,29 @@ class DepotDownloaderManifestFetcher:
                 apps.add(int(k))
             except (TypeError, ValueError):
                 continue
-        return sorted(apps)
+        # Durability (#213 follow-up): also cover apps prefilled OUTSIDE the
+        # selection — a `.bin` in the live cache with no `.shas` in the archive yet
+        # (e.g. a `--recently-purchased` game). Bounded to that delta so the first
+        # run never triggers a full-library DepotDownloader logon burst (#228).
+        have_bin = self._app_ids_with_ext(self._manifest_cache_dir, "bin")
+        have_shas = self._app_ids_with_ext(self._archive_dir, "shas")
+        return sorted(apps | (have_bin - have_shas))
+
+    @staticmethod
+    def _app_ids_with_ext(directory: Path | None, ext: str) -> set[int]:
+        """app_ids that have a ``<dir>/v1/{app}_*.{ext}`` manifest. Inlined (no
+        ``manifest_locator`` import) to preserve agent import-isolation."""
+        apps: set[int] = set()
+        if directory is None:
+            return apps
+        v1 = directory / "v1"
+        if not v1.is_dir():
+            return apps
+        for path in v1.glob(f"*.{ext}"):
+            first = path.stem.split("_", 1)[0]
+            if first.isdigit():
+                apps.add(int(first))
+        return apps
 
     def _write_shas(self, app_id: int, depot_id: int, gid: str, shas: set[str]) -> bool:
         """Write {app}_{app}_{depot}_{gid}.shas (one lowercase 40-hex SHA1/line).

--- a/src/orchestrator/scheduler/jobs.py
+++ b/src/orchestrator/scheduler/jobs.py
@@ -285,6 +285,22 @@ async def enqueue_auto_classify_block(pool: Pool, agent_client: AgentClient | No
             )
             exclude_ids = [i for i in (as_int(r["app_id"]) for r in excl) if i is not None]
             restore_ids = [i for i in (as_int(r["app_id"]) for r in allow) if i is not None]
+            # Also (re)add prefilled-but-not-excluded games to the selection so a
+            # game the host `--recently-purchased` cron downloaded (a `.bin` in the
+            # agent cache, outside the curated selection) persists in
+            # selectedAppsToPrefill.json — showing checked in `--select-apps` and
+            # staying in the durable prefill set. Same `.bin`-cache source as
+            # library_sync. Best-effort: a prefilled_apps() failure leaves the
+            # allow-only restore set.
+            try:
+                prefilled = await agent_client.prefilled_apps()
+            except Exception as e:  # best-effort — a failed enum must not crash the tick
+                prefilled = []
+                _log.warning(
+                    "scheduler.auto_classify_block.prefilled_apps_failed", reason=str(e)[:200]
+                )
+            exclude_set = set(exclude_ids)
+            restore_ids = sorted({*restore_ids, *(a for a in prefilled if a not in exclude_set)})
             if exclude_ids or restore_ids:
                 res = await agent_client.prune_steam_selection(exclude_ids, restore_ids)
                 _log.info("scheduler.auto_classify_block.pruned", **res)

--- a/tests/agent/test_steam.py
+++ b/tests/agent/test_steam.py
@@ -205,6 +205,14 @@ class _FakeFetcher:
         return self._result
 
 
+def test_manifest_fetcher_built_with_cache_dir():
+    """create_agent_app wires the live manifest cache dir into the fetcher so it can
+    cover prefilled apps missing a .shas (new-purchase durability)."""
+    s = Settings(orchestrator_token="a" * 32)
+    app = create_agent_app(settings=s)
+    assert app.state.manifest_fetcher._manifest_cache_dir == s.steam_manifest_cache_dir
+
+
 def test_fetch_manifests_requires_bearer():
     app = create_agent_app(settings=Settings(orchestrator_token="a" * 32))
     app.state.manifest_fetcher = _FakeFetcher()

--- a/tests/jobs/test_sweep_handler.py
+++ b/tests/jobs/test_sweep_handler.py
@@ -91,6 +91,34 @@ async def test_sweep_validates_candidate_games_all_platforms(pool, monkeypatch):
     assert sorted(seen) == sorted([g_ok, g_vf, g_epic])
 
 
+async def test_gated_sweep_includes_unknown_owned_game(pool, monkeypatch):
+    """A newly-purchased game is inserted at status='unknown'; the gated sweep must
+    validate it (owned=1) so it flips off 'unknown' — but must NOT sweep an
+    unowned 'unknown' row (owned=0)."""
+    _healthy(monkeypatch)
+    g_unknown = await _seed(pool, status="unknown", app_id="648800")  # owned=1
+    g_ok = await _seed(pool, status="up_to_date", app_id="730")
+    # unowned unknown row — must be skipped (owned guard).
+    await pool.execute_write(
+        "INSERT INTO games (platform, app_id, title, owned, status) "
+        "VALUES ('steam','999','t',0,'unknown')"
+    )
+    g_unowned = (await pool.read_one("SELECT id FROM games WHERE app_id='999'"))["id"]
+
+    seen: list[int] = []
+
+    async def fake_validate_one(pool_, deps_, game_id, settings):
+        seen.append(game_id)
+        from orchestrator.validator.disk_stat import ValidationResult
+
+        return ValidationResult(1, 1, 0, "cached", "100", None)
+
+    monkeypatch.setattr("orchestrator.jobs.handlers.sweep.validate_one_game", fake_validate_one)
+    await sweep_handler(_job(), Deps(pool=pool, agent_client=_Agent()))
+    assert g_unknown in seen and g_ok in seen
+    assert g_unowned not in seen
+
+
 async def test_sweep_isolates_per_game_errors(pool, monkeypatch):
     _healthy(monkeypatch)
     g1 = await _seed(pool, app_id="1")
@@ -236,7 +264,9 @@ async def test_default_payload_keeps_status_gated(pool, monkeypatch):
     job = {"id": 1, "kind": "sweep", "payload": None}
     await sweep_handler(job, Deps(pool=pool, agent_client=_Agent()))
     assert captured["sql"] == sweep_mod._CANDIDATE_SQL
-    assert "status IN ('up_to_date','validation_failed')" in captured["sql"]
+    # Gated (not full) SQL: status-scoped incl. 'unknown' (new-purchase auto-cover), owned-guarded.
+    assert "status IN ('unknown','up_to_date','validation_failed')" in captured["sql"]
+    assert "owned = 1" in captured["sql"]
 
 
 async def test_malformed_payload_falls_back_to_gated(pool, monkeypatch):

--- a/tests/platform/steam/test_manifest_fetcher.py
+++ b/tests/platform/steam/test_manifest_fetcher.py
@@ -346,3 +346,43 @@ def test_fetch_all_bounds_transient_retries_then_counts_failed(tmp_path, monkeyp
     r = f.fetch_all()
     assert r.fetched == 1 and r.failed == 1
     assert attempts[730] == 3  # 1 initial + 2 retries, then given up
+
+
+def test_enumerate_unions_uncovered_cache_apps(tmp_path):
+    """Durability: an app with a live `.bin` but no `.shas` (a --recently-purchased
+    game outside the selection) is enumerated; one already covered by a `.shas` is
+    NOT; selection apps are always included."""
+    steam_cfg = tmp_path / "Config"
+    steam_cfg.mkdir()
+    (steam_cfg / "selectedAppsToPrefill.json").write_text(json.dumps([111]))
+    cache = tmp_path / "cache"
+    (cache / "v1").mkdir(parents=True)
+    archive = tmp_path / "archive"
+    (archive / "v1").mkdir(parents=True)
+    (cache / "v1" / "222_222_2221_gidA.bin").write_bytes(b"x")  # .bin, no .shas -> enumerate
+    (cache / "v1" / "333_333_3331_gidB.bin").write_bytes(b"x")  # .bin + .shas -> skip
+    (archive / "v1" / "333_333_3331_gidB.shas").write_text("")
+    f = DepotDownloaderManifestFetcher(
+        binary=tmp_path / "DepotDownloader",
+        config_dir=tmp_path / "dd-config",
+        steam_config_dir=steam_cfg,
+        archive_dir=archive,
+        delay_sec=0.0,
+        manifest_cache_dir=cache,
+    )
+    assert f._enumerate_app_ids() == [111, 222]
+
+
+def test_enumerate_selection_only_when_no_cache_dir(tmp_path):
+    steam_cfg = tmp_path / "Config"
+    steam_cfg.mkdir()
+    (steam_cfg / "selectedAppsToPrefill.json").write_text(json.dumps([111]))
+    f = DepotDownloaderManifestFetcher(
+        binary=tmp_path / "DepotDownloader",
+        config_dir=tmp_path / "dd-config",
+        steam_config_dir=steam_cfg,
+        archive_dir=tmp_path / "archive",
+        delay_sec=0.0,
+        manifest_cache_dir=None,
+    )
+    assert f._enumerate_app_ids() == [111]

--- a/tests/scheduler/test_jobs.py
+++ b/tests/scheduler/test_jobs.py
@@ -440,6 +440,38 @@ class TestAutoClassifyBlockActuation:
         assert 1 in exclude_ids  # the music app auto-excluded
         assert 9 in restore_ids  # the operator allow
 
+    async def test_reconcile_readds_prefilled_non_excluded(self, pool):
+        """A prefilled (has-a-.bin) game that is not excluded — e.g. a
+        --recently-purchased download — is (re)added to the selection; an
+        excluded prefilled app is not."""
+        from unittest.mock import AsyncMock
+
+        from orchestrator.scheduler.jobs import enqueue_auto_classify_block
+
+        await _seed_classified(pool, "900", "music", "OST")  # → excluded
+        agent = AsyncMock()
+        agent.prune_steam_selection.return_value = {"removed": 1, "restored": 1, "remaining": 5}
+        agent.prefilled_apps.return_value = [648800, 900]  # both prefilled; 900 is excluded
+        await enqueue_auto_classify_block(pool, agent)
+        exclude_ids, restore_ids = agent.prune_steam_selection.await_args.args
+        assert 648800 in restore_ids  # prefilled + not excluded → re-added
+        assert 900 not in restore_ids  # excluded → not re-added
+        assert 900 in exclude_ids
+
+    async def test_reconcile_survives_prefilled_apps_error(self, pool):
+        """A prefilled_apps() failure must not crash the tick; the prune still runs
+        with the DB allow set only."""
+        from unittest.mock import AsyncMock
+
+        from orchestrator.scheduler.jobs import enqueue_auto_classify_block
+
+        await _seed_classified(pool, "900", "music", "OST")
+        agent = AsyncMock()
+        agent.prune_steam_selection.return_value = {"removed": 1, "restored": 0, "remaining": 5}
+        agent.prefilled_apps.side_effect = RuntimeError("agent down")
+        await enqueue_auto_classify_block(pool, agent)  # must not raise
+        agent.prune_steam_selection.assert_awaited_once()
+
     async def test_no_agent_client_skips_prune(self, pool):
         from orchestrator.scheduler.jobs import enqueue_auto_classify_block
 


### PR DESCRIPTION
## Summary

Fixes a real gap found while debugging **Raft** (bought as a test): the host `SteamPrefill --recently-purchased` cron downloaded + cached it at 12:47 AM (depot 648801, 2.09 GiB through lancache), but the orchestrator showed `status='unknown'` indefinitely. Root cause was **not** the downloader — it was three orchestrator-side gaps. This makes new purchases self-heal: buy a game → cached that night → within 6h it's validated *and* in the durable prefill selection, hands-off. **No host-cron edit, no schema change, no 2FA.**

## Root cause (adversarially-verified due-diligence workflow)

- **Load-bearing bug:** the scheduled *gated* validation sweep enumerated only `up_to_date`/`validation_failed`, and there's **no scheduled *full* sweep** — so a row inserted at the default `unknown` (library_sync writes title+owned only) was **never** auto-validated. `games.metadata=NULL` was a red herring: the validator reads on-disk `.bin`/`.shas`, which the host had already written (the depot metadata on legacy rows is vestigial pre-③ data).
- **Durability gap:** the manifest fetcher enumerated only the SteamPrefill *selection*, so recent purchases got no durable `.shas`.
- **Operator ask:** recent purchases should persist into `selectedAppsToPrefill.json` (show checked in `--select-apps`).

## Changes (3 pieces)

1. **`sweep.py`** — the gated sweep now validates `unknown` **owned** games (owned-guarded). A recent purchase auto-validates off its already-cached manifest within one 6h cycle; an uncovered `unknown` game returns `outcome='error'` which validate leaves untouched (non-clobbering). *This is the actual fix.*
2. **`manifest_fetcher.py` + `agent/app.py`** — the fetcher also covers apps with a live `.bin` but no matching `.shas`, **bounded** to that delta (never a full-library logon burst, #228); wired via `manifest_cache_dir=steam_manifest_cache_dir`.
3. **`scheduler/jobs.py`** — the selection reconcile re-adds prefilled-but-not-excluded apps to `restore_ids` (the agent's `reconcile_selection` already *adds* via `restore_ids`, so no agent/RPC change). Operator deselects, tracked as DB excludes, are still honored.

Non-goals (respected): no `games.metadata`/`current_version` population (vestigial), no near-immediate `library_sync` validate-enqueue (≤6h chosen), no `fetch_manifests` cadence change, no host edit, no schema change.

Spec: `docs/superpowers/specs/2026-07-07-steam-new-purchase-auto-coverage-design.md`. Plan: `docs/superpowers/plans/2026-07-07-steam-new-purchase-auto-coverage.md`.

## Tests
Full suite **1566 passed** (only the pre-existing `test_licenses.py` FileNotFoundError fails); mypy + ruff clean. TDD per piece: sweep enumerates `unknown` owned (not owned=0); fetcher enumerates has-.bin-no-.shas + skips covered; agent wiring; reconcile re-adds prefilled-non-excluded + survives a `prefilled_apps()` error.

## Post-merge (I'll run, no 2FA)
Deploy control plane → LXC 1105, agent → UGREEN (recreate). Verify Raft `648800` → `up_to_date` within one 6h sweep, appears in `selectedAppsToPrefill.json`, and gets a `.shas` on the next weekly fetch.