### PR TITLE
fix(agent): sync the LIVE prefill cache to the archive, not a static root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — the manifest archive sync watched the wrong directory, so newly-prefilled games stayed invisible — 2026-08-17
+
+The agent's lifespan started `manifest_archive_sync_loop` with `steam_manifest_cache_dir` (`/steamprefill-cache`) as its source. That is one of the roots `GET /v1/steam/prefilled-apps` already enumerates, and it is static — so the loop copied **0 files every cycle for a week**, and because its success log is guarded by `if copied:` it did so in complete silence.
+
+Meanwhile the host prefill cron runs SteamPrefill with `HOME=/tmp`, so real manifests land in `steam_prefill_live_cache_dir` (`/tmp/.cache/SteamPrefill`) — a directory nothing synced, and which is lost when the agent container restarts.
+
+- **Live impact:** 11 newly-purchased Steam games (Abyssus, Astroloot, Bloody Spell, Riftstorm, Swordcery + 6 Ghost Recon titles) were fully downloaded into lancache yet never appeared in the orchestrator, because their manifests never reached a root `prefilled-apps` enumerates. Confirmed on the live agent: 62 `.bin` files were pending in the live cache with 0 of them archived; the newest archived `.bin` predated them by a week.
+- **Fixed:** the loop now watches `steam_prefill_live_cache_dir`. Regression test asserts the source *and* destination the lifespan wires up — the previous tests only asserted that a task existed, which is why the wrong directory went unnoticed.
+- **Related:** the post-prefill capture (`_capture_prefill_manifests`) already used the live dir correctly, but only fires for agent-initiated prefills; host-cron prefills bypass it entirely, leaving this loop as their only path to the archive.
+
 ### Infrastructure — ruff 0.16.2; Markdown excluded from the formatter — 2026-08-16
 
 ruff 0.16 began formatting Python code blocks embedded in Markdown, which expanded the formatter's file set from 250 to 427 and would have failed CI's Lint job on 37 documentation files. Excluding `*.md` (the opt-out Astral's formatter docs prescribe) restores the previous file set exactly.

--- a/src/orchestrator/agent/app.py
+++ b/src/orchestrator/agent/app.py
@@ -84,7 +84,16 @@ def create_agent_app(*, settings: Settings | None = None) -> FastAPI:
         if interval > 0:
             sync_task = asyncio.create_task(
                 manifest_archive_sync_loop(
-                    Path(settings.steam_manifest_cache_dir),
+                    # The LIVE cache — the dir SteamPrefill actually writes to
+                    # ($HOME/.cache/SteamPrefill; the host prefill cron runs it
+                    # with HOME=/tmp). NOT steam_manifest_cache_dir: that is a
+                    # root `prefilled-apps` already enumerates and is static, so
+                    # syncing it copied 0 files every cycle — silently, since the
+                    # success log is guarded by `if copied:`. Real manifests
+                    # accumulated unsynced in the live dir (lost on container
+                    # restart), so 11 newly-purchased games were fully cached in
+                    # lancache yet invisible to the orchestrator for days.
+                    Path(settings.steam_prefill_live_cache_dir),
                     Path(settings.steam_manifest_archive_dir),
                     interval,
                 )

--- a/tests/agent/test_app_lifespan.py
+++ b/tests/agent/test_app_lifespan.py
@@ -79,3 +79,39 @@ async def test_loop_runs_immediately(monkeypatch):
     with contextlib.suppress(asyncio.CancelledError):
         await task
     assert calls  # ran once immediately, before the first sleep
+
+
+async def test_sync_task_uses_the_live_prefill_cache_as_source(monkeypatch):
+    """The sync loop must read the dir SteamPrefill actually writes to.
+
+    Found live 2026-08-17: the lifespan started the loop with
+    `steam_manifest_cache_dir` (/steamprefill-cache) as live_root. That is one of
+    the roots `prefilled-apps` already enumerates, and it is static — so every
+    cycle copied 0 files and, because the success log is guarded by `if copied:`,
+    it did so in total silence for a week.
+
+    Meanwhile the host prefill cron runs SteamPrefill with HOME=/tmp, so real
+    manifests land in `steam_prefill_live_cache_dir` (/tmp/.cache/SteamPrefill) —
+    a dir nothing synced and which is lost on container restart. 11 newly
+    purchased games were fully downloaded into lancache yet stayed invisible to
+    the orchestrator because their manifests never reached an enumerated root.
+    """
+    captured: dict[str, object] = {}
+
+    def _fake_loop(live_root, archive_root, interval_sec, **kw):
+        captured["live_root"] = live_root
+        captured["archive_root"] = archive_root
+
+        async def _noop() -> None:
+            await asyncio.sleep(3600)
+
+        return _noop()
+
+    monkeypatch.setattr(agent_app_mod, "manifest_archive_sync_loop", _fake_loop)
+    settings = Settings(orchestrator_token=TOKEN, manifest_archive_sync_interval_sec=1800)
+    app = create_agent_app(settings=settings)
+    async with app.router.lifespan_context(app):
+        pass
+
+    assert captured["live_root"] == settings.steam_prefill_live_cache_dir
+    assert captured["archive_root"] == settings.steam_manifest_archive_dir


### PR DESCRIPTION
Third and final defect in the "11 owned games are invisible" investigation — and the one that made the first two fixes insufficient on their own.

## The bug

The agent lifespan started the archive sync with the wrong source directory:

```python
manifest_archive_sync_loop(
    Path(settings.steam_manifest_cache_dir),      # /steamprefill-cache  <- static
    Path(settings.steam_manifest_archive_dir),
    interval,
)
```

`steam_manifest_cache_dir` is a root `GET /v1/steam/prefilled-apps` **already enumerates**, and it is static. So the loop copied **0 files every cycle for a week** — and because its success log is guarded by `if copied:`, it did so in total silence.

Meanwhile the host prefill cron runs SteamPrefill with `HOME=/tmp`, so real manifests land in `steam_prefill_live_cache_dir` (`/tmp/.cache/SteamPrefill`) — a directory **nothing synced**, and which is lost when the agent container restarts.

## Live evidence

```
/steamprefill-cache/v1  4731 .bin   <- synced from; static, already in archive
/manifest-archive/v1    4751 .bin   <- newest was a week old
/tmp/.cache/.../v1        64 .bin   <- where the cron ACTUALLY writes; 62 unsynced
```

11 newly-purchased games were fully downloaded into lancache (73 min of real CDN traffic, confirmed in `cron.log`) yet never appeared in the orchestrator, because their manifests never reached a root `prefilled-apps` enumerates.

## Proven in production

Running the sync manually with the corrected source:

```
manifest_archive.synced  archive=/manifest-archive/v1 copied=62
prefilled-apps: 1149 -> 1160   (+11, exactly the missing games)
```

A subsequent `library_sync` created all 11 rows at `status='unknown'` — a sweep candidate, so they validate on the next tick. The chain now completes end to end.

## The fix

Point the loop at `steam_prefill_live_cache_dir`. `_capture_prefill_manifests` already used that directory correctly, but it only fires for **agent-initiated** prefills; host-cron prefills bypass it entirely, leaving this loop as their only path to the archive.

## Test

The regression test asserts the source **and** destination the lifespan wires up. The pre-existing tests only asserted that *a task existed* — which is precisely why the wrong directory went unnoticed.

RED watched first:
```
AssertionError: assert PosixPath('/steamprefill-cache') == PosixPath('/tmp/.cache/SteamPrefill')
```

## Verification

- Full suite: **1650 passed, 3 deselected, 0 failed**
- `ruff check`, `ruff format --check` (250 files), `mypy` strict (104 files): clean

## Deploy note

Requires an **agent redeploy** on the NAS to take effect. Until then the manual sync is the stopgap — already run once, so current state is good.

## Known follow-up (not fixed here)

`sync_task.add_done_callback(app.state.agent_bg_tasks.discard)` discards a finished task without inspecting it, so a background task that dies logs nothing. That is the deeper reason this hid for a week, and it applies to every task in `agent_bg_tasks`.

## Related

- PR #279 — `not_downloaded` sweep dead-end (second defect)
- PR #280 — ADR-0016, ownership as an explicit input (first defect, structural)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124bEEK8jGD1FugqnN6WJyV
