### PR TITLE
feat(#222): manual-downloads support for Amazon/Humble/Itch (space/dot launchers + files)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Changed — manual-downloads endpoint supports Amazon/Humble/Itch (space/dot launchers + files) — 2026-07-10
+
+The manual-download listing (`GET /v1/manual-downloads/{launcher}` + control proxy) is extended so Game_shelf can diff Amazon, Humble Bundle, and Itch.io downloads against the owned library, not just GOG. (#222)
+
+- **Changed:** the launcher-name allowlist widens from `^[A-Za-z0-9_-]+$` to `^[A-Za-z0-9 ._-]+$` (both agent and control routers), so folder names with a space or dot — `Amazon Games`, `Humble Bundle`, `Itch.io` — are reachable. Path traversal stays impossible (no `/`; the resolve-under-root guard rejects `.`/`..`).
+- **Changed:** a new `?include_files=true` query lists loose installer/archive *files* (Humble/Itch downloads are single files, not per-game folders), not just directories. Default `false` keeps GOG/Amazon dir-only listing byte-identical (zero regression).
+- **Changed:** `AgentClient.manual_downloads(launcher, include_files=False)` URL-encodes the launcher (spaces/dots) and forwards the flag.
+
 ### Fixed — newly-purchased Steam games stuck at `unknown` (new-purchase auto-coverage) — 2026-07-07
 
 A Steam game bought and cached by the host `SteamPrefill prefill --recently-purchased` cron stayed `status='unknown'` in the orchestrator indefinitely (Game_shelf showed "Unknown"). Root cause: the scheduled *gated* validation sweep enumerated only `up_to_date`/`validation_failed` games, and there is **no scheduled *full* sweep** — so a row inserted at the default `unknown` (library_sync writes title+owned only) was never auto-validated by any cron. (`games.metadata` being NULL was a red herring: the validator reads the on-disk `.bin`/`.shas`, which the host had already written; the legacy depot metadata on older rows is vestigial pre-③ data.)

--- a/docs/superpowers/plans/2026-07-10-manual-coverage-orchestrator.md
+++ b/docs/superpowers/plans/2026-07-10-manual-coverage-orchestrator.md
@@ -1,0 +1,290 @@
+# Manual-Coverage Orchestrator Support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the orchestrator serve manual-download folder listings for launchers whose on-disk folder name contains a space or dot (`Amazon Games`, `Humble Bundle`, `Itch.io`), and optionally list loose files (Humble/Itch), so Game_shelf can diff them against the owned library.
+
+**Architecture:** Two tiny, backward-compatible changes mirrored across the agent router (`GET /v1/manual-downloads/{launcher}`), the control-plane proxy (`GET /api/v1/manual-downloads/{launcher}`), and the client (`AgentClient.manual_downloads`). (1) Widen the launcher-name allowlist regex from `^[A-Za-z0-9_-]+$` to `^[A-Za-z0-9 ._-]+$` — traversal stays impossible (no `/`; the resolve-under-root guard rejects `.`/`..`). (2) Add an `include_files` query param (default `false`) so file-based launchers can list files, not just directories; default `false` keeps GOG/Amazon behavior byte-identical.
+
+**Tech Stack:** Python 3.12, FastAPI, pytest, mypy, ruff. Framework hooks active (enforce-plan-tracking → a plan task must be `in_progress` before editing source; enforce-evaluate → marker before each commit; pre-commit ruff+mypy+semgrep).
+
+## Global Constraints
+
+- Regex (verbatim, both routers): `^[A-Za-z0-9 ._-]+$`. No `/`, no other chars.
+- The resolve-under-root guard (`if target.parent != root: 400`) MUST remain in the agent router.
+- `include_files` default is `False` everywhere; GOG/Amazon must keep dir-only listing.
+- Agent still skips entries whose name starts with `!` or `.` in BOTH dir and file mode.
+- `AgentClient.manual_downloads` MUST URL-encode the launcher: `urllib.parse.quote(launcher, safe="")`.
+- No schema/migration. No new third-party imports (`urllib.parse` is stdlib — no Context7 lookup needed).
+- Run tests from repo root with `.venv/bin/python -m pytest ... -q`. Commit only after ruff+mypy clean.
+
+---
+
+### Task 1: Agent router — widen regex + `include_files`
+
+**Files:**
+- Modify: `src/orchestrator/agent/routers/manual_downloads.py`
+- Test: `tests/agent/test_manual_downloads.py`
+
+**Interfaces:**
+- Produces: `GET /v1/manual-downloads/{launcher}?include_files=<bool>` — 200 `{launcher, present, entries}`; accepts space/dot launcher names; `include_files=true` adds regular files to `entries`.
+
+- [ ] **Step 1: Write failing tests** (append to `tests/agent/test_manual_downloads.py`)
+
+```python
+def test_accepts_launcher_with_space_and_dot(tmp_path):
+    for folder in ("Amazon Games", "Humble Bundle", "Itch.io"):
+        (tmp_path / folder / "A Game").mkdir(parents=True)
+    app = create_agent_app(settings=_settings(tmp_path))
+    client = TestClient(app, headers=AUTH)
+    for folder in ("Amazon Games", "Humble Bundle", "Itch.io"):
+        r = client.get(f"/v1/manual-downloads/{folder}")
+        assert r.status_code == 200, folder
+        assert r.json()["entries"] == ["A Game"]
+
+
+def test_include_files_lists_files_when_true(tmp_path):
+    hb = tmp_path / "Humble Bundle"
+    hb.mkdir(parents=True)
+    (hb / "VVVVVV-04212026.zip").write_text("x")
+    (hb / "A Folder Game").mkdir()
+    (hb / "!downloading").write_text("x")
+    (hb / ".hidden").write_text("x")
+    app = create_agent_app(settings=_settings(tmp_path))
+    client = TestClient(app, headers=AUTH)
+    default = client.get("/v1/manual-downloads/Humble Bundle").json()["entries"]
+    assert default == ["A Folder Game"]  # dirs only, unchanged
+    withfiles = client.get("/v1/manual-downloads/Humble Bundle?include_files=true").json()["entries"]
+    assert withfiles == ["A Folder Game", "VVVVVV-04212026.zip"]  # file added, !/. skipped
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/agent/test_manual_downloads.py -q`
+Expected: FAIL (space launcher → 400; `include_files` param ignored).
+
+- [ ] **Step 3: Implement** — edit `src/orchestrator/agent/routers/manual_downloads.py`
+
+Change the regex constant:
+```python
+_LAUNCHER_RE = re.compile(r"^[A-Za-z0-9 ._-]+$")
+```
+Change the handler signature + listing to accept `include_files`:
+```python
+@router.get("/v1/manual-downloads/{launcher}")
+async def manual_downloads(
+    launcher: str, request: Request, include_files: bool = False
+) -> ManualDownloadsResponse:
+    if not _LAUNCHER_RE.match(launcher):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="invalid launcher")
+    settings = request.app.state.settings
+    root = settings.manual_downloads_cache_path.resolve()
+    target = (root / launcher).resolve()
+    if target.parent != root:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="invalid launcher")
+    if not target.is_dir():
+        return ManualDownloadsResponse(launcher=launcher, present=False, entries=[])
+    entries = sorted(
+        e.name
+        for e in target.iterdir()
+        if (e.is_dir() or (include_files and e.is_file()))
+        and not e.name.startswith(("!", "."))
+    )
+    return ManualDownloadsResponse(launcher=launcher, present=True, entries=entries)
+```
+
+- [ ] **Step 4: Run to verify pass** (existing traversal test `test_rejects_path_traversal_launcher` must still pass — `..`/`GOG/..` still rejected by the resolve guard; `%2e%2e` decodes to `..`)
+
+Run: `.venv/bin/python -m pytest tests/agent/test_manual_downloads.py -q`
+Expected: PASS (all).
+
+- [ ] **Step 5: ruff + mypy, then commit**
+
+Run: `.venv/bin/ruff check src/orchestrator/agent/routers/manual_downloads.py && .venv/bin/mypy src/orchestrator/agent/routers/manual_downloads.py`
+```bash
+git add src/orchestrator/agent/routers/manual_downloads.py tests/agent/test_manual_downloads.py
+git commit -m "feat(#222): agent manual-downloads accepts space/dot launchers + include_files"
+```
+
+---
+
+### Task 2: `AgentClient.manual_downloads` — encode launcher + `include_files`
+
+**Files:**
+- Modify: `src/orchestrator/clients/agent_client.py` (method at ~line 245)
+- Test: `tests/clients/test_agent_client.py` (create if absent; otherwise append)
+
+**Interfaces:**
+- Consumes: agent endpoint from Task 1.
+- Produces: `AgentClient.manual_downloads(launcher: str, include_files: bool = False) -> dict[str, Any]` — issues `GET /v1/manual-downloads/<quoted-launcher>[?include_files=true]`.
+
+- [ ] **Step 1: Write failing test** — capture the path the client requests. Look at how other tests in this repo fake `_request` (e.g. `tests/clients/`), then:
+
+```python
+import pytest
+from orchestrator.clients.agent_client import AgentClient
+
+
+class _CapResp:
+    def json(self):
+        return {"launcher": "Amazon Games", "present": True, "entries": []}
+
+
+@pytest.mark.asyncio
+async def test_manual_downloads_encodes_launcher_and_include_files(monkeypatch):
+    client = AgentClient(base_url="http://agent", token="t")
+    seen = {}
+
+    async def fake_request(method, path, **kw):
+        seen["method"], seen["path"] = method, path
+        return _CapResp()
+
+    monkeypatch.setattr(client, "_request", fake_request)
+    await client.manual_downloads("Amazon Games")
+    assert seen["path"] == "/v1/manual-downloads/Amazon%20Games"
+    await client.manual_downloads("Itch.io", include_files=True)
+    assert seen["path"] == "/v1/manual-downloads/Itch.io?include_files=true"
+```
+(Match the actual `AgentClient` constructor signature and async test style used elsewhere in `tests/clients/`; adjust `AgentClient(...)` args to the real ones.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/clients/test_agent_client.py -q -k manual_downloads`
+Expected: FAIL (space not encoded; no `include_files`).
+
+- [ ] **Step 3: Implement** — edit `src/orchestrator/clients/agent_client.py`
+
+Add `from urllib.parse import quote` to the imports at the top of the file, then replace the method:
+```python
+    async def manual_downloads(
+        self, launcher: str, include_files: bool = False
+    ) -> dict[str, Any]:
+        """List the manually-downloaded game entries under `<cache>/<launcher>/`
+        on the agent host (#222). Returns {launcher, present, entries}. The launcher
+        may contain spaces/dots (e.g. "Amazon Games") so it is URL-encoded here; the
+        caller still validates it against the alnum/space/./-/_ allowlist. With
+        include_files, loose files (Humble/Itch installers) are listed too."""
+        path = f"/v1/manual-downloads/{quote(launcher, safe='')}"
+        if include_files:
+            path += "?include_files=true"
+        resp = await self._request("GET", path)
+        result: dict[str, Any] = resp.json()
+        return result
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/python -m pytest tests/clients/test_agent_client.py -q -k manual_downloads`
+Expected: PASS.
+
+- [ ] **Step 5: ruff + mypy, then commit**
+
+Run: `.venv/bin/ruff check src/orchestrator/clients/agent_client.py && .venv/bin/mypy src/orchestrator/clients/agent_client.py`
+```bash
+git add src/orchestrator/clients/agent_client.py tests/clients/test_agent_client.py
+git commit -m "feat(#222): AgentClient.manual_downloads url-encodes launcher + include_files"
+```
+
+---
+
+### Task 3: Control-plane router — widen regex + forward `include_files`
+
+**Files:**
+- Modify: `src/orchestrator/api/routers/manual_downloads.py`
+- Test: `tests/api/test_manual_downloads_router.py`
+
+**Interfaces:**
+- Consumes: `AgentClient.manual_downloads(launcher, include_files)` from Task 2.
+- Produces: `GET /api/v1/manual-downloads/{launcher}?include_files=<bool>` — accepts space/dot launchers, forwards `include_files` to the client.
+
+- [ ] **Step 1: Write failing tests** — the existing test file defines a fake client with `manual_downloads(self, launcher)`; widen it to capture `include_files`. Add:
+
+```python
+def test_router_accepts_space_launcher_and_forwards_include_files(...):
+    # Fake client records (launcher, include_files); assert:
+    #  GET /api/v1/manual-downloads/Amazon%20Games         -> client called ("Amazon Games", False)
+    #  GET /api/v1/manual-downloads/Itch.io?include_files=true -> client called ("Itch.io", True)
+```
+Update the fake client signature to `async def manual_downloads(self, launcher, include_files=False)` and record both args. (Follow the existing harness in `tests/api/test_manual_downloads_router.py`.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/api/test_manual_downloads_router.py -q`
+Expected: FAIL (space launcher rejected by old regex; `include_files` not forwarded).
+
+- [ ] **Step 3: Implement** — edit `src/orchestrator/api/routers/manual_downloads.py`
+
+Change the regex:
+```python
+_LAUNCHER_RE = re.compile(r"^[A-Za-z0-9 ._-]+$")
+```
+Change the handler to accept and forward `include_files`:
+```python
+async def manual_downloads(
+    launcher: str, request: Request, include_files: bool = False
+) -> JSONResponse:
+    if not _LAUNCHER_RE.match(launcher):
+        return JSONResponse(content={"detail": "invalid launcher"}, status_code=400)
+    client = getattr(request.app.state, "agent_client", None)
+    if client is None:
+        return JSONResponse(content={"detail": "agent not configured"}, status_code=503)
+    try:
+        result = await client.manual_downloads(launcher, include_files=include_files)
+    except Exception as e:
+        _log.error("api.manual_downloads.agent_error", launcher=launcher, reason=str(e)[:200])
+        return JSONResponse(content={"detail": "agent unavailable"}, status_code=503)
+    return JSONResponse(content=result)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/python -m pytest tests/api/test_manual_downloads_router.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: ruff + mypy, then commit**
+
+Run: `.venv/bin/ruff check src/orchestrator/api/routers/manual_downloads.py && .venv/bin/mypy src/orchestrator/api/routers/manual_downloads.py`
+```bash
+git add src/orchestrator/api/routers/manual_downloads.py tests/api/test_manual_downloads_router.py
+git commit -m "feat(#222): control manual-downloads accepts space/dot launchers + forwards include_files"
+```
+
+---
+
+### Task 4: CHANGELOG + full-suite verification + PR
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: CHANGELOG** — under the current unreleased section add:
+```
+### Changed
+- Manual-downloads endpoint accepts launcher folder names with spaces/dots
+  (Amazon Games, Humble Bundle, Itch.io) and can list loose files via
+  `?include_files=true` (default off keeps GOG/Amazon dir-only). (#222)
+```
+
+- [ ] **Step 2: Full suite + lint**
+
+Run: `.venv/bin/python -m pytest -q --ignore=tests/scripts` (only pre-existing `test_licenses.py` may fail)
+Run: `.venv/bin/ruff check src tests && .venv/bin/mypy src`
+Expected: green (aside from the known pre-existing licenses failure).
+
+- [ ] **Step 3: Commit + push + open PR**
+```bash
+git add CHANGELOG.md
+git commit -m "docs(#222): CHANGELOG — manual-downloads space/dot launchers + include_files"
+git push -u origin <branch>
+gh pr create --title "feat(#222): manual-downloads support for Amazon/Humble/Itch (space/dot + files)" --body "..."
+```
+(Karl merges the PR — never `gh pr merge`.)
+
+## Deploy (after merge; no 2FA)
+- Control plane LXC 1105: `cd /root/lancache-orchestrator && git fetch && git reset --hard origin/main && docker build -t orchestrator:dpa . && bash /root/deploy-orchestrator-lxc.sh` (tag rollback `orchestrator:dpa-pre-manualcov` first).
+- Agent (UGREEN .40): RECREATE the `orchestrator-agent` container (via `/home/karl/deploy-agent.sh`) so the router change loads — restart is not enough for a code change.
+- Verify: `GET /api/v1/manual-downloads/Amazon%20Games` → 200 with 384 entries; `.../Humble%20Bundle?include_files=true` → the 18 files.
+
+## Self-Review
+- **Spec coverage:** A1 regex (Tasks 1+3), A2 include_files (Tasks 1+3), agent_client encode (Task 2). ✓
+- **Traversal:** resolve-under-root guard retained in Task 1; existing traversal test unchanged. ✓
+- **Regression:** default `include_files=false` → dir-only, asserted in Task 1. ✓

--- a/src/orchestrator/agent/routers/manual_downloads.py
+++ b/src/orchestrator/agent/routers/manual_downloads.py
@@ -20,7 +20,7 @@ router = APIRouter()
 # Restricting it to alnum / '_' / '-' means it can contain NO '.' or '/', so it
 # can never form '..' or escape the cache root — path-traversal is impossible by
 # construction (defense-in-depth resolve-check below regardless).
-_LAUNCHER_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+_LAUNCHER_RE = re.compile(r"^[A-Za-z0-9 ._-]+$")
 
 
 class ManualDownloadsResponse(BaseModel):
@@ -31,7 +31,9 @@ class ManualDownloadsResponse(BaseModel):
 
 
 @router.get("/v1/manual-downloads/{launcher}")
-async def manual_downloads(launcher: str, request: Request) -> ManualDownloadsResponse:
+async def manual_downloads(
+    launcher: str, request: Request, include_files: bool = False
+) -> ManualDownloadsResponse:
     if not _LAUNCHER_RE.match(launcher):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="invalid launcher")
     settings = request.app.state.settings
@@ -43,9 +45,12 @@ async def manual_downloads(launcher: str, request: Request) -> ManualDownloadsRe
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="invalid launcher")
     if not target.is_dir():
         return ManualDownloadsResponse(launcher=launcher, present=False, entries=[])
-    # Game folders only: skip files (README.md), lancache control entries
-    # (!downloading / !orphaned), and any dotfiles.
+    # Dir-per-game launchers (GOG/Amazon) list folders only. File-based launchers
+    # (Humble/Itch — loose installers) opt into files via include_files. Always skip
+    # lancache control entries (!downloading / !orphaned) and dotfiles.
     entries = sorted(
-        e.name for e in target.iterdir() if e.is_dir() and not e.name.startswith(("!", "."))
+        e.name
+        for e in target.iterdir()
+        if (e.is_dir() or (include_files and e.is_file())) and not e.name.startswith(("!", "."))
     )
     return ManualDownloadsResponse(launcher=launcher, present=True, entries=entries)

--- a/src/orchestrator/api/routers/manual_downloads.py
+++ b/src/orchestrator/api/routers/manual_downloads.py
@@ -16,8 +16,9 @@ from fastapi.responses import JSONResponse
 
 _log = structlog.get_logger(__name__)
 
-# Same allowlist the agent enforces — a single traversal-safe path component.
-_LAUNCHER_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+# Same allowlist the agent enforces — a traversal-safe path component that may
+# contain spaces/dots (Amazon Games, Itch.io) but never a '/'.
+_LAUNCHER_RE = re.compile(r"^[A-Za-z0-9 ._-]+$")
 
 router = APIRouter(prefix="/api/v1", tags=["manual-downloads"])
 
@@ -32,14 +33,16 @@ router = APIRouter(prefix="/api/v1", tags=["manual-downloads"])
     },
     summary="List manually-downloaded game folders for a launcher",
 )
-async def manual_downloads(launcher: str, request: Request) -> JSONResponse:
+async def manual_downloads(
+    launcher: str, request: Request, include_files: bool = False
+) -> JSONResponse:
     if not _LAUNCHER_RE.match(launcher):
         return JSONResponse(content={"detail": "invalid launcher"}, status_code=400)
     client = getattr(request.app.state, "agent_client", None)
     if client is None:
         return JSONResponse(content={"detail": "agent not configured"}, status_code=503)
     try:
-        result = await client.manual_downloads(launcher)
+        result = await client.manual_downloads(launcher, include_files=include_files)
     except Exception as e:  # agent down / transport error — never 500
         _log.error("api.manual_downloads.agent_error", launcher=launcher, reason=str(e)[:200])
         return JSONResponse(content={"detail": "agent unavailable"}, status_code=503)

--- a/src/orchestrator/clients/agent_client.py
+++ b/src/orchestrator/clients/agent_client.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import time
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 import structlog
@@ -242,11 +243,16 @@ class AgentClient:
         result: list[int] = resp.json()["app_ids"]
         return result
 
-    async def manual_downloads(self, launcher: str) -> dict[str, Any]:
-        """List the manually-downloaded game folders under `<cache>/<launcher>/`
-        on the agent host (#222). Returns {launcher, present, entries}. The caller
-        validates `launcher` (alnum/_/-) before it reaches the path."""
-        resp = await self._request("GET", f"/v1/manual-downloads/{launcher}")
+    async def manual_downloads(self, launcher: str, include_files: bool = False) -> dict[str, Any]:
+        """List the manually-downloaded game entries under `<cache>/<launcher>/`
+        on the agent host (#222). Returns {launcher, present, entries}. The launcher
+        may contain spaces/dots (e.g. "Amazon Games") so it is URL-encoded here; the
+        caller still validates it against the allowlist. With include_files, loose
+        files (Humble/Itch installers) are listed too, not just directories."""
+        path = f"/v1/manual-downloads/{quote(launcher, safe='')}"
+        if include_files:
+            path += "?include_files=true"
+        resp = await self._request("GET", path)
         result: dict[str, Any] = resp.json()
         return result
 

--- a/tests/agent/test_manual_downloads.py
+++ b/tests/agent/test_manual_downloads.py
@@ -80,3 +80,34 @@ def test_requires_auth(tmp_path):
     app = create_agent_app(settings=_settings(tmp_path))
     client = TestClient(app)
     assert client.get("/v1/manual-downloads/GOG").status_code == 401
+
+
+def test_accepts_launcher_with_space_and_dot(tmp_path):
+    # Amazon Games / Humble Bundle / Itch.io folder names contain a space or dot;
+    # the launcher allowlist must accept them (traversal still blocked — no '/').
+    for folder in ("Amazon Games", "Humble Bundle", "Itch.io"):
+        (tmp_path / folder / "A Game").mkdir(parents=True)
+    app = create_agent_app(settings=_settings(tmp_path))
+    client = TestClient(app, headers=AUTH)
+    for folder in ("Amazon Games", "Humble Bundle", "Itch.io"):
+        r = client.get(f"/v1/manual-downloads/{folder}")
+        assert r.status_code == 200, folder
+        assert r.json()["entries"] == ["A Game"], folder
+
+
+def test_include_files_lists_files_when_true(tmp_path):
+    hb = tmp_path / "Humble Bundle"
+    hb.mkdir(parents=True)
+    (hb / "VVVVVV-04212026.zip").write_text("x")
+    (hb / "A Folder Game").mkdir()
+    (hb / "!downloading").write_text("x")
+    (hb / ".hidden").write_text("x")
+    app = create_agent_app(settings=_settings(tmp_path))
+    client = TestClient(app, headers=AUTH)
+    default = client.get("/v1/manual-downloads/Humble Bundle").json()["entries"]
+    assert default == ["A Folder Game"]  # dirs only, unchanged default
+    resp = client.get("/v1/manual-downloads/Humble Bundle?include_files=true")
+    assert resp.json()["entries"] == [
+        "A Folder Game",
+        "VVVVVV-04212026.zip",
+    ]  # file added; !/. skipped

--- a/tests/api/test_manual_downloads_router.py
+++ b/tests/api/test_manual_downloads_router.py
@@ -13,9 +13,11 @@ class _FakeAgent:
         self._result = result
         self._exc = exc
         self.calls: list[str] = []
+        self.include_files_calls: list[bool] = []
 
-    async def manual_downloads(self, launcher: str):
+    async def manual_downloads(self, launcher: str, include_files: bool = False):
         self.calls.append(launcher)
+        self.include_files_calls.append(include_files)
         if self._exc is not None:
             raise self._exc
         return self._result
@@ -33,10 +35,24 @@ async def test_proxies_agent_listing(client, unit_app):
 
 async def test_invalid_launcher_400(client, unit_app):
     unit_app.state.agent_client = _FakeAgent(result={})
-    # A dot is not allowed (traversal-safe allowlist) — rejected before the agent.
-    r = await client.get("/api/v1/manual-downloads/a.b", headers=AUTH)
+    # Dots/spaces ARE allowed now (Itch.io / Amazon Games); a char outside the
+    # allowlist (e.g. '@') is still rejected before the agent.
+    r = await client.get("/api/v1/manual-downloads/a@b", headers=AUTH)
     assert r.status_code == 400
     assert unit_app.state.agent_client.calls == []  # never reached the agent
+
+
+async def test_accepts_space_launcher_and_forwards_include_files(client, unit_app):
+    unit_app.state.agent_client = _FakeAgent(
+        result={"launcher": "Amazon Games", "present": True, "entries": ["A Game"]}
+    )
+    r = await client.get("/api/v1/manual-downloads/Amazon Games", headers=AUTH)
+    assert r.status_code == 200
+    r2 = await client.get("/api/v1/manual-downloads/Itch.io?include_files=true", headers=AUTH)
+    assert r2.status_code == 200
+    agent = unit_app.state.agent_client
+    assert agent.calls == ["Amazon Games", "Itch.io"]
+    assert agent.include_files_calls == [False, True]
 
 
 async def test_no_agent_configured_503(client, unit_app):

--- a/tests/clients/test_agent_client.py
+++ b/tests/clients/test_agent_client.py
@@ -486,3 +486,17 @@ async def test_steam_purge_non_2xx_raises():
     client = _client(handler)
     with pytest.raises(AgentError):
         await client.steam_purge(440)
+
+
+async def test_manual_downloads_encodes_launcher_and_include_files():
+    captured: dict[str, list[str]] = {"paths": []}
+
+    def handler(request):
+        captured["paths"].append(request.url.raw_path.decode())
+        return httpx.Response(200, json={"launcher": "x", "present": True, "entries": []})
+
+    client = _client(handler)
+    await client.manual_downloads("Amazon Games")
+    await client.manual_downloads("Itch.io", include_files=True)
+    assert captured["paths"][0] == "/v1/manual-downloads/Amazon%20Games"
+    assert captured["paths"][1] == "/v1/manual-downloads/Itch.io?include_files=true"


### PR DESCRIPTION
## Summary
Extends the manual-download listing so Game_shelf can diff **Amazon**, **Humble Bundle**, and **Itch.io** downloads against the owned library (previously GOG-only). Two small, backward-compatible changes across the agent router, control proxy, and client.

## Changes
- **Widen launcher-name allowlist** `^[A-Za-z0-9_-]+$` → `^[A-Za-z0-9 ._-]+$` (agent + control routers) so folder names with a space/dot (`Amazon Games`, `Humble Bundle`, `Itch.io`) are reachable. Traversal stays impossible — no `/`, and the resolve-under-root guard still rejects `.`/`..` (existing traversal test unchanged).
- **`?include_files=true`** lists loose installer/archive *files* (Humble/Itch are single files, not per-game folders), not just directories. **Default `false` keeps GOG/Amazon dir-only listing byte-identical** — zero regression.
- **`AgentClient.manual_downloads(launcher, include_files=False)`** URL-encodes the launcher (`quote(..., safe='')`) and forwards the flag.

## Tests (TDD)
- Agent: accepts `Amazon Games`/`Humble Bundle`/`Itch.io`; `include_files=true` lists files, default lists dirs only; traversal still rejected.
- Client: launcher URL-encoded (`Amazon%20Games`), `?include_files=true` appended.
- Control: space launcher accepted, `include_files` forwarded; non-allowlist char (`@`) still 400.
- Full suite: 1570 passed (only the pre-existing `test_licenses` env failure).

## Deploy (after merge, no 2FA)
Control plane LXC 1105 (regex) + agent RECREATE on .40 (include_files). Amazon works once control is live; Humble/Itch need the agent's include_files.

Pairs with Game_shelf PR (registry + normalizer + aliases). Part of #222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)