### PR TITLE
security: pin transitive h2 to 4.4.1 (GHSA-6hr6-w5qg-qmwg)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Security — pin transitive `h2` to 4.4.1 (GHSA-6hr6-w5qg-qmwg) — 2026-08-09
+
+The CI dependency audit began failing on `h2==4.3.0`: **GHSA-6hr6-w5qg-qmwg** (medium) — *"duplicate Host header could facilitate request smuggling"*, vulnerable `<= 4.4.0`, fixed in `4.4.1`. `h2` is transitive via `httpx[http2]` (the orchestrator uses httpx as a client for Epic CDN pulls and agent RPC). Newly disclosed rather than a regression: main last ran green on 2026-07-22 and would fail this audit today.
+
+- **Security:** `h2==4.4.1` pinned in `requirements.in`, following the convention already used there for `python-dotenv` and `starlette` — an explicit transitive override with the advisory cited inline, so a future `pip-compile` cannot silently regress it. httpx 0.28.1 requires only `h2>=3,<5`, so no httpx bump is needed.
+- **Infrastructure:** lockfiles regenerated. `hpack` 4.1.0 → 4.2.0 (required by h2 4.4.1). In `requirements-dev.txt` the `--allow-unsafe` build-tool pins moved with the regeneration: `pip` 26.0.1 → 26.2.1 and `setuptools` 83.0.0 → 84.0.0 (dev lockfile only; not shipped at runtime).
+
 ### Changed — manual-downloads endpoint supports Amazon/Humble/Itch (space/dot launchers + files) — 2026-07-10
 
 The manual-download listing (`GET /v1/manual-downloads/{launcher}` + control proxy) is extended so Game_shelf can diff Amazon, Humble Bundle, and Itch.io downloads against the owned library, not just GOG. (#222)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -206,13 +206,15 @@ h11==0.16.0 \
     # via
     #   httpcore
     #   uvicorn
-h2==4.3.0 \
-    --hash=sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1 \
-    --hash=sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd
-    # via httpx
-hpack==4.1.0 \
-    --hash=sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496 \
-    --hash=sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca
+h2==4.4.1 \
+    --hash=sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6 \
+    --hash=sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516
+    # via
+    #   -r requirements.in
+    #   httpx
+hpack==4.2.0 \
+    --hash=sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0 \
+    --hash=sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986
     # via h2
 httpcore==1.0.9 \
     --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55 \
@@ -1026,11 +1028,11 @@ wheel==0.46.3 \
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.0.1 \
-    --hash=sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b \
-    --hash=sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8
+pip==26.2.1 \
+    --hash=sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e \
+    --hash=sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f
     # via pip-tools
-setuptools==83.0.0 \
-    --hash=sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef \
-    --hash=sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3
+setuptools==84.0.0 \
+    --hash=sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670 \
+    --hash=sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73
     # via pip-tools

--- a/requirements.in
+++ b/requirements.in
@@ -15,3 +15,7 @@ python-dotenv==1.2.2
 # GHSA-jp82-jpqv-5vv3 in 1.1.0 (fix 1.3.1). fastapi 0.136.3 requires only
 # starlette>=0.46.0, so this is compatible without a fastapi bump.
 starlette==1.3.1
+# Transitive from httpx[http2]; pinned here to override GHSA-6hr6-w5qg-qmwg
+# ("duplicate Host header could facilitate request smuggling", vulnerable <= 4.4.0)
+# in 4.3.0. httpx 0.28.1 requires only h2>=3,<5, so this needs no httpx bump.
+h2==4.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,13 +49,15 @@ h11==0.16.0 \
     # via
     #   httpcore
     #   uvicorn
-h2==4.3.0 \
-    --hash=sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1 \
-    --hash=sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd
-    # via httpx
-hpack==4.1.0 \
-    --hash=sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496 \
-    --hash=sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca
+h2==4.4.1 \
+    --hash=sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6 \
+    --hash=sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516
+    # via
+    #   -r requirements.in
+    #   httpx
+hpack==4.2.0 \
+    --hash=sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0 \
+    --hash=sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986
     # via h2
 httpcore==1.0.9 \
     --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55 \


### PR DESCRIPTION
## Problem

The CI **Dependencies** audit fails on `h2==4.3.0`:

```
h2   4.3.0   GHSA-6hr6-w5qg-qmwg   4.4.1
```

**GHSA-6hr6-w5qg-qmwg** (medium) — *"h2: Duplicate Host header could facilitate request smuggling"*. Vulnerable `<= 4.4.0`, fixed in `4.4.1`.

`h2` is transitive via `httpx[http2]` — httpx is the client used for Epic CDN chunk pulls and control→agent RPC.

This is a **newly-disclosed advisory, not a regression**: main last ran green on 2026-07-22 and would fail this same audit today. It currently blocks #261.

## Fix

`h2==4.4.1` pinned in `requirements.in`, following the convention already established in that file for `python-dotenv` and `starlette` — an explicit transitive override with the advisory cited inline, so a future `pip-compile` cannot silently regress it.

httpx 0.28.1 declares only `h2>=3,<5`, so this needs **no httpx bump**. (Bumping httpx would not have worked as a fix — no httpx version forces h2 >= 4.4.1.)

## Lockfile regeneration — full disclosure of what moved

Verified the regenerated diff contains **no package changes beyond these**:

| Package | Change | Why |
|---|---|---|
| `h2` | 4.3.0 → 4.4.1 | the security fix |
| `hpack` | 4.1.0 → 4.2.0 | required by h2 4.4.1 |
| `pip` | 26.0.1 → 26.2.1 | `requirements-dev.txt` only — `--allow-unsafe` build-tool pin, resolved to latest on regeneration |
| `setuptools` | 83.0.0 → 84.0.0 | same as above |

`pip`/`setuptools` are **dev-lockfile only and never shipped at runtime**. They moved as a side effect of regenerating with the original `--allow-unsafe` flag (an earlier run that omitted the flag was caught and redone — dropping it would have unpinned them entirely and broken `pip install --require-hashes`).

## Testing

- Full suite: **1,571 passed**
- Diff audited line-by-line: only the four packages above changed; no structural drift beyond h2's `# via` comment now also citing `-r requirements.in` (correct — it is now a direct pin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)