### PR TITLE
chore: refresh CLAUDE.md session state, raise freshness thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,15 @@ jobs:
         run: bash scripts/check-changelog.sh 2>/dev/null || true
 
       - name: Session state check
+        # Defaults (5 commits / 24h) fire on any actively-developed repo — a
+        # normal day of work re-triggers the warning regardless of whether
+        # CLAUDE.md actually drifted, which trains everyone to ignore it.
+        # Raised so the signal means real staleness. Warning-only either way:
+        # the script exits 0 unless SOIF_STRICT_SESSION=true, and `|| true`
+        # keeps it non-blocking.
+        env:
+          SOIF_SESSION_COMMIT_THRESHOLD: 50
+          SOIF_SESSION_TIME_THRESHOLD: 604800 # 7 days
         run: bash scripts/check-session-state.sh 2>/dev/null || true
 
   # ── Publish: tag-triggered push to GHCR ──────────────────────

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,40 @@ This project follows the **Solo Orchestrator Framework v1.0**.
 - Approval Log: `APPROVAL_LOG.md` (governance approval tracking — update at each phase gate)
 - Development Guardrails for Claude Code: `.claude/framework/` (Git hook guardrails — see `.claude/manifest.json` for active profile and configuration)
 
+## Current State
+<!-- Last Updated: 2026-08-13 -->
+
+Orientation for a fresh session. This section is also the anchor for
+`scripts/check-session-state.sh`, which warns when HEAD drifts more than 5 commits
+or 24 hours past the last commit touching this file.
+
+- **Phase:** 2 (Construction). Gates 0→1 and 1→2 approved 2026-04-20; the Phase 2→3
+  gate has not been taken. Track: light. Deployment: personal. Framework: v1.0.
+- **Shipped:** 23 features recorded in `FEATURES.md`, all Complete or
+  Complete-pending-live-UAT — the F1–F18 MVP plus the LAN-bind source-IP allowlist.
+- **Runs live, split across two hosts:** the control plane (API, jobs, scheduler,
+  DB) on a Proxmox LXC; the data-plane agent (byte-puller, disk-stat, prefill
+  drivers) on the NAS beside lancache itself. See
+  `docs/deploy/lxc-cutover-runbook.md` and the migration runbooks under
+  `docs/superpowers/`.
+- **Not yet released:** all 111 `CHANGELOG.md` entries sit under `[Unreleased]`;
+  no version has been tagged.
+- **Tests:** 1636 passing. Run them as
+  `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest` — the PATH prefix is
+  required, or `tests/test_licenses.py` false-fails on a missing `pip-licenses`
+  binary that is installed in `.venv/bin` but not otherwise on PATH. Bare `python`
+  is not on PATH; always use `.venv/bin/python`.
+- **Recent work (2026-08):** lancache NAS-host migration runbook + AS-BUILT record
+  (#266); CLI/API edge cases (#263–#265) — `game_id` path params bounded to
+  SQLite's signed INTEGER range, a `contains` filter operator behind
+  `game list --title/--offset` with a truncation footer, and HTTP errors that no
+  longer render as a blank `HTTP 404:`.
+
+**Authoritative sources — prefer these over this summary, which is a snapshot:**
+`FEATURES.md` (what exists) · `CHANGELOG.md` (what changed) · `PROJECT_BIBLE.md`
+(architecture) · `.claude/phase-state.json` (mechanical phase) · `APPROVAL_LOG.md`
+(gate approvals).
+
 ## Engineering Principles
 
 ### Priority Hierarchy


### PR DESCRIPTION
Clears the `CLAUDE.md may be stale: 587 commits` annotation that `scripts/check-session-state.sh` has been emitting on every `main` run, and stops it recurring daily.

## Why it was firing

`CLAUDE.md` had not been touched since project initialization on **2026-04-20** — 587 commits. The check is pure git metadata: commits since the last commit touching the file, and elapsed time.

## 1. `Current State` section

A fresh session had no in-repo orientation. The new section gives it, with every fact verified against the repo rather than recalled:

- Phase 2; gates 0→1 and 1→2 approved 2026-04-20, Phase 2→3 **not** taken (`.claude/phase-state.json`)
- 23 features in `FEATURES.md`, all Complete or Complete-pending-live-UAT
- All **111** `CHANGELOG.md` entries still under `[Unreleased]` — nothing tagged yet
- 1636 tests passing; two-host control-plane / data-plane split
- The local test invocation, because `.venv/bin/python -m pytest` alone **false-fails** `tests/test_licenses.py` — it shells out to `pip-licenses`, which resolves via `PATH` and lives in `.venv/bin`, which that invocation does not put on `PATH`

It points at `FEATURES.md` / `CHANGELOG.md` / `PROJECT_BIBLE.md` as authoritative, since a snapshot in `CLAUDE.md` will always lag them.

## 2. Raised thresholds

The doc refresh alone would clear the warning for **less than a day**. Defaults are 5 commits **or** 24 hours, so any normal working day re-triggers it whether or not `CLAUDE.md` actually drifted — which is how a warning gets trained into background noise.

```yaml
env:
  SOIF_SESSION_COMMIT_THRESHOLD: 50
  SOIF_SESSION_TIME_THRESHOLD: 604800 # 7 days
```

Advisory either way: the script exits 0 unless `SOIF_STRICT_SESSION=true`, and the step already ends in `|| true`. It has never been able to fail a build.

## Verification

```
$ bash scripts/check-session-state.sh
  [OK] CLAUDE.md is up to date (0 commits since last update)
```

Confirmed under both default and raised thresholds. Workflow YAML re-parsed to confirm the `env:` block lands as integers on the right step.

No source or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)