### PR TITLE
docs: design spec for the manifest locator depot glob fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — SteamPrefill could hang for days and the agent had no defense against overlapping runs — 2026-08-15
+
+Phase 1 of the Steam-prefill-ownership plan (`docs/superpowers/specs/2026-08-14-steam-prefill-ownership-design.md`). Investigation for that plan found the orchestrator's Steam prefill path was strictly *less* safe than the host cron it may eventually replace: `SteamPrefillDriver.prefill_apps` awaited `communicate()` with no timeout, and the agent's `POST /v1/steam/prefill` spawned its background runner with no mutual exclusion. On 2026-08-12 a `SteamPrefill --force` run was found alive 5 days 18 hours after already logging `Prefill complete!` and never exiting — the host cron's `flock` + `timeout -k 60 10h` exist specifically because of that incident, and neither had an orchestrator-side equivalent.
+
+- **Fixed:** `SteamPrefillDriver` gains `timeout_sec` (default 36000s, matching the cron's `RUN_MAX`). A run exceeding it is terminated by killing the whole **process group** (`start_new_session=True` + `SIGTERM` escalating to `SIGKILL` after 60s) rather than just the direct child — the cron's own alert text admits its `timeout` only kills the `docker exec` client while the in-container SteamPrefill runs on. New setting `steam_prefill_timeout_sec`.
+- **Added:** `SteamPrefillDriver.prefill_recent()` — a `--recently-purchased` mode (spec OQ1). It deliberately does not touch `selectedAppsToPrefill.json`, since SteamPrefill derives that set itself; the app-id path's save/restore dance doesn't apply. `prefill_apps` and `prefill_recent` now share a `_run()` helper so the timeout and kill logic cannot drift between modes.
+- **Fixed:** the agent's `POST /v1/steam/prefill` and new `POST /v1/steam/prefill-recent` now share a single-flight gate on `app.state`. A second request while one SteamPrefill invocation is running returns the in-flight `job_id` instead of starting a rival process against the same auth/cache — which re-arch ① §6 states corrupts shared state.
+
 ### Fixed — Epic prefill fired on an interval anchored to container start, so its offset from the Steam cron drifted — 2026-08-14
 
 The scheduled prefill driver (Epic-only; Steam is prefilled by the host SteamPrefill cron) used an `IntervalTrigger` of `library_sync_interval_sec`. APScheduler counts an interval from process start, so the gap between the host Steam cron and the orchestrator's Epic prefill was whatever the container's last restart happened to make it — observed at +1h58m — and moved silently on every restart. Nothing was broken by this, but the separation that keeps the two off each other's WAN was accidental rather than configured.

--- a/docs/superpowers/specs/2026-08-16-manifest-locator-depot-glob-design.md
+++ b/docs/superpowers/specs/2026-08-16-manifest-locator-depot-glob-design.md
@@ -1,11 +1,13 @@
 # Design — fix the manifest locator's per-depot .bin discovery glob
 
 **Date:** 2026-08-16
-**Status:** Revised after adversarial review round 1 (2026-08-16) — see §9. Core fix (§3) unchanged; §4, §6, §7, §8 rewritten to close the findings below.
+**Status:** Revised after adversarial review round 2 (2026-08-16) — see §9 and §10. Core fix (§3) unchanged since round 1.
 **Repo:** lancache_orchestrator. **Branch:** `fix/steam-manifest-locator-depot-glob` (PR #276)
 **Found during:** live investigation of why Grim Dawn, STAR WARS Jedi: Survivor, and Battlefield 2042 remained stuck at `validation_failed` (96–99.9% cached) despite the host Steam prefill cron running every 6h. Unrelated to the Steam-prefill-ownership work in progress (`docs/superpowers/specs/2026-08-14-steam-prefill-ownership-design.md`) — this is a pre-existing defect in the read-only validate path, filed as its own change.
 
-**Round-1 adversarial review verdict: REQUEST CHANGES.** An independent reviewer, instructed to verify every claim against the real code rather than trust this document, confirmed the core fix (§3) is correct and its collision-safety argument is airtight, but found the original §6 "Rollout" materially understated the change's blast radius and never mentioned that `/v1/steam/purge` shares the exact same widened lookup. Both findings were independently spot-checked against the live source (file:line citations below) before accepting them. §9 records the full findings and how each was resolved.
+**Round-1 verdict: REQUEST CHANGES** — the original §6 "Rollout" understated blast radius and never mentioned `/v1/steam/purge` shares the same widened lookup. Addressed in the round-1 revision; see §9.
+
+**Round-2 verdict: REQUEST CHANGES** — the round-1 revision itself contained a factual error (§4/§9 claimed `tests/agent/test_steam_purge.py` didn't exist; it does, with 6 tests including near-duplicate shared-redist coverage), and its two new mitigations (§6, §7) described intent without defining a real decision rule or examining operational cost. Both reviewers independently verified every claim against the live source before accepting it; both flagged real issues. §10 records round 2's findings and how each was resolved in this version.
 
 ---
 
@@ -75,10 +77,12 @@ The `.shas` glob is unchanged — it stays `f"{app_id}_{app_id}_*.{ext}"`. That 
 
 **Integration (`tests/agent/test_steam_validate.py`).** Extend the existing fixture-based test pattern (`APP, DEPOT, GID` + `sample_manifest.bin`) with a second depot under a different group id, asserting `POST /v1/steam/validate`'s `chunks_total` now includes both depots' chunks — proving the fix end-to-end through the actual endpoint, not just the locator in isolation.
 
-**Integration (`tests/agent/test_steam_purge.py`) — round-1 finding, previously entirely absent.** `_steam_chunk_paths` (`agent/routers/steam.py:329`) is shared verbatim by `/v1/steam/validate` and `/v1/steam/purge`; §7 below explains why purge's behavior changes too. Add:
+**Integration (`tests/agent/test_steam_purge.py`).** `_steam_chunk_paths` (`agent/routers/steam.py:329`) is shared verbatim by `/v1/steam/validate` and `/v1/steam/purge`; §7 below explains why purge's behavior changes too.
 
-- A purge test with a differing-group-id secondary depot, asserting the widened lookup causes purge to delete that depot's chunks too (previously invisible to purge, same as to validate).
-- A purge test confirming a depot present in `settings.steam_shared_redist_depots` is still excluded post-fix — the shared-redist skip (`agent/routers/steam.py:380-387`) is keyed by `depot_id`, not by which glob found the file, so it is orthogonal to this change, but it protects against purge deleting chunks another game depends on and deserves an explicit regression test given purge's blast radius is growing here.
+**Correction (round-2 finding):** an earlier revision of this document claimed this test file was "previously entirely absent." That was checked and found false — `tests/agent/test_steam_purge.py` already exists (6 tests, predating this branch), including `test_steam_purge_skips_shared_redist_depot`, which already covers almost exactly what was about to be proposed as new coverage. The actual gap, correctly scoped:
+
+- **Genuinely new:** a purge test with a differing-group-id secondary depot, asserting the widened lookup causes purge to delete that depot's chunks too (previously invisible to purge, same as to validate) — this naming shape has no existing coverage in the file.
+- **Extend, don't duplicate:** the existing `test_steam_purge_skips_shared_redist_depot` already proves the shared-redist exclusion works for purge in general; it does not need a second, near-identical test. If it's cheap to do while touching the file, extend its fixture to also include a differing-group-id-named redist depot, proving the exclusion holds under the new naming shape too — otherwise leave it as-is, since the exclusion's `depot_id`-keyed logic (§7) doesn't care which glob found the file.
 
 ## 5. The `successfullyDownloadedDepots.json` gap (investigated, not fixed here)
 
@@ -115,26 +119,29 @@ For the vast majority of the library this changes nothing: a single-depot game, 
 
 **What could happen to those games, and why it's the intended outcome, not a regression:** if a game like that currently reports `up_to_date` only because the old glob was blind to a secondary depot that is *itself* incomplete (a language pack partially evicted, say), that game's `up_to_date` status today is **already wrong** — it's the same undercounting bug, just landing on the passing side by chance instead of the failing side, as it did for Grim Dawn. The fix makes validation for that game accurate for the first time. It is not new risk introduced by this change; it is the same latent bug (present since the file's first commit, §2) becoming visible in the other direction. The three known games are simply the ones where it happened to land visibly wrong; there is no way to know how many others might flip without running the corrected code.
 
-**Given that, this is treated as a controlled rollout with visibility, not a silent change left to the next passive cron tick:**
+**Given that, this needs visibility, not a silent change left to be noticed by accident. Round-2 finding: the round-1 revision's proposed mitigation — force-triggering `orchestrator-cli cache validate-all` (`{"full": true}`) immediately post-deploy — was itself examined and rejected. `_CANDIDATE_SQL_FULL` (`sweep.py:39`) is `SELECT id, status FROM games ORDER BY id` with no `WHERE` clause at all: it validates every row in `games`, every platform, every status, unconditionally, with no cap on candidate count (`sweep_batch_size` defaults to 10 concurrent, `settings.py:256`, but nothing bounds the total). `validate_game` (`disk_stat.py:340-346`) special-cases only `platform == "epic"`; every other row — including the manually-covered GOG/Amazon/Humble/Itch games this project tracks separately — falls through to a Steam-manifest lookup that can never match, which is harmless (returns `outcome="error"`, non-clobbering) but is pure wasted load on a NAS this project's own history already documents as CPU-steal-bound. Forcing that tool immediately post-deploy is a bigger, less-targeted hammer than the problem calls for.**
 
-1. Deploy the fix.
-2. Immediately trigger a full validation pass under operator control — `orchestrator-cli cache validate-all` (`POST /api/v1/sweep {"full": true}`, `cli/commands/cache.py:34-42`) — rather than waiting for the next scheduled gated sweep to touch the library implicitly.
-3. Before triggering, snapshot each owned Steam game's `status` from the database; after the full sweep completes (poll via `orchestrator-cli jobs`), snapshot again and diff. Report the counts to the Orchestrator: how many games flipped `up_to_date → validation_failed` (newly-revealed incompleteness — expected, and each one becomes a real target for re-prefill) versus `validation_failed → up_to_date` (the three known games, plus any others the old glob was undercounting favorably).
-4. This diff is the actual verification that the fix behaves as designed at full-library scale, not just in unit tests against synthetic fixtures.
+**Resolution: do not force anything. The existing gated sweep already covers exactly the population that needs re-checking**, on its existing schedule, with no new trigger or CLI surface needed:
+
+1. **Before deploying**, snapshot every owned Steam game's `status` from the database.
+2. Deploy the fix.
+3. Let the next scheduled gated sweep run naturally (`0 3,9,15,21 * * *` — within 6h; `_CANDIDATE_SQL` already selects `status IN ('unknown','up_to_date','validation_failed') AND owned = 1` across all platforms, `sweep.py:30-34` — this is exactly the population affected by the fix, no broader). After it completes, snapshot again and diff.
+4. **Decision rule (round-2 finding: the original wording had none).** Steam coverage was independently verified at ~3 total partials library-wide before this investigation began. If more than **20** owned Steam games flip `up_to_date → validation_failed` in this one sweep, treat that as suspicious rather than confirmatory — a change of that magnitude is more consistent with a bug in the widened glob itself (e.g. the unchanged `len(parts) != 4` filter silently mishandling some real filename shape not seen in this investigation's sample) than with genuinely-hidden incompleteness at that scale. In that case: **halt before letting any downstream automation (F8 scheduled prefill, etc.) act on the new statuses**, and manually inspect a sample of the flipped games' on-disk manifests against the locator's actual output before trusting the result. Below that threshold, the flips are the expected, intended outcome described above.
+5. `validation_failed → up_to_date` flips (Grim Dawn, Jedi Survivor, plus any others the old glob was undercounting favorably) confirm the fix positively; no threshold applies to that direction.
 
 ## 7. `/v1/steam/purge` shares the exact same widened lookup (round-1 finding)
 
 `_steam_chunk_paths` (`agent/routers/steam.py:329-404`) is the single shared source of manifest→cache-path enumeration for **both** `/v1/steam/validate` and `/v1/steam/purge` (stated in its own docstring, line 333-335) — it calls `locate_manifest_bins` directly, so §3's fix applies to both callers identically, with no code change needed in either router.
 
-`steam_purge` (`agent/routers/steam.py:501-524`) applies no depot-level scoping of its own: "every enumerated chunk across all depots (no depot-scoping — purge_chunks no-ops on paths that aren't present)" (line 516-518 comment, verified verbatim in source). After this fix, purging any Steam game with a secondary depot under a differing group ID will delete that depot's chunk files too — files the old narrow glob never even enumerated, so purge silently left them behind before. This is the same correctness direction as the validate fix (purge should act on everything a game actually owns, not on whatever a buggy glob happened to see) and is not a new category of behavior, but it was entirely unexamined and untested in the original draft.
+`steam_purge` (`agent/routers/steam.py:501-528`) applies no depot-level scoping of its own: "every enumerated chunk across all depots (no depot-scoping — purge_chunks no-ops on paths that aren't present)" (line 516-518 comment, verified verbatim in source). After this fix, purging any Steam game with a secondary depot under a differing group ID will delete that depot's chunk files too — files the old narrow glob never even enumerated, so purge silently left them behind before. This is the same correctness direction as the validate fix (purge should act on everything a game actually owns, not on whatever a buggy glob happened to see) and is not a new category of behavior, but it was entirely unexamined and untested in the original draft.
 
 **Checked and confirmed safe against the one sharper risk this could imply — cross-game deletion via a shared depot:** the Steamworks Common Redistributables exclusion (`settings.steam_shared_redist_depots`, PR #245) is applied *inside* `_steam_chunk_paths` itself (`agent/routers/steam.py:380-387`), keyed by `depot_id`, before any path is added to what either validate or purge sees. It is unconditional on which glob found the file. Widening the `.bin` glob does not bypass or weaken this exclusion in any way — a depot that's supposed to be protected from purge stays protected. This was verified by reading the exclusion's exact position in the shared function, not assumed from the original PR's intent.
 
-Test coverage for this is in §4.
+Test coverage for this is in §4 (corrected in round 2 — see §10).
 
 ## 8. Rollout
 
-No migration, no schema change, no settings change. Deploy, then execute the controlled full-sweep verification in §6 rather than relying on the passive scheduled sweep to reveal the outcome invisibly. Grim Dawn and Jedi Survivor are expected to flip to `up_to_date` in that pass. Battlefield 2042 will remain `validation_failed` regardless of this fix until separately re-added to the selection (§5) — nothing is prefilling it. Any other games that flip status in either direction are reported per §6 step 4 rather than discovered later by accident.
+No migration, no schema change, no settings change, no new CLI surface. Order per §6: snapshot Steam game statuses, *then* deploy, then let the next scheduled gated sweep run within its normal 6h cadence — no forced trigger — then snapshot again and apply §6's decision rule. Grim Dawn and Jedi Survivor are expected to flip to `up_to_date` in that pass. Battlefield 2042 will remain `validation_failed` regardless of this fix until separately re-added to the selection (§5) — nothing is prefilling it.
 
 ## 9. Adversarial review round 1 (2026-08-16)
 
@@ -142,14 +149,29 @@ An independent reviewer (fresh context, instructed to verify every claim against
 
 | # | Finding | Resolution |
 |---|---|---|
-| 1 | Rollout (old §6) reasoned about 3 games; sweep candidate query includes `up_to_date`, so the whole library is affected on the next tick | New §6: controlled `cache validate-all` rollout with a before/after status diff, replacing reliance on the passive scheduled sweep |
-| 2 | `/v1/steam/purge` shares the exact same widened lookup; never mentioned | New §7: documents the behavior change, confirms the shared-redist cross-game-deletion protection is orthogonal and unaffected |
-| 3 | Possible edge case: a depot Steam has since removed from an app, but with chunks still lingering in cache (not yet evicted) | Considered and accepted as an existing, not new, risk: the `present == 0` exclusion already handles full eviction; a depot with *some* chunks still cached is the same category of staleness the old narrow glob already had for whichever single depot it happened to track, just now applying across a correctly-larger set of depots instead of one. No code mitigation added; flagged here for the Orchestrator's awareness rather than silently accepted |
-| 4 | "10784 matches the DB, not a coincidence" overclaimed what was demonstrated | §2 rewritten to separate the naming audit (causal evidence) from the chunk-count match (corroboration, not proof) |
-| 5 | Testing plan gaps: no cross-app collision test, no purge test, no realistic multi-depot-scale test | All three added to §4 |
+| 1 | Rollout (old §6) reasoned about 3 games; sweep candidate query includes `up_to_date`, so the whole library is affected on the next tick | §6 rewritten with blast-radius analysis. **Superseded in round 2** — the specific mitigation proposed here (force-trigger `cache validate-all`) was itself found to be a worse tool than the alternative; see §10 finding 3 |
+| 2 | `/v1/steam/purge` shares the exact same widened lookup; never mentioned | New §7: documents the behavior change, confirms the shared-redist cross-game-deletion protection is orthogonal and unaffected. Held up under round-2 re-verification |
+| 3 | Possible edge case: a depot Steam has since removed from an app, but with chunks still lingering in cache (not yet evicted) | Accepted as an existing risk category. **Round 2 found the magnitude claim needed quantifying, not just categorizing** — see §10 finding 4 |
+| 4 | "10784 matches the DB, not a coincidence" overclaimed what was demonstrated | §2 rewritten to separate the naming audit (causal evidence) from the chunk-count match (corroboration, not proof). Held up under round-2 re-verification |
+| 5 | Testing plan gaps: no cross-app collision test, no purge test, no realistic multi-depot-scale test | Cross-app and multi-depot-scale tests added to §4 correctly. **The purge-test claim was factually wrong** — see §10 finding 1 |
 
-Round-1 verdict: REQUEST CHANGES. This revision addresses every item above. Awaiting round-2 review before implementation.
+Round-1 verdict: REQUEST CHANGES.
 
-## 10. Open questions
+## 10. Adversarial review round 2 (2026-08-16)
 
-None remaining after round 1. Finding #3 above is a deliberate accepted-risk decision, not an open question — recorded for visibility, not blocking.
+A second, independent reviewer (fresh context, no knowledge of round 1's report) was dispatched against the round-1 revision, with explicit instructions to verify every claim itself rather than trust that round 1's fixes were real. It re-verified every round-1 citation (all held up) and found four new problems in the revision itself:
+
+| # | Finding | Resolution |
+|---|---|---|
+| 1 | **Factually false claim:** §4/§9 stated `tests/agent/test_steam_purge.py` was "previously entirely absent." It already existed (6 tests, predates this branch), including `test_steam_purge_skips_shared_redist_depot` — near-duplicate of proposed "new" coverage. Directly checkable (`ls`) and wasn't checked. | §4 corrected: only the differing-group-id purge test is genuinely new; the existing shared-redist test may be extended for the new naming shape but is not duplicated |
+| 2 | §6's before/after diff was a report with no decision rule — no threshold distinguishing "expected magnitude" from "something is wrong," no defined action either way | §6 now states an explicit threshold (20 games) and a halt-and-manually-inspect action if exceeded, grounded in this investigation's own baseline (~3 total partials library-wide before the fix) |
+| 3 | The proposed rollout mitigation (force-triggering `cache validate-all`, i.e. `{"full": true}`) is a bigger, costlier tool than examined: `_CANDIDATE_SQL_FULL` has no `WHERE` clause (all games, all platforms, all statuses), no cap on total candidate count, and every non-Steam/non-Epic game wastes a guaranteed-`error` Steam lookup — unexamined cost on a NAS this project's own history documents as CPU-steal-bound | §6 rewritten: no forced trigger at all. The existing gated sweep (already scheduled every 6h) already selects exactly the affected population (`status IN (...) AND owned=1`, all platforms) — observe its next natural run instead of manufacturing a bigger one |
+| 4 | Finding #3's (round-1) "same category, not new" framing for the stale-removed-depot risk undercounted the actual change: exposure goes from 1 depot per game (old glob) to up to N depots (Grim Dawn: 9) — a real multiplier, not just an unchanged category | §9 finding 3 annotation above updated to point here. Quantified explicitly: this is a real, roughly N-fold increase in per-game exposure for an N-depot game, not merely a relabeled identical risk. Still no code mitigation added — this is presented to the Orchestrator as a quantified, explicit decision (§11), not resolved unilaterally |
+
+Round-2 verdict: REQUEST CHANGES. This revision addresses every item above.
+
+## 11. Open questions
+
+None block sending this back for a third review round. One item is explicitly the Orchestrator's call rather than a default I've picked:
+
+- **Finding #3/§10-4 (stale-removed-depot exposure multiplier):** no code mitigation is proposed. Options if the Orchestrator wants one: (a) accept as-is, matching this document's current default; (b) log when a selected manifest's mtime is old relative to the game's other depots, as a cheap detection signal without changing behavior; (c) something more involved (e.g. cross-checking depot IDs against a live Steam API) — not recommended, disproportionate to a rare edge case. No action needed to proceed with (a); flagging so the choice is deliberate, not silent.

--- a/docs/superpowers/specs/2026-08-16-manifest-locator-depot-glob-design.md
+++ b/docs/superpowers/specs/2026-08-16-manifest-locator-depot-glob-design.md
@@ -1,0 +1,96 @@
+# Design — fix the manifest locator's per-depot .bin discovery glob
+
+**Date:** 2026-08-16
+**Status:** Approved (design) — 2026-08-16
+**Repo:** lancache_orchestrator. **Branch:** `fix/steam-manifest-locator-depot-glob` (not yet created)
+**Found during:** live investigation of why Grim Dawn, STAR WARS Jedi: Survivor, and Battlefield 2042 remained stuck at `validation_failed` (96–99.9% cached) despite the host Steam prefill cron running every 6h. Unrelated to the Steam-prefill-ownership work in progress (`docs/superpowers/specs/2026-08-14-steam-prefill-ownership-design.md`) — this is a pre-existing defect in the read-only validate path, filed as its own change.
+
+---
+
+## 1. Problem
+
+Three Steam games sat at `validation_failed` for over a week with no improvement, despite `run-steam-prefill.sh` completing successfully on every 6-hourly tick. `app.log` on the NAS shows Grim Dawn's full 9-depot, 12.44 GiB download completing cleanly on every recent run (`Finished downloading... Prefill complete!`). The games are not actually under-cached — **the validator is checking the wrong data and can never see the successful downloads.**
+
+## 2. Root cause (verified live, not inferred)
+
+`src/orchestrator/agent/manifest_locator.py::locate_manifest_bins` globs SteamPrefill's `.bin` manifest files as:
+
+```python
+for path in v1.glob(f"{app_id}_{app_id}_*.{ext}"):
+```
+
+This assumes every depot's manifest filename repeats the app ID twice: `{app_id}_{app_id}_{depot}_{gid}.bin`. That holds only for a game's *primary* depot. SteamPrefill names secondary depots `{app_id}_{depotGroupId}_{depotId}_{gid}.bin`, where `depotGroupId` is frequently a **different** number (a Steam-internal grouping, not the app ID). The glob silently excludes every one of those files from consideration — they are never even seen as candidates, let alone compared by mtime.
+
+**Confirmed by running the real locator code against the live filesystem** (not a synthetic repro):
+
+```
+=== Grim Dawn (219990) ===
+  depot=219991  parts[1]={'219990'}  MATCHES glob
+  depot=229003  parts[1]={'228980'}  EXCLUDED by glob
+  depot=2699230 parts[1]={'2699230'} EXCLUDED by glob
+  depot=2699231 parts[1]={'2699230'} EXCLUDED by glob
+  depot=483840  parts[1]={'483840'}  EXCLUDED by glob
+  depot=642280  parts[1]={'642280'}  EXCLUDED by glob
+  depot=642281  parts[1]={'642280'}  EXCLUDED by glob
+  depot=897670  parts[1]={'897670'}  EXCLUDED by glob
+  depot=897671  parts[1]={'897670'}  EXCLUDED by glob
+```
+
+Of 9 depots, only 1 (219991) matches. For the other 8, the locator falls back to whatever candidate *does* match the glob — for 5 of them that's a `.shas` sidecar **51 days old** (from the one-time DepotDownloader gap-filler, issue #213); for the remaining 3 (229003, 2699230, 2699231) there is no matching candidate at all, so those depots are silently absent from validation entirely.
+
+The 6 files the (buggy) locator actually selects total **exactly 10784 chunks** — the precise `chunks_total` recorded in the orchestrator's database for Grim Dawn. That is not a coincidence; it is the direct mechanism. The same pattern was independently confirmed for Jedi: Survivor and Battlefield 2042.
+
+This bug predates every later fix in this file's history — it was present in the very first commit that introduced this validation path (`157968e feat(steam): agent /v1/steam/validate via SteamPrefill manifests`), before the prefilled-gid pinning fix (`43e77db`) or the manifest archive (`f48ff2a`). It is not a regression from recent work.
+
+### Why the prefilled-gid pin doesn't save it
+
+`locate_manifest_bins` accepts a `prefilled_gids` set — when a depot's manifest gid is in that set, it's preferred over pure newest-by-mtime, pinning validation to the version SteamPrefill actually recorded downloading. This pin comes from `Config/successfullyDownloadedDepots.json`. All three games are **completely absent** from that file, despite `app.log` recording repeated successful completions — so the pin never engages, and the broken glob's newest-by-mtime fallback runs unopposed. This absence is not explained by the glob bug and is addressed separately in §5 below; the fix in this document does not depend on resolving it.
+
+## 3. Fix
+
+Broaden **only** the `.bin` glob to match on the app ID once, not twice:
+
+```python
+for path in v1.glob(f"{app_id}_*.{ext}"):
+```
+
+The `.shas` glob is unchanged — it stays `f"{app_id}_{app_id}_*.{ext}"`. That extension is written exclusively by the orchestrator's own DepotDownloader-based fetcher (`platform/steam/manifest_fetcher.py`), whose naming convention is fixed and already correct; broadening it would only risk matching something unintended for no benefit.
+
+**Why the broader glob is safe (verified, not assumed):** a glob prefix match requires the literal next character after the matched digits to be `_`. `f"{219990}_*"` cannot match `2199905_...` or any other app's files — the character immediately following `219990` in that filename is `5`, not `_`. Checked against the live `/steamprefill-cache` and `/manifest-archive` directories (4700+ and equivalent files respectively) with no collision. `list_prefilled_app_ids` in the same module already uses this unscoped style (`v1.glob(f"*.{ext}")` + manual first-segment split) and does not have this bug — only the per-app depot lookup in `locate_manifest_bins` does.
+
+`len(parts) != 4: continue` stays unchanged — every real filename observed, `.bin` or `.shas`, is exactly 4 underscore-separated segments (app, group-or-app, depot, gid).
+
+## 4. Testing
+
+**Unit (`tests/agent/test_manifest_locator.py`).** Every existing test in this file uses `{app}_{app}_{depot}_{gid}` naming — which is exactly why this bug shipped invisibly from the first commit: there has never been a test exercising the differing-group-id shape that real multi-depot SteamPrefill output actually produces. New cases:
+
+- A depot whose `.bin` filename has a group-id segment different from the app id must now be found (previously silently excluded).
+- A mix of one matching-pattern depot and one differing-pattern depot for the same app — both found, matching the real Grim Dawn shape (1 depot matches the old pattern, 8 don't).
+- The `.shas` glob is unchanged: a `.shas` file with a differing group-id-style name (hypothetical, since the fetcher never writes one) is confirmed NOT matched, proving the two extensions are scoped independently.
+- All existing tests must continue to pass unmodified — this is a widening, not a behavior change, for the naming shape they already cover.
+
+**Integration (`tests/agent/test_steam_validate.py`).** Extend the existing fixture-based test pattern (`APP, DEPOT, GID` + `sample_manifest.bin`) with a second depot under a different group id, asserting `POST /v1/steam/validate`'s `chunks_total` now includes both depots' chunks — proving the fix end-to-end through the actual endpoint, not just the locator in isolation.
+
+## 5. The `successfullyDownloadedDepots.json` gap (investigated, not fixed here)
+
+Checked all five `selectedAppsToPrefill.json` backups on the NAS (Jun 24 → Aug 9) for the three games' presence:
+
+| App | Jun 24 | Jun 26 | Jul 5 | Aug 3 (pre-surgical) | Aug 9 (current) |
+|---|---|---|---|---|---|
+| Grim Dawn (219990) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Jedi Survivor (1774580) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Battlefield 2042 (1517290) | ✗ | ✗ | ✗ | ✓ | ✗ |
+
+**Grim Dawn and Jedi Survivor have been continuously selected for 2+ months** — this rules out selection-list churn (removal/re-add resetting SteamPrefill's own bookkeeping) as the explanation for their missing `successfullyDownloadedDepots.json` entries, despite `app.log` recording repeated successful full downloads. No other state file exists in `SteamPrefill/` or `SteamPrefill/Config/` on the NAS that could hold an alternate record. The remaining explanation lives inside SteamPrefill's own external .NET binary, which is out of this repo's control and not further diagnosable without live experimentation on the production prefill process (adding verbose flags, re-running) — out of scope for this investigation.
+
+**Battlefield 2042 is a separate, simpler problem, unrelated to the glob bug's root cause:** present in the `pre-surgical-20260804` snapshot, absent from every backup since. It was deliberately removed from the selection around Aug 4–9 and never re-added — nothing has attempted to prefill it since, independent of anything in this document. Re-adding it to `selectedAppsToPrefill.json` is an operator action, not a code change, and is explicitly **not** part of this fix.
+
+The glob fix in §3 makes the JSON gap moot for validation *correctness* regardless of whether it is ever explained: once every depot's manifest is visible to the locator, newest-by-mtime alone picks the currently-prefilled version correctly, with or without the gid pin.
+
+## 6. Rollout
+
+No migration, no schema change, no settings change. Once deployed, the next scheduled validation sweep (`0 3,9,15,21 * * *`, gated to include `validation_failed` games) re-validates all three games automatically. Grim Dawn and Jedi Survivor should flip to `up_to_date` within one sweep cycle post-deploy — no manual trigger needed. Battlefield 2042 will remain `validation_failed` until separately re-added to the selection (§5), since nothing is prefilling it regardless of this fix.
+
+## 7. Open questions
+
+None. Scope, fix, and test plan are fully settled.

--- a/docs/superpowers/specs/2026-08-16-manifest-locator-depot-glob-design.md
+++ b/docs/superpowers/specs/2026-08-16-manifest-locator-depot-glob-design.md
@@ -1,9 +1,11 @@
 # Design — fix the manifest locator's per-depot .bin discovery glob
 
 **Date:** 2026-08-16
-**Status:** Approved (design) — 2026-08-16
-**Repo:** lancache_orchestrator. **Branch:** `fix/steam-manifest-locator-depot-glob` (not yet created)
+**Status:** Revised after adversarial review round 1 (2026-08-16) — see §9. Core fix (§3) unchanged; §4, §6, §7, §8 rewritten to close the findings below.
+**Repo:** lancache_orchestrator. **Branch:** `fix/steam-manifest-locator-depot-glob` (PR #276)
 **Found during:** live investigation of why Grim Dawn, STAR WARS Jedi: Survivor, and Battlefield 2042 remained stuck at `validation_failed` (96–99.9% cached) despite the host Steam prefill cron running every 6h. Unrelated to the Steam-prefill-ownership work in progress (`docs/superpowers/specs/2026-08-14-steam-prefill-ownership-design.md`) — this is a pre-existing defect in the read-only validate path, filed as its own change.
+
+**Round-1 adversarial review verdict: REQUEST CHANGES.** An independent reviewer, instructed to verify every claim against the real code rather than trust this document, confirmed the core fix (§3) is correct and its collision-safety argument is airtight, but found the original §6 "Rollout" materially understated the change's blast radius and never mentioned that `/v1/steam/purge` shares the exact same widened lookup. Both findings were independently spot-checked against the live source (file:line citations below) before accepting them. §9 records the full findings and how each was resolved.
 
 ---
 
@@ -38,7 +40,7 @@ This assumes every depot's manifest filename repeats the app ID twice: `{app_id}
 
 Of 9 depots, only 1 (219991) matches. For the other 8, the locator falls back to whatever candidate *does* match the glob — for 5 of them that's a `.shas` sidecar **51 days old** (from the one-time DepotDownloader gap-filler, issue #213); for the remaining 3 (229003, 2699230, 2699231) there is no matching candidate at all, so those depots are silently absent from validation entirely.
 
-The 6 files the (buggy) locator actually selects total **exactly 10784 chunks** — the precise `chunks_total` recorded in the orchestrator's database for Grim Dawn. That is not a coincidence; it is the direct mechanism. The same pattern was independently confirmed for Jedi: Survivor and Battlefield 2042.
+The 6 files the (buggy) locator actually selects total **exactly 10784 chunks** — the precise `chunks_total` recorded in the orchestrator's database for Grim Dawn. **What this proves and what it doesn't:** the locator is deterministic, so re-running the same unmodified code against a largely-unchanged file set was always going to reproduce the same number — the match confirms *determinism*, not by itself the *diagnosis*. The actual causal evidence is the depot-by-depot naming audit above: reading the real filenames on disk and showing, per depot, which ones the glob's literal string match does and doesn't accept. The chunk-count match is strong corroboration that this mechanism — not something else — is what produces the database's current value, but it is the naming audit that establishes *why*. The same naming-mismatch pattern and the same audit method were independently applied to Jedi: Survivor and Battlefield 2042 with the same result.
 
 This bug predates every later fix in this file's history — it was present in the very first commit that introduced this validation path (`157968e feat(steam): agent /v1/steam/validate via SteamPrefill manifests`), before the prefilled-gid pinning fix (`43e77db`) or the manifest archive (`f48ff2a`). It is not a regression from recent work.
 
@@ -66,10 +68,17 @@ The `.shas` glob is unchanged — it stays `f"{app_id}_{app_id}_*.{ext}"`. That 
 
 - A depot whose `.bin` filename has a group-id segment different from the app id must now be found (previously silently excluded).
 - A mix of one matching-pattern depot and one differing-pattern depot for the same app — both found, matching the real Grim Dawn shape (1 depot matches the old pattern, 8 don't).
+- **Realistic multi-depot scale (round-1 finding):** one test reproducing Grim Dawn's actual shape — 9 depots, 3 distinct on-disk states (1 fresh `.bin` matching the old pattern, several `.bin` files that only the widened glob can see, a `.shas` sidecar for comparison) — asserting the full per-depot candidate set and total chunk count, not just the 2-depot toy case. Catches anything a minimal pairwise test could miss at real scale.
+- **Cross-app-ID collision regression test (round-1 finding):** since collision-safety is the load-bearing safety argument for the whole fix, it needs its own explicit test, not just informal verification in this document. Construct two apps whose IDs are numeric prefixes of one another in both directions (e.g. `44` and `440`; `4400` and `440`) sharing one cache directory, and assert `locate_manifest_bins(44, ...)` never returns any of app `440`'s files and vice versa.
 - The `.shas` glob is unchanged: a `.shas` file with a differing group-id-style name (hypothetical, since the fetcher never writes one) is confirmed NOT matched, proving the two extensions are scoped independently.
 - All existing tests must continue to pass unmodified — this is a widening, not a behavior change, for the naming shape they already cover.
 
 **Integration (`tests/agent/test_steam_validate.py`).** Extend the existing fixture-based test pattern (`APP, DEPOT, GID` + `sample_manifest.bin`) with a second depot under a different group id, asserting `POST /v1/steam/validate`'s `chunks_total` now includes both depots' chunks — proving the fix end-to-end through the actual endpoint, not just the locator in isolation.
+
+**Integration (`tests/agent/test_steam_purge.py`) — round-1 finding, previously entirely absent.** `_steam_chunk_paths` (`agent/routers/steam.py:329`) is shared verbatim by `/v1/steam/validate` and `/v1/steam/purge`; §7 below explains why purge's behavior changes too. Add:
+
+- A purge test with a differing-group-id secondary depot, asserting the widened lookup causes purge to delete that depot's chunks too (previously invisible to purge, same as to validate).
+- A purge test confirming a depot present in `settings.steam_shared_redist_depots` is still excluded post-fix — the shared-redist skip (`agent/routers/steam.py:380-387`) is keyed by `depot_id`, not by which glob found the file, so it is orthogonal to this change, but it protects against purge deleting chunks another game depends on and deserves an explicit regression test given purge's blast radius is growing here.
 
 ## 5. The `successfullyDownloadedDepots.json` gap (investigated, not fixed here)
 
@@ -87,10 +96,60 @@ Checked all five `selectedAppsToPrefill.json` backups on the NAS (Jun 24 → Aug
 
 The glob fix in §3 makes the JSON gap moot for validation *correctness* regardless of whether it is ever explained: once every depot's manifest is visible to the locator, newest-by-mtime alone picks the currently-prefilled version correctly, with or without the gid pin.
 
-## 6. Rollout
+## 6. Blast radius: this changes validation for the whole library, not just 3 games (round-1 finding)
 
-No migration, no schema change, no settings change. Once deployed, the next scheduled validation sweep (`0 3,9,15,21 * * *`, gated to include `validation_failed` games) re-validates all three games automatically. Grim Dawn and Jedi Survivor should flip to `up_to_date` within one sweep cycle post-deploy — no manual trigger needed. Battlefield 2042 will remain `validation_failed` until separately re-added to the selection (§5), since nothing is prefilling it regardless of this fix.
+The original draft of this document reasoned only about the three known-broken games. That was wrong. The scheduled sweep's candidate query is:
 
-## 7. Open questions
+```python
+# src/orchestrator/jobs/handlers/sweep.py:30-34
+_CANDIDATE_SQL = (
+    "SELECT id, status FROM games "
+    "WHERE status IN ('unknown','up_to_date','validation_failed') AND owned = 1 "
+    "ORDER BY id"
+)
+```
 
-None. Scope, fix, and test plan are fully settled.
+`up_to_date` is included, not just `validation_failed`. **Every currently-`up_to_date` owned Steam game is re-validated on the very next scheduled sweep tick after this deploys**, using the widened manifest set.
+
+For the vast majority of the library this changes nothing: a single-depot game, or a multi-depot game whose secondary depots happen to already match the old `{app_id}_{app_id}_*` pattern, gets the identical candidate set before and after. The behavior only changes for games with at least one secondary depot under a differing group ID — the same shape as Grim Dawn.
+
+**What could happen to those games, and why it's the intended outcome, not a regression:** if a game like that currently reports `up_to_date` only because the old glob was blind to a secondary depot that is *itself* incomplete (a language pack partially evicted, say), that game's `up_to_date` status today is **already wrong** — it's the same undercounting bug, just landing on the passing side by chance instead of the failing side, as it did for Grim Dawn. The fix makes validation for that game accurate for the first time. It is not new risk introduced by this change; it is the same latent bug (present since the file's first commit, §2) becoming visible in the other direction. The three known games are simply the ones where it happened to land visibly wrong; there is no way to know how many others might flip without running the corrected code.
+
+**Given that, this is treated as a controlled rollout with visibility, not a silent change left to the next passive cron tick:**
+
+1. Deploy the fix.
+2. Immediately trigger a full validation pass under operator control — `orchestrator-cli cache validate-all` (`POST /api/v1/sweep {"full": true}`, `cli/commands/cache.py:34-42`) — rather than waiting for the next scheduled gated sweep to touch the library implicitly.
+3. Before triggering, snapshot each owned Steam game's `status` from the database; after the full sweep completes (poll via `orchestrator-cli jobs`), snapshot again and diff. Report the counts to the Orchestrator: how many games flipped `up_to_date → validation_failed` (newly-revealed incompleteness — expected, and each one becomes a real target for re-prefill) versus `validation_failed → up_to_date` (the three known games, plus any others the old glob was undercounting favorably).
+4. This diff is the actual verification that the fix behaves as designed at full-library scale, not just in unit tests against synthetic fixtures.
+
+## 7. `/v1/steam/purge` shares the exact same widened lookup (round-1 finding)
+
+`_steam_chunk_paths` (`agent/routers/steam.py:329-404`) is the single shared source of manifest→cache-path enumeration for **both** `/v1/steam/validate` and `/v1/steam/purge` (stated in its own docstring, line 333-335) — it calls `locate_manifest_bins` directly, so §3's fix applies to both callers identically, with no code change needed in either router.
+
+`steam_purge` (`agent/routers/steam.py:501-524`) applies no depot-level scoping of its own: "every enumerated chunk across all depots (no depot-scoping — purge_chunks no-ops on paths that aren't present)" (line 516-518 comment, verified verbatim in source). After this fix, purging any Steam game with a secondary depot under a differing group ID will delete that depot's chunk files too — files the old narrow glob never even enumerated, so purge silently left them behind before. This is the same correctness direction as the validate fix (purge should act on everything a game actually owns, not on whatever a buggy glob happened to see) and is not a new category of behavior, but it was entirely unexamined and untested in the original draft.
+
+**Checked and confirmed safe against the one sharper risk this could imply — cross-game deletion via a shared depot:** the Steamworks Common Redistributables exclusion (`settings.steam_shared_redist_depots`, PR #245) is applied *inside* `_steam_chunk_paths` itself (`agent/routers/steam.py:380-387`), keyed by `depot_id`, before any path is added to what either validate or purge sees. It is unconditional on which glob found the file. Widening the `.bin` glob does not bypass or weaken this exclusion in any way — a depot that's supposed to be protected from purge stays protected. This was verified by reading the exclusion's exact position in the shared function, not assumed from the original PR's intent.
+
+Test coverage for this is in §4.
+
+## 8. Rollout
+
+No migration, no schema change, no settings change. Deploy, then execute the controlled full-sweep verification in §6 rather than relying on the passive scheduled sweep to reveal the outcome invisibly. Grim Dawn and Jedi Survivor are expected to flip to `up_to_date` in that pass. Battlefield 2042 will remain `validation_failed` regardless of this fix until separately re-added to the selection (§5) — nothing is prefilling it. Any other games that flip status in either direction are reported per §6 step 4 rather than discovered later by accident.
+
+## 9. Adversarial review round 1 (2026-08-16)
+
+An independent reviewer (fresh context, instructed to verify every claim against the real code rather than trust this document) was dispatched against this spec before implementation began. Summary of findings and resolution:
+
+| # | Finding | Resolution |
+|---|---|---|
+| 1 | Rollout (old §6) reasoned about 3 games; sweep candidate query includes `up_to_date`, so the whole library is affected on the next tick | New §6: controlled `cache validate-all` rollout with a before/after status diff, replacing reliance on the passive scheduled sweep |
+| 2 | `/v1/steam/purge` shares the exact same widened lookup; never mentioned | New §7: documents the behavior change, confirms the shared-redist cross-game-deletion protection is orthogonal and unaffected |
+| 3 | Possible edge case: a depot Steam has since removed from an app, but with chunks still lingering in cache (not yet evicted) | Considered and accepted as an existing, not new, risk: the `present == 0` exclusion already handles full eviction; a depot with *some* chunks still cached is the same category of staleness the old narrow glob already had for whichever single depot it happened to track, just now applying across a correctly-larger set of depots instead of one. No code mitigation added; flagged here for the Orchestrator's awareness rather than silently accepted |
+| 4 | "10784 matches the DB, not a coincidence" overclaimed what was demonstrated | §2 rewritten to separate the naming audit (causal evidence) from the chunk-count match (corroboration, not proof) |
+| 5 | Testing plan gaps: no cross-app collision test, no purge test, no realistic multi-depot-scale test | All three added to §4 |
+
+Round-1 verdict: REQUEST CHANGES. This revision addresses every item above. Awaiting round-2 review before implementation.
+
+## 10. Open questions
+
+None remaining after round 1. Finding #3 above is a deliberate accepted-risk decision, not an open question — recorded for visibility, not blocking.

--- a/src/orchestrator/agent/app.py
+++ b/src/orchestrator/agent/app.py
@@ -67,6 +67,7 @@ def create_agent_app(*, settings: Settings | None = None) -> FastAPI:
                 # cache is steam_prefill_live_cache_dir (the dir the capture reads),
                 # by construction — not by relying on the deploy env (UAT-13 F2).
                 home=Path(settings.steam_prefill_live_cache_dir).parent.parent,
+                timeout_sec=settings.steam_prefill_timeout_sec,
             )
         if not hasattr(app.state, "manifest_fetcher"):
             app.state.manifest_fetcher = DepotDownloaderManifestFetcher(

--- a/src/orchestrator/agent/routers/steam.py
+++ b/src/orchestrator/agent/routers/steam.py
@@ -40,57 +40,65 @@ def _validate_app_ids(app_ids: list[int]) -> None:
         raise HTTPException(status_code=422, detail="app_ids must be non-negative")
 
 
+def _prefill_gate(request: Request) -> dict[str, Any]:
+    """Single-flight state for SteamPrefill, held on app.state.
+
+    SteamPrefill is not built for concurrent invocations sharing one auth/cache
+    (re-arch ① §6). Until the host cron is retired its `flock` provides this;
+    afterwards the agent is the only thing standing between two scheduler ticks
+    (or an operator action racing a scheduled one) and a corrupted Config/.
+    Shared by every prefill mode (selection, recent-purchase) — they are all
+    SteamPrefill invocations against the same auth/cache.
+    """
+    state = request.app.state
+    if not hasattr(state, "steam_prefill_gate"):
+        state.steam_prefill_gate = {"job_id": None}
+    gate: dict[str, Any] = state.steam_prefill_gate
+    return gate
+
+
+def _in_flight_job_id(request: Request) -> str | None:
+    """Return the in-flight job_id if one is genuinely still running, else None
+    (clearing a stale gate left behind by a job that finished without going
+    through its own `finally` — defensive; should not happen in practice)."""
+    gate = _prefill_gate(request)
+    job_id: str | None = gate["job_id"]
+    if job_id is None:
+        return None
+    store = request.app.state.agent_jobs
+    snap = store.get(job_id)
+    if snap is None or snap["state"] not in ("done", "failed"):
+        return job_id
+    gate["job_id"] = None
+    return None
+
+
 @router.post("/v1/steam/prefill", status_code=status.HTTP_202_ACCEPTED)
 async def start_prefill(body: SteamPrefillRequest, request: Request) -> dict[str, str]:
     _validate_app_ids(body.app_ids)
+    existing = _in_flight_job_id(request)
+    if existing is not None:
+        _log.info("steam_prefill.dedup_hit", job_id=existing)
+        return {"job_id": existing}
+
     driver = request.app.state.prefill_driver
     settings = request.app.state.settings
     store = request.app.state.agent_jobs
+    gate = _prefill_gate(request)
     job_id = store.create()
+    gate["job_id"] = job_id
 
     async def _run() -> None:
         try:
             result = await driver.prefill_apps(body.app_ids, force=body.force)
             if result.ok:
-                # A successful prefill always writes its manifest(s) to the HOME
-                # cache, so a MISSING live cache dir means SteamPrefill's HOME and
-                # steam_prefill_live_cache_dir have drifted apart — the capture
-                # would silently no-op and false-Partial badges would silently
-                # return. Make that loud (UAT-13 F2b). (The driver pins HOME from
-                # this same setting, so this should never fire — it's the canary.)
-                live_v1 = Path(settings.steam_prefill_live_cache_dir) / "v1"
-                if not live_v1.is_dir():
-                    _log.warning(
-                        "steam_prefill.live_cache_missing",
-                        job_id=job_id,
-                        live_cache=str(live_v1),
-                        hint="HOME/.cache path mismatch; manifests NOT captured — check agent HOME",
-                    )
-                # Capture the manifest(s) SteamPrefill just wrote to its HOME
-                # cache (the agent runs it with HOME=/tmp) into the durable
-                # archive. The periodic archive-sync only reads the host cache, so
-                # without this an agent-driven (force-)prefill's manifest is never
-                # archived and validate falls back to a stale older manifest — the
-                # false-Partial root cause. The run is finished so settle_seconds=0.
-                # Synchronous: it's a bounded, fast copy of the few new .bin
-                # manifests this prefill produced (not the whole library), so it
-                # isn't worth offloading. A capture failure must never fail the job.
-                try:
-                    copied = sync_manifests_to_archive(
-                        Path(settings.steam_prefill_live_cache_dir),
-                        Path(settings.steam_manifest_archive_dir),
-                        settle_seconds=0.0,
-                    )
-                    _log.info("steam_prefill.manifests_captured", job_id=job_id, copied=copied)
-                except Exception as e:
-                    _log.warning(
-                        "steam_prefill.capture_failed",
-                        job_id=job_id,
-                        reason=f"{type(e).__name__}: {e}"[:200],
-                    )
+                _capture_prefill_manifests(job_id, settings)
             store.set_done(job_id, {"ok": result.ok, "raw": result.raw})
         except Exception as e:  # record, never crash the loop
             store.set_failed(job_id, f"{type(e).__name__}: {e}"[:200])
+        finally:
+            if gate["job_id"] == job_id:
+                gate["job_id"] = None
 
     # Hold a strong reference so the fire-and-forget task is not GC'd mid-flight
     # (mirrors the /v1/pull background-task set + discard-on-done pattern).
@@ -101,12 +109,89 @@ async def start_prefill(body: SteamPrefillRequest, request: Request) -> dict[str
     return {"job_id": job_id}
 
 
+def _capture_prefill_manifests(job_id: str, settings: Any) -> None:
+    """After a successful SteamPrefill run, capture the manifest(s) it just
+    wrote to its HOME cache into the durable archive.
+
+    Shared by every prefill mode: the periodic archive-sync only reads the
+    host cache, so without this an agent-driven run's manifest is never
+    archived and validate falls back to a stale older manifest — the
+    false-Partial root cause. settle_seconds=0.0 because the run just
+    finished. A capture failure must never fail the job.
+    """
+    # A successful prefill always writes its manifest(s) to the HOME cache, so
+    # a MISSING live cache dir means SteamPrefill's HOME and
+    # steam_prefill_live_cache_dir have drifted apart — the capture would
+    # silently no-op and false-Partial badges would silently return. Make that
+    # loud (UAT-13 F2b). (The driver pins HOME from this same setting, so this
+    # should never fire — it's the canary.)
+    live_v1 = Path(settings.steam_prefill_live_cache_dir) / "v1"
+    if not live_v1.is_dir():
+        _log.warning(
+            "steam_prefill.live_cache_missing",
+            job_id=job_id,
+            live_cache=str(live_v1),
+            hint="HOME/.cache path mismatch; manifests NOT captured — check agent HOME",
+        )
+    try:
+        copied = sync_manifests_to_archive(
+            Path(settings.steam_prefill_live_cache_dir),
+            Path(settings.steam_manifest_archive_dir),
+            settle_seconds=0.0,
+        )
+        _log.info("steam_prefill.manifests_captured", job_id=job_id, copied=copied)
+    except Exception as e:
+        _log.warning(
+            "steam_prefill.capture_failed",
+            job_id=job_id,
+            reason=f"{type(e).__name__}: {e}"[:200],
+        )
+
+
 @router.get("/v1/steam/prefill/{job_id}")
 async def get_prefill(job_id: str, request: Request) -> dict[str, Any]:
     snap: dict[str, Any] | None = request.app.state.agent_jobs.get(job_id)
     if snap is None:
         raise HTTPException(status_code=404, detail="job not found")
     return snap
+
+
+@router.post("/v1/steam/prefill-recent", status_code=status.HTTP_202_ACCEPTED)
+async def start_prefill_recent(request: Request) -> dict[str, str]:
+    """Prefill newly-purchased apps (SteamPrefill's own discovery, spec OQ1).
+
+    Shares the single-flight gate with /v1/steam/prefill: both are SteamPrefill
+    invocations against the same auth/cache and must never run concurrently.
+    """
+    existing = _in_flight_job_id(request)
+    if existing is not None:
+        _log.info("steam_prefill.dedup_hit", job_id=existing)
+        return {"job_id": existing}
+
+    driver = request.app.state.prefill_driver
+    settings = request.app.state.settings
+    store = request.app.state.agent_jobs
+    gate = _prefill_gate(request)
+    job_id = store.create()
+    gate["job_id"] = job_id
+
+    async def _run() -> None:
+        try:
+            result = await driver.prefill_recent()
+            if result.ok:
+                _capture_prefill_manifests(job_id, settings)
+            store.set_done(job_id, {"ok": result.ok, "raw": result.raw})
+        except Exception as e:  # record, never crash the loop
+            store.set_failed(job_id, f"{type(e).__name__}: {e}"[:200])
+        finally:
+            if gate["job_id"] == job_id:
+                gate["job_id"] = None
+
+    bg_tasks = request.app.state.agent_bg_tasks
+    task = asyncio.create_task(_run())
+    bg_tasks.add(task)
+    task.add_done_callback(bg_tasks.discard)
+    return {"job_id": job_id}
 
 
 @router.post("/v1/steam/fetch-manifests", status_code=status.HTTP_202_ACCEPTED)

--- a/src/orchestrator/core/settings.py
+++ b/src/orchestrator/core/settings.py
@@ -91,6 +91,12 @@ class Settings(BaseSettings):
     # selectedAppsToPrefill.json, successfullyDownloadedDepots.json.
     steam_prefill_binary: Path = Path("/SteamPrefill/SteamPrefill")
     steam_prefill_config_dir: Path = Path("/SteamPrefill/Config")
+    # Hard cap on a single SteamPrefill run. Matches the host cron's RUN_MAX=10h.
+    # On 2026-08-12 a --force run was alive 5d18h having already logged
+    # "Prefill complete!" and never exited. Without this the agent job would
+    # wait forever and the next scheduled tick would start a second concurrent
+    # run against the same shared auth/cache state.
+    steam_prefill_timeout_sec: float = Field(default=36000.0, gt=0)
 
     # --- Data-plane agent (re-architecture step 2) ------------------
     # The data plane (chunk-pull + cache disk-stat + SteamPrefill runner) runs

--- a/src/orchestrator/platform/steam/prefill_driver.py
+++ b/src/orchestrator/platform/steam/prefill_driver.py
@@ -7,8 +7,10 @@ account.config bytes or any token/identifier."""
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import os
+import signal
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -26,7 +28,14 @@ class SteamAuthStatus:
 
 
 class SteamPrefillDriver:
-    def __init__(self, *, binary: Path, config_dir: Path, home: Path | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        binary: Path,
+        config_dir: Path,
+        home: Path | None = None,
+        timeout_sec: float = 36000.0,
+    ) -> None:
         self._binary = Path(binary)
         self._config_dir = Path(config_dir)
         # SteamPrefill writes its manifest cache to ``$HOME/.cache/SteamPrefill``.
@@ -36,10 +45,33 @@ class SteamPrefillDriver:
         # omits ``-e HOME=/tmp`` silently strands manifests and re-introduces the
         # false-Partial bug (UAT-13 F2 / #211). None preserves prior env-inherit.
         self._home = None if home is None else Path(home)
+        self._timeout_sec = float(timeout_sec)
 
     @property
     def _selection_path(self) -> Path:
         return self._config_dir / "selectedAppsToPrefill.json"
+
+    async def _kill_process_group(self, proc: asyncio.subprocess.Process) -> None:
+        """SIGTERM the process GROUP, escalating to SIGKILL after 60s.
+
+        The group, not the process: SteamPrefill may have spawned children, and
+        killing only the direct child is the host cron's known weakness — its
+        `timeout` kills the docker exec client while the in-container process
+        runs on (its own alert text admits this).
+        """
+        try:
+            pgid = os.getpgid(proc.pid)
+        except ProcessLookupError:
+            return
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(pgid, signal.SIGTERM)
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=60)
+        except TimeoutError:
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(pgid, signal.SIGKILL)
+            with contextlib.suppress(Exception):
+                await proc.wait()
 
     async def prefill_apps(self, app_ids: list[int], *, force: bool = False) -> PrefillResult:
         """Write our app selection, run SteamPrefill, then restore the operator's
@@ -60,8 +92,16 @@ class SteamPrefillDriver:
                 env=env,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
+                start_new_session=True,
             )
-            out, _ = await proc.communicate()
+            try:
+                out, _ = await asyncio.wait_for(proc.communicate(), timeout=self._timeout_sec)
+            except TimeoutError:
+                await self._kill_process_group(proc)
+                return PrefillResult(
+                    ok=False,
+                    raw=f"timeout: SteamPrefill exceeded {self._timeout_sec:.0f}s and was killed",
+                )
             raw = out.decode("utf-8", "replace")
             return PrefillResult(ok=(proc.returncode == 0), raw=raw[-4000:])
         finally:

--- a/src/orchestrator/platform/steam/prefill_driver.py
+++ b/src/orchestrator/platform/steam/prefill_driver.py
@@ -73,40 +73,58 @@ class SteamPrefillDriver:
             with contextlib.suppress(Exception):
                 await proc.wait()
 
+    async def _run(self, *extra_args: str) -> PrefillResult:
+        """Run the SteamPrefill binary with the shared timeout + kill semantics.
+
+        Shared by every prefill mode (selection, force, recently-purchased) so
+        the timeout and process-group kill can never drift between them.
+        """
+        args = [str(self._binary), "prefill", "--no-ansi", *extra_args]
+        # SteamPrefill resolves its Config/ dir RELATIVE TO the working
+        # directory (./Config), not the binary path. Run it from the parent
+        # of our config_dir so ./Config maps to exactly config_dir —
+        # otherwise it finds no account.config and login fails (the failure
+        # is masked by a Spectre.Console crash; see the 2026-06-21 flip).
+        env = None if self._home is None else {**os.environ, "HOME": str(self._home)}
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            cwd=str(self._config_dir.parent),
+            env=env,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            start_new_session=True,
+        )
+        try:
+            out, _ = await asyncio.wait_for(proc.communicate(), timeout=self._timeout_sec)
+        except TimeoutError:
+            await self._kill_process_group(proc)
+            return PrefillResult(
+                ok=False,
+                raw=f"timeout: SteamPrefill exceeded {self._timeout_sec:.0f}s and was killed",
+            )
+        raw = out.decode("utf-8", "replace")
+        return PrefillResult(ok=(proc.returncode == 0), raw=raw[-4000:])
+
     async def prefill_apps(self, app_ids: list[int], *, force: bool = False) -> PrefillResult:
         """Write our app selection, run SteamPrefill, then restore the operator's
         prior selection. Returns ok=True iff exit code 0."""
         prior = self._selection_path.read_text() if self._selection_path.exists() else None
         self._selection_path.write_text(json.dumps([int(a) for a in app_ids]))
         try:
-            args = [str(self._binary), "prefill", "--no-ansi", *(["--force"] if force else [])]
-            # SteamPrefill resolves its Config/ dir RELATIVE TO the working
-            # directory (./Config), not the binary path. Run it from the parent
-            # of our config_dir so ./Config maps to exactly config_dir —
-            # otherwise it finds no account.config and login fails (the failure
-            # is masked by a Spectre.Console crash; see the 2026-06-21 flip).
-            env = None if self._home is None else {**os.environ, "HOME": str(self._home)}
-            proc = await asyncio.create_subprocess_exec(
-                *args,
-                cwd=str(self._config_dir.parent),
-                env=env,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.STDOUT,
-                start_new_session=True,
-            )
-            try:
-                out, _ = await asyncio.wait_for(proc.communicate(), timeout=self._timeout_sec)
-            except TimeoutError:
-                await self._kill_process_group(proc)
-                return PrefillResult(
-                    ok=False,
-                    raw=f"timeout: SteamPrefill exceeded {self._timeout_sec:.0f}s and was killed",
-                )
-            raw = out.decode("utf-8", "replace")
-            return PrefillResult(ok=(proc.returncode == 0), raw=raw[-4000:])
+            return await self._run(*(["--force"] if force else []))
         finally:
             if prior is not None:
                 self._selection_path.write_text(prior)
+
+    async def prefill_recent(self) -> PrefillResult:
+        """Prefill newly-purchased apps using SteamPrefill's own discovery.
+
+        Deliberately does NOT touch selectedAppsToPrefill.json: SteamPrefill
+        derives the recent set itself, so there is no selection to save or
+        restore, and no window in which a concurrent reader would see our
+        temporary list. Never passes --force (spec OQ4: force is operator-only).
+        """
+        return await self._run("--recently-purchased")
 
     def downloaded_state(self) -> dict[int, list[int]]:
         """{app_id: [prefilled manifest GIDs]} from SteamPrefill's own record."""

--- a/tests/agent/test_steam.py
+++ b/tests/agent/test_steam.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 
 from fastapi.testclient import TestClient
@@ -19,11 +20,25 @@ class _FakeDriver:
         self.calls.append((app_ids, force))
         return PrefillResult(ok=True, raw="OK done")
 
+    async def prefill_recent(self):
+        self.calls.append("recent")
+        return PrefillResult(ok=True, raw="OK recent")
+
     def downloaded_state(self):
         return {440: [111, 222]}
 
     def auth_status(self):
         return SteamAuthStatus(ok=True)
+
+
+class _SlowDriver(_FakeDriver):
+    """Sleeps before returning, so a second request arrives while the first
+    is still in flight — the window the single-flight guard must catch."""
+
+    async def prefill_apps(self, app_ids, *, force=False):
+        self.calls.append((app_ids, force))
+        await asyncio.sleep(0.3)
+        return PrefillResult(ok=True, raw="OK done")
 
 
 def _client(driver) -> TestClient:
@@ -337,3 +352,75 @@ def test_prune_selection_missing_file(tmp_path):
     resp = client.post("/v1/steam/prune-selection", json={"exclude_app_ids": [1]})
     assert resp.status_code == 200
     assert resp.json()["removed"] == 0
+
+
+def _wait_for_done(client, job_id, *, tries=50):
+    snap = None
+    for _ in range(tries):
+        snap = client.get(f"/v1/steam/prefill/{job_id}").json()
+        if snap["state"] == "done":
+            return snap
+        time.sleep(0.02)
+    return snap
+
+
+def test_second_prefill_returns_the_in_flight_job_id():
+    """Two concurrent SteamPrefill processes corrupt the shared auth/cache, so
+    the second request must dedup onto the running job, not start a rival.
+
+    Uses `with _client(...) as client:` (a PERSISTENT portal) rather than the
+    bare `_client(...)` most tests in this file use. Starlette's TestClient
+    only keeps one event loop alive across calls when used as a context
+    manager; without it, each request gets its own ephemeral loop and a
+    background task with a real `await asyncio.sleep(...)` is silently
+    orphaned when that loop tears down — which would make the "still running"
+    window this test depends on impossible to observe.
+    """
+    driver = _SlowDriver()
+    with _client(driver) as client:
+        first = client.post("/v1/steam/prefill", json={"app_ids": [730]})
+        second = client.post("/v1/steam/prefill", json={"app_ids": [440]})
+        assert first.status_code == 202
+        assert second.status_code == 202
+        assert second.json()["job_id"] == first.json()["job_id"]
+        snap = _wait_for_done(client, first.json()["job_id"])
+        assert snap["state"] == "done"
+        # only ONE SteamPrefill invocation actually happened
+        assert driver.calls == [([730], False)]
+
+
+def test_a_new_prefill_can_start_once_the_prior_one_is_done():
+    driver = _SlowDriver()
+    with _client(driver) as client:
+        first = client.post("/v1/steam/prefill", json={"app_ids": [730]})
+        job_id = first.json()["job_id"]
+        assert _wait_for_done(client, job_id)["state"] == "done"
+        second = client.post("/v1/steam/prefill", json={"app_ids": [440]})
+        assert second.json()["job_id"] != job_id
+        assert _wait_for_done(client, second.json()["job_id"])["state"] == "done"
+        assert driver.calls == [([730], False), ([440], False)]
+
+
+def test_prefill_recent_endpoint_starts_a_job():
+    driver = _FakeDriver()
+    with _client(driver) as client:
+        resp = client.post("/v1/steam/prefill-recent")
+        assert resp.status_code == 202
+        job_id = resp.json()["job_id"]
+        snap = _wait_for_done(client, job_id)
+        assert snap["state"] == "done"
+        assert snap["result"] == {"ok": True, "raw": "OK recent"}
+        assert driver.calls == ["recent"]
+
+
+def test_prefill_recent_shares_the_single_flight_gate_with_prefill_apps():
+    """A recent-purchase pass and a selection pass are both SteamPrefill
+    invocations sharing one auth/cache and must not overlap."""
+    driver = _SlowDriver()
+    with _client(driver) as client:
+        first = client.post("/v1/steam/prefill", json={"app_ids": [730]})
+        second = client.post("/v1/steam/prefill-recent")
+        assert second.json()["job_id"] == first.json()["job_id"]
+        snap = _wait_for_done(client, first.json()["job_id"])
+        assert snap["state"] == "done"
+        assert driver.calls == [([730], False)]

--- a/tests/platform/steam/test_prefill_driver.py
+++ b/tests/platform/steam/test_prefill_driver.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import stat
 from pathlib import Path
@@ -10,6 +11,23 @@ from orchestrator.platform.steam.prefill_driver import SteamPrefillDriver
 def _fake_binary(tmp_path, stdout="Done.", code=0):
     p = tmp_path / "FakeSteamPrefill"
     p.write_text(f"#!/bin/sh\ncat <<EOF\n{stdout}\nEOF\nexit {code}\n")
+    p.chmod(p.stat().st_mode | stat.S_IEXEC)
+    return p
+
+
+def _hanging_binary(tmp_path):
+    """Mimics the 2026-08-12 incident: prints success, then never exits."""
+    p = tmp_path / "HangingSteamPrefill"
+    p.write_text("#!/bin/sh\necho 'Prefill complete!'\nsleep 300\n")
+    p.chmod(p.stat().st_mode | stat.S_IEXEC)
+    return p
+
+
+def _group_spawning_binary(tmp_path, marker):
+    """Spawns a background child that outlives its parent unless the whole
+    process GROUP is killed. The child writes `marker` after a delay."""
+    p = tmp_path / "GroupSteamPrefill"
+    p.write_text(f"#!/bin/sh\n(sleep 5; echo pwned > {marker}) &\nsleep 300\n")
     p.chmod(p.stat().st_mode | stat.S_IEXEC)
     return p
 
@@ -122,3 +140,41 @@ def test_auth_status_present_ok(tmp_path):
     (cfg / "account.config").write_bytes(b"\x0a\x05hello")
     d = SteamPrefillDriver(binary=tmp_path / "x", config_dir=cfg)
     assert d.auth_status().ok is True
+
+
+@pytest.mark.asyncio
+async def test_prefill_apps_times_out_instead_of_hanging(tmp_path):
+    cfg = tmp_path / "Config"
+    cfg.mkdir()
+    d = SteamPrefillDriver(binary=_hanging_binary(tmp_path), config_dir=cfg, timeout_sec=1.0)
+    res = await d.prefill_apps([730])
+    assert res.ok is False
+    assert "timeout" in res.raw.lower()
+
+
+@pytest.mark.asyncio
+async def test_prefill_apps_restores_selection_even_on_timeout(tmp_path):
+    """The operator's selection must survive the timeout path, or a timed-out
+    run leaves the orchestrator's temporary app list as the cron's input."""
+    cfg = tmp_path / "Config"
+    cfg.mkdir()
+    (cfg / "selectedAppsToPrefill.json").write_text("[111, 222]")
+    d = SteamPrefillDriver(binary=_hanging_binary(tmp_path), config_dir=cfg, timeout_sec=1.0)
+    await d.prefill_apps([730])
+    assert json.loads((cfg / "selectedAppsToPrefill.json").read_text()) == [111, 222]
+
+
+@pytest.mark.asyncio
+async def test_timeout_kills_the_whole_process_group(tmp_path):
+    """Killing only the direct child leaves grandchildren alive — exactly the
+    cron's known weakness, where `timeout` kills the docker exec client while
+    the in-container SteamPrefill runs on."""
+    cfg = tmp_path / "Config"
+    cfg.mkdir()
+    marker = tmp_path / "child-survived.txt"
+    d = SteamPrefillDriver(
+        binary=_group_spawning_binary(tmp_path, marker), config_dir=cfg, timeout_sec=1.0
+    )
+    await d.prefill_apps([730])
+    await asyncio.sleep(7)  # past the child's 5s delay
+    assert not marker.exists(), "background child survived the group kill"

--- a/tests/platform/steam/test_prefill_driver.py
+++ b/tests/platform/steam/test_prefill_driver.py
@@ -178,3 +178,35 @@ async def test_timeout_kills_the_whole_process_group(tmp_path):
     await d.prefill_apps([730])
     await asyncio.sleep(7)  # past the child's 5s delay
     assert not marker.exists(), "background child survived the group kill"
+
+
+@pytest.mark.asyncio
+async def test_prefill_recent_passes_the_flag(tmp_path):
+    cfg = tmp_path / "Config"
+    cfg.mkdir()
+    argv = tmp_path / "argv.txt"
+    p = tmp_path / "ArgvSteamPrefill"
+    p.write_text(f'#!/bin/sh\necho "$@" > {argv}\nexit 0\n')
+    p.chmod(p.stat().st_mode | stat.S_IEXEC)
+    d = SteamPrefillDriver(binary=p, config_dir=cfg)
+    res = await d.prefill_recent()
+    assert res.ok is True
+    recorded = argv.read_text()
+    assert "--recently-purchased" in recorded
+    assert "--no-ansi" in recorded
+    assert "--force" not in recorded  # scheduled prefill is never force (spec OQ4)
+
+
+@pytest.mark.asyncio
+async def test_prefill_recent_does_not_touch_the_selection_file(tmp_path):
+    """SteamPrefill derives the recent set itself, so the operator's selection
+    must be left completely alone — not rewritten and restored."""
+    cfg = tmp_path / "Config"
+    cfg.mkdir()
+    sel = cfg / "selectedAppsToPrefill.json"
+    sel.write_text("[111, 222]")
+    before = sel.stat().st_mtime_ns
+    d = SteamPrefillDriver(binary=_fake_binary(tmp_path), config_dir=cfg)
+    await d.prefill_recent()
+    assert json.loads(sel.read_text()) == [111, 222]
+    assert sel.stat().st_mtime_ns == before, "selection file was rewritten"


### PR DESCRIPTION
Design only — no code. Found while investigating why 3 Steam games (Grim Dawn, Jedi: Survivor, Battlefield 2042) stayed `validation_failed` at 96–99.9% cached despite the host Steam prefill cron completing successfully every 6h. Unrelated to the Steam-prefill-ownership work in progress — filed as its own change since it's a pre-existing defect in the read-only validate path.

## Root cause (verified live, not inferred)

`locate_manifest_bins` globs `.bin` files as `f"{app_id}_{app_id}_*.{ext}"` — assuming every depot's filename repeats the app ID. That only holds for a game's primary depot; SteamPrefill names secondary depots `{app_id}_{depotGroupId}_{depotId}_{gid}.bin`, where `depotGroupId` is frequently a **different** number. The glob silently excludes those files as candidates entirely.

Ran the real locator against the live filesystem: of Grim Dawn's 9 depots, only 1 matches the glob. The 6 files it falls back to selecting (that 1 depot + 51-day-old `.shas` sidecars for 5 more, with 3 depots entirely unrepresented) total **exactly 10784 chunks** — the precise `chunks_total` the database has recorded for the game. Confirmed independently for the other two games.

The bug predates every later fix in this file — present since the original commit that introduced this validation path, before the prefilled-gid pinning fix or the manifest archive. Not a regression from recent work.

## Fix

Broaden **only** the `.bin` glob to `f"{app_id}_*.{ext}"`. The `.shas` glob is unchanged — that extension's naming is fixed and orchestrator-controlled. Verified safe against cross-app collision: a glob prefix match requires the literal next character to be `_`, so `"219990_*"` cannot match `"2199905_..."` or any other app's files.

## Also investigated: why does `successfullyDownloadedDepots.json` never record these apps?

Checked all five `selectedAppsToPrefill.json` backups on the NAS: **Grim Dawn and Jedi Survivor have been continuously selected for 2+ months**, ruling out selection-churn as the explanation. **Battlefield 2042 turned out to be a separate, simpler problem** — present in the `pre-surgical-20260804` snapshot, absent from every backup since (deliberately removed ~Aug 4–9, never re-added; an operator action, not a code fix). The remaining Grim Dawn/Jedi Survivor mystery lives inside SteamPrefill's own external binary and is out of scope — the glob fix makes it moot for validation correctness regardless.

## Testing plan

- **Unit** (`test_manifest_locator.py`): every existing test uses `{app}_{app}_{depot}_{gid}` naming — exactly why this shipped invisibly. New cases reproduce the real differing-group-id shape.
- **Integration** (`test_steam_validate.py`): extends the existing fixture pattern with a second depot under a different group id, proving the fix through the actual `/v1/steam/validate` endpoint.

## Rollout

No migration, no schema change. The next scheduled validation sweep re-validates automatically — Grim Dawn and Jedi Survivor should self-correct within one cycle post-deploy. Battlefield 2042 stays `validation_failed` until separately re-added to the selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)