### PR TITLE
fix(scheduler): pin Epic prefill to a wall-clock cron slot (+3h45m from Steam)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — Epic prefill fired on an interval anchored to container start, so its offset from the Steam cron drifted — 2026-08-14
+
+The scheduled prefill driver (Epic-only; Steam is prefilled by the host SteamPrefill cron) used an `IntervalTrigger` of `library_sync_interval_sec`. APScheduler counts an interval from process start, so the gap between the host Steam cron and the orchestrator's Epic prefill was whatever the container's last restart happened to make it — observed at +1h58m — and moved silently on every restart. Nothing was broken by this, but the separation that keeps the two off each other's WAN was accidental rather than configured.
+
+- **Fixed:** the job now uses `CronTrigger.from_crontab(..., timezone="UTC")`, so the slot is wall-clock and survives restarts.
+- **Added:** `ORCH_SCHEDULED_PREFILL_CRON` (`scheduled_prefill_cron`), defaulting to `45 3,9,15,21 * * *`, validated fail-fast at settings construction like `validation_sweep_cron`.
+- **Why that slot:** a fixed **+3h45m** after the host Steam cron. The NAS runs MDT and prefills at 00/06/12/18 local; because the UTC offset and the cadence are both 6h, that is also 00/06/12/18 UTC. The `:45` is not cosmetic — the validation sweep starts on the hour at those same hours and runs ~39 min, and it is platform-agnostic, so an Epic game validated while its prefill is still writing reports as a false partial. Starting at :45 lets the sweep drain first.
+- **Documentation:** the `validation_sweep_cron` comment claimed the sweep was offset from an `epic 1/7/13/19` host cron. There is no Epic host cron — Epic has been orchestrator-owned since Piece 2, and the crontab on the NAS documents that it is deliberately absent to avoid double-prefill. Corrected to describe the real schedule.
+
+Note for operators: the cross-launcher dedup this schedule feeds already exists and is unchanged — Game_shelf pushes the "already covered on a higher-priority launcher" set to `PUT /api/v1/prefill-exclusions/gameshelf/epic` daily (115 Epic games at time of writing), and `enqueue_scheduled_prefill` skips them.
+
 ### Fixed — bodiless HTTP errors rendered as a blank `HTTP 404:` — 2026-08-13
 
 `OrchClient._request` built its error as `f"HTTP {status}: {detail}"` from the JSON body, falling back to `resp.text[:200]`. A response with no body — common from a reverse proxy — left nothing after the colon. This was worst in exactly the case it matters most: a wrong `--url`/`ORCH_API_URL` pointed at a host that does not serve the route. (#265)

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1246,8 +1246,18 @@ shipped in `0001_initial.sql`.
     /api/v1/block-list` (paginated F9 envelope; idempotent POST 201/200,
     pre-block OK; idempotent DELETE `{removed}`)
   - `src/orchestrator/scheduler/jobs.py::enqueue_scheduled_prefill` — the
-    version-diff `INSERT...SELECT` (registered on the library-sync interval via
-    `scheduler/manager.py`; `settings.scheduled_prefill_enabled`)
+    Epic-only `INSERT...SELECT` (Steam is prefilled by the host SteamPrefill
+    cron). Registered via `scheduler/manager.py` on a **wall-clock cron**,
+    `settings.scheduled_prefill_cron` (`ORCH_SCHEDULED_PREFILL_CRON`),
+    default `45 3,9,15,21 * * *` = a fixed +3h45m after the host Steam cron
+    (00/06/12/18 UTC), starting 45 min past the hour so the ~39-min
+    validation sweep at those same hours has drained. An interval trigger
+    was wrong here: it anchors to process start, so the offset drifted on
+    every container restart. Gated by
+    `settings.scheduled_prefill_enabled`. Cross-launcher dedup comes from
+    `prefill_exclusions` (Game_shelf pushes the "covered on a
+    higher-priority launcher" set), so an Epic copy of a game already on
+    Steam is never prefilled.
   - `src/orchestrator/platform/steam/enumerate.py::_app_version_token` — Steam
     version token (buildid → depot-gid composite)
   - `src/orchestrator/jobs/handlers/{library_sync,prefill}.py` — write

--- a/src/orchestrator/api/main.py
+++ b/src/orchestrator/api/main.py
@@ -227,6 +227,7 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         validation_sweep_enabled=settings.validation_sweep_enabled,
         validation_sweep_cron=settings.validation_sweep_cron,
         scheduled_prefill_enabled=settings.scheduled_prefill_enabled,
+        scheduled_prefill_cron=settings.scheduled_prefill_cron,
         auto_classify_block_enabled=settings.auto_classify_block_enabled,
         fetch_manifests_enabled=settings.fetch_manifests_enabled,
         fetch_manifests_cron=settings.fetch_manifests_cron,

--- a/src/orchestrator/core/settings.py
+++ b/src/orchestrator/core/settings.py
@@ -223,12 +223,26 @@ class Settings(BaseSettings):
     scheduler_library_sync_interval_sec: int = Field(default=21600, ge=60, le=86400)
     # F13 — scheduled validation sweep.
     validation_sweep_enabled: bool = True
-    # Every 6h at 03/09/15/21 UTC — offset from the host prefill crons
-    # (steam 0/6/12/18, epic 1/7/13/19, gog 4/16) so a sweep never overlaps a
-    # prefill burst. 5-field cron (min hour dom mon dow), UTC.
+    # Every 6h at 03/09/15/21 UTC — offset from the prefill schedules so a
+    # sweep never overlaps a prefill burst: host steam cron 0/6/12/18 UTC, gog
+    # 4/16, and the orchestrator's own Epic prefill at :45 past these same
+    # hours (it starts once this ~39-min sweep has drained). 5-field cron
+    # (min hour dom mon dow), UTC.
     validation_sweep_cron: str = "0 3,9,15,21 * * *"
-    # F8: the scheduled prefill driver runs on the library-sync interval.
+    # F8: the scheduled prefill driver (Epic-only — Steam is prefilled by the
+    # host SteamPrefill cron). Wall-clock cron, NOT an interval: an interval
+    # counts from process start, so the gap between the host Steam cron and
+    # this job was whatever the container's last restart made it, and changed
+    # silently on every restart.
+    #
+    # 45 min past 03/09/15/21 UTC = a fixed +3h45m after the host Steam cron
+    # (00/06/12/18 UTC — the NAS runs MDT at 00/06/12/18 local, and the 6h
+    # offset and 6h cadence coincide). The :45 clears the validation sweep,
+    # which starts on the hour at those same hours and runs ~39 min: the sweep
+    # is platform-agnostic, so validating an Epic game while its prefill is
+    # still writing reports it as a false partial.
     scheduled_prefill_enabled: bool = True
+    scheduled_prefill_cron: str = "45 3,9,15,21 * * *"
     # #225: after a game is prefilled, auto-exclude classifier-flagged non-games
     # (soundtracks/tools/servers/demos) from FUTURE prefill. Runs on the same
     # interval as the scheduled prefill; download-once-then-block.
@@ -393,6 +407,16 @@ class Settings(BaseSettings):
             CronTrigger.from_crontab(v)
         except Exception as e:  # apscheduler raises ValueError on bad expressions
             raise ValueError(f"invalid validation_sweep_cron {v!r}: {e}") from e
+        return v
+
+    @field_validator("scheduled_prefill_cron", mode="after")
+    @classmethod
+    def _validate_scheduled_prefill_cron(cls, v: str) -> str:
+        """Fail-fast on a malformed cron by constructing the trigger now."""
+        try:
+            CronTrigger.from_crontab(v)
+        except Exception as e:  # apscheduler raises ValueError on bad expressions
+            raise ValueError(f"invalid scheduled_prefill_cron {v!r}: {e}") from e
         return v
 
     @field_validator("fetch_manifests_cron", mode="after")

--- a/src/orchestrator/scheduler/manager.py
+++ b/src/orchestrator/scheduler/manager.py
@@ -68,6 +68,7 @@ class SchedulerManager:
         validation_sweep_enabled: bool = True,
         validation_sweep_cron: str = "0 3,9,15,21 * * *",
         scheduled_prefill_enabled: bool = True,
+        scheduled_prefill_cron: str = "45 3,9,15,21 * * *",
         auto_classify_block_enabled: bool = True,
         fetch_manifests_enabled: bool = True,
         fetch_manifests_cron: str = "0 5 * * 1",
@@ -80,6 +81,7 @@ class SchedulerManager:
         self._validation_sweep_enabled = validation_sweep_enabled
         self._validation_sweep_cron = validation_sweep_cron
         self._scheduled_prefill_enabled = scheduled_prefill_enabled
+        self._scheduled_prefill_cron = scheduled_prefill_cron
         self._auto_classify_block_enabled = auto_classify_block_enabled
         self._fetch_manifests_enabled = fetch_manifests_enabled
         self._fetch_manifests_cron = fetch_manifests_cron
@@ -160,16 +162,26 @@ class SchedulerManager:
                 )
 
             if self._scheduled_prefill_enabled:
-                # F8: same cadence as library sync, independent of it (no
-                # completion-chaining) — eventually consistent: a fresh patch is
-                # enqueued once both the next sync (refreshing current_version)
-                # and the next prefill diff have run.
+                # F8: independent of library sync (no completion-chaining) —
+                # eventually consistent: a fresh patch is enqueued once both the
+                # next sync (refreshing current_version) and the next prefill
+                # pass have run.
+                #
+                # Wall-clock cron, NOT an interval. An IntervalTrigger counts
+                # from process start, so the gap between the host Steam cron and
+                # this Epic prefill was set by whenever the container last
+                # restarted and moved silently on every restart. The slot has to
+                # stay fixed: it sits +3h45m after the Steam cron so the two do
+                # not compete for WAN, and 45 min past the hour so the ~39-min
+                # validation sweep at 03/09/15/21 has drained first — the sweep
+                # is platform-agnostic, and validating an Epic game while its
+                # prefill is still writing reports it as a false partial.
                 scheduler.add_job(
                     enqueue_scheduled_prefill,
-                    trigger=IntervalTrigger(seconds=self._library_sync_interval_sec),
+                    trigger=CronTrigger.from_crontab(self._scheduled_prefill_cron, timezone="UTC"),
                     args=(self._pool,),
                     id=SCHEDULED_PREFILL_JOB_ID,
-                    name="Enqueue scheduled prefill (version-diff)",
+                    name="Enqueue scheduled prefill (Epic)",
                     replace_existing=True,
                 )
 

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -337,6 +337,19 @@ class TestFieldValidators:
         with pytest.raises(ValidationError):
             Settings(validation_sweep_cron="not a cron")
 
+    def test_scheduled_prefill_cron_default(self):
+        """+3h45m from the host Steam cron (00/06/12/18 UTC), and 45 min past
+        the hour so the ~39-min validation sweep at 03/09/15/21 has drained —
+        validating an Epic game while its prefill writes reports a false
+        partial."""
+        s = Settings(orchestrator_token=VALID_TOKEN)
+        assert s.scheduled_prefill_cron == "45 3,9,15,21 * * *"
+
+    def test_invalid_scheduled_prefill_cron_fails_fast(self, monkeypatch):
+        monkeypatch.setenv("ORCH_TOKEN", VALID_TOKEN)
+        with pytest.raises(ValidationError):
+            Settings(scheduled_prefill_cron="not a cron")
+
     def test_sweep_batch_size_must_be_ge_1(self):
         with pytest.raises(ValidationError):
             Settings(orchestrator_token=VALID_TOKEN, sweep_batch_size=0)

--- a/tests/scheduler/test_manager.py
+++ b/tests/scheduler/test_manager.py
@@ -329,6 +329,84 @@ class TestScheduledPrefillRegistration:
         finally:
             await mgr.shutdown()
 
+    # --- Epic prefill must fire on a WALL-CLOCK schedule -------------------
+    #
+    # The job used an IntervalTrigger, which counts from process start, so the
+    # gap between the host Steam cron and the orchestrator's Epic prefill was
+    # whatever the container's last restart happened to make it — and changed
+    # silently on every restart. The Epic prefill has to sit a fixed distance
+    # after Steam (WAN contention) and after the validation sweep drains
+    # (validating a game mid-prefill reports it as a false partial).
+
+    async def test_scheduled_prefill_uses_cron_not_interval(self, pool):
+        """An IntervalTrigger anchors to process start; only a CronTrigger
+        pins the job to a wall-clock slot across restarts."""
+        from apscheduler.triggers.cron import CronTrigger
+
+        from orchestrator.scheduler.manager import SCHEDULED_PREFILL_JOB_ID
+
+        mgr = SchedulerManager(
+            pool=pool,
+            enabled=True,
+            library_sync_interval_sec=21600,
+            validation_sweep_enabled=False,
+            scheduled_prefill_enabled=True,
+        )
+        await mgr.start()
+        try:
+            job = mgr.get_job(SCHEDULED_PREFILL_JOB_ID)
+            assert job is not None
+            assert isinstance(job.trigger, CronTrigger), (
+                f"expected CronTrigger, got {type(job.trigger).__name__} — an interval "
+                f"trigger makes the offset from the Steam cron depend on restart time"
+            )
+        finally:
+            await mgr.shutdown()
+
+    async def test_scheduled_prefill_cron_is_passed_through(self, pool):
+        from orchestrator.scheduler.manager import SCHEDULED_PREFILL_JOB_ID
+
+        mgr = SchedulerManager(
+            pool=pool,
+            enabled=True,
+            library_sync_interval_sec=21600,
+            validation_sweep_enabled=False,
+            scheduled_prefill_enabled=True,
+            scheduled_prefill_cron="15 2 * * *",
+        )
+        await mgr.start()
+        try:
+            job = mgr.get_job(SCHEDULED_PREFILL_JOB_ID)
+            assert job is not None
+            fields = {f.name: str(f) for f in job.trigger.fields}
+            assert fields["hour"] == "2"
+            assert fields["minute"] == "15"
+        finally:
+            await mgr.shutdown()
+
+    async def test_scheduled_prefill_default_slot_clears_the_sweep(self, pool):
+        """Default must be 45 min past 03/09/15/21 UTC: a fixed +3h45m from the
+        host Steam cron (00/06/12/18 UTC), landing after the ~39-min validation
+        sweep that starts on the hour at those same hours."""
+        from orchestrator.scheduler.manager import SCHEDULED_PREFILL_JOB_ID
+
+        mgr = SchedulerManager(
+            pool=pool,
+            enabled=True,
+            library_sync_interval_sec=21600,
+            validation_sweep_enabled=False,
+            scheduled_prefill_enabled=True,
+        )
+        await mgr.start()
+        try:
+            job = mgr.get_job(SCHEDULED_PREFILL_JOB_ID)
+            assert job is not None
+            fields = {f.name: str(f) for f in job.trigger.fields}
+            assert fields["minute"] == "45"
+            assert fields["hour"] == "3,9,15,21"
+        finally:
+            await mgr.shutdown()
+
     async def test_scheduled_prefill_disabled_not_registered(self, pool):
         from orchestrator.scheduler.manager import SCHEDULED_PREFILL_JOB_ID
 


### PR DESCRIPTION
## What prompted this

A request to build an Epic prefill script that dedups against the Steam prefill list, Steam-priority, on a 6h schedule offset from Steam.

**That already exists** — investigation confirmed both halves are live:

- **Epic prefill every 6h** — orchestrator-owned via `ORCH_SCHEDULED_PREFILL_ENABLED` (enabled 2026-08-10), not a host cron. The NAS crontab documents that an Epic host cron is deliberately absent to avoid double-prefill; the `EpicPrefill` binary there is vestigial (Aug 2024).
- **Steam-priority dedup** — 115 Epic games carry `gameshelf: covered on higher-priority launcher` in `prefill_exclusions`, pushed daily by Game_shelf and honoured by `enqueue_scheduled_prefill`. Spot-checked: Rogue Legacy, Breathedge, Eastern Exorcist are excluded on Epic and `up_to_date` on Steam.

So no new script. But investigating surfaced a real defect.

## The defect

The job used `IntervalTrigger(seconds=library_sync_interval_sec)`. APScheduler counts an interval from **process start**, so the offset between the host Steam cron and the Epic prefill was set by whenever the container last restarted — and changed silently on every restart. Observed live at **+1h58m**.

Nothing was broken by it, but the separation keeping the two off each other's WAN was accidental rather than configured.

## The fix

`CronTrigger.from_crontab(..., timezone="UTC")` behind a new `scheduled_prefill_cron` setting (`ORCH_SCHEDULED_PREFILL_CRON`), fail-fast validated at construction exactly like `validation_sweep_cron`.

Default **`45 3,9,15,21 * * *`** — a fixed +3h45m after Steam:

```
Steam  (host cron, MDT)  00:00 06:00 12:00 18:00  = 00/06/12/18 UTC
Sweep  (orch, UTC)       03:00 ......... ~39 min
Epic   (orch, UTC)       03:45   <- sweep drained, WAN free
```

Two things fix that slot:

- The NAS runs MDT at 00/06/12/18 local; since the UTC offset and the cadence are both 6h, that is also 00/06/12/18 UTC, so +3h lands on 03/09/15/21.
- **The `:45` is not cosmetic.** The validation sweep starts on the *hour* at those same hours and runs ~39 min, and it is platform-agnostic — an Epic game validated while its prefill is still writing reports as a **false partial**, a failure mode this project has hit repeatedly. Starting at :45 lets the sweep drain first.

## Also corrected

The `validation_sweep_cron` comment claimed the sweep was offset from an `epic 1/7/13/19` host cron. No such cron exists — Epic has been orchestrator-owned since Piece 2. My change would have made that comment actively misleading.

## Verification

- 5 tests written first and **watched fail**, then pass: trigger type is `CronTrigger` not `IntervalTrigger`, custom cron passes through, default slot is `:45` at `3,9,15,21`, plus settings default and fail-fast on a malformed cron.
- Full suite as CI runs it: **1641 passed, 3 deselected, 0 failed**
- `ruff check`, `ruff format --check`, `mypy` (strict, 104 files): clean

## Deploy note

Not yet applied to the LXC — this changes the schedule only on redeploy. No migration, no data change; `ORCH_SCHEDULED_PREFILL_CRON` can override the default without a rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)