### PR TITLE
fix(agent): surface failures from fire-and-forget background tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — a dying agent background task logged nothing, hiding failures indefinitely — 2026-08-17
+
+Every fire-and-forget task in the agent (prefill, pull, manifest fetch, archive sync) was wired as `bg_tasks.add(task)` + `task.add_done_callback(bg_tasks.discard)`. `discard` releases the strong reference without ever inspecting the task, and asyncio only reports an unretrieved exception when the task object is garbage-collected — which for a task held in a set until it finishes means the traceback is discarded along with the reference. A task that raised simply vanished.
+
+This is the reason the manifest-archive sync silently no-oped **for a week** before anyone noticed. `db/pool.py` already guarded its own tasks with `_log_bg_task_exception`; the agent never adopted the same discipline.
+
+- **Fixed:** new `agent/background.py` with `track_background_task(task, bg_tasks)`, which holds the strong reference *and* attaches an exception-logging callback emitting `agent.background_task_failed` at error level with the task name, message and exception type. All four agent call sites now use it, so the two concerns can no longer be separated by accident — the exact way this bug arose.
+- **Cancellation is deliberately not reported as a failure:** the lifespan cancels every tracked task on shutdown/redeploy, so logging that as an error would make each normal restart look like a crash and train operators to ignore the signal.
+- Covered by four tests: a failing task logs, a successful one does not, a cancelled one does not, and the strong reference is still released when the task completes.
+
 ### Fixed — the manifest archive sync watched the wrong directory, so newly-prefilled games stayed invisible — 2026-08-17
 
 The agent's lifespan started `manifest_archive_sync_loop` with `steam_manifest_cache_dir` (`/steamprefill-cache`) as its source. That is one of the roots `GET /v1/steam/prefilled-apps` already enumerates, and it is static — so the loop copied **0 files every cycle for a week**, and because its success log is guarded by `if copied:` it did so in complete silence.

--- a/src/orchestrator/agent/app.py
+++ b/src/orchestrator/agent/app.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 import structlog
 from fastapi import FastAPI
 
+from orchestrator.agent.background import track_background_task
 from orchestrator.agent.jobs import AgentJobStore
 from orchestrator.agent.manifest_archive import manifest_archive_sync_loop
 from orchestrator.agent.routers import epic, health, manual_downloads, pull, stat, steam
@@ -99,8 +100,7 @@ def create_agent_app(*, settings: Settings | None = None) -> FastAPI:
                     interval,
                 )
             )
-            app.state.agent_bg_tasks.add(sync_task)
-            sync_task.add_done_callback(app.state.agent_bg_tasks.discard)
+            track_background_task(sync_task, app.state.agent_bg_tasks)
         try:
             yield
         finally:

--- a/src/orchestrator/agent/background.py
+++ b/src/orchestrator/agent/background.py
@@ -1,0 +1,62 @@
+"""Tracking for the agent's fire-and-forget background tasks.
+
+Every agent task (prefill, pull, manifest fetch, archive sync) was wired as::
+
+    bg_tasks.add(task)
+    task.add_done_callback(bg_tasks.discard)
+
+`discard` releases the strong reference but never inspects the task, and asyncio
+only reports an unretrieved exception when the task object is garbage-collected —
+which, for a task held in a set until it finishes, means the traceback is
+discarded along with the reference. A task that raised therefore vanished without
+a single log line.
+
+That is not a theoretical gap. The manifest archive sync loop silently no-oped
+for a week (#281); the pattern here is why nothing surfaced it. `db/pool.py`
+already guards its own tasks with `_log_bg_task_exception` — the agent simply
+never adopted the same discipline.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+if TYPE_CHECKING:  # asyncio is referenced only in annotations
+    import asyncio
+
+_log = structlog.get_logger(__name__)
+
+
+def _log_task_exception(task: asyncio.Task[Any]) -> None:
+    """Surface an unhandled exception from a fire-and-forget agent task.
+
+    Cancellation is excluded deliberately: the lifespan cancels every tracked
+    task on shutdown/redeploy, so reporting that as an error would make each
+    normal restart look like a crash and train the operator to ignore exactly
+    the signal this exists to provide.
+    """
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        _log.error(
+            "agent.background_task_failed",
+            task_name=task.get_name(),
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+
+
+def track_background_task(task: asyncio.Task[Any], bg_tasks: set[asyncio.Task[Any]]) -> None:
+    """Hold a strong reference to ``task`` until it finishes, and log if it dies.
+
+    The strong reference is required: asyncio only keeps a weak reference to a
+    running task, so an untracked fire-and-forget task can be garbage-collected
+    mid-flight. Both concerns belong together — the whole class of bug this fixes
+    came from doing the first and forgetting the second.
+    """
+    bg_tasks.add(task)
+    task.add_done_callback(bg_tasks.discard)
+    task.add_done_callback(_log_task_exception)

--- a/src/orchestrator/agent/routers/pull.py
+++ b/src/orchestrator/agent/routers/pull.py
@@ -10,6 +10,7 @@ import structlog
 from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel, ConfigDict
 
+from orchestrator.agent.background import track_background_task
 from orchestrator.agent.puller import ChunkSpec, pull_chunks
 
 _log = structlog.get_logger(__name__)
@@ -95,8 +96,7 @@ async def start_pull(body: PullRequest, request: Request) -> dict[str, str]:
     # (mirrors db/pool.py's background-task set + discard-on-done pattern).
     bg_tasks = request.app.state.agent_bg_tasks
     task = asyncio.create_task(_run())
-    bg_tasks.add(task)
-    task.add_done_callback(bg_tasks.discard)
+    track_background_task(task, bg_tasks)
     return {"job_id": job_id}
 
 

--- a/src/orchestrator/agent/routers/steam.py
+++ b/src/orchestrator/agent/routers/steam.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel, ConfigDict, Field
 
 from orchestrator.agent._paths import under_cache_root
+from orchestrator.agent.background import track_background_task
 from orchestrator.agent.manifest_archive import sync_manifests_to_archive
 from orchestrator.agent.manifest_locator import list_prefilled_app_ids, locate_manifest_bins
 from orchestrator.agent.manifest_parser import parse_chunk_shas, parse_shas
@@ -150,8 +151,7 @@ async def start_prefill(body: SteamPrefillRequest, request: Request) -> dict[str
     # (mirrors the /v1/pull background-task set + discard-on-done pattern).
     bg_tasks = request.app.state.agent_bg_tasks
     task = asyncio.create_task(_run())
-    bg_tasks.add(task)
-    task.add_done_callback(bg_tasks.discard)
+    track_background_task(task, bg_tasks)
     return {"job_id": job_id}
 
 
@@ -249,8 +249,7 @@ async def start_fetch_manifests(request: Request) -> dict[str, str]:
 
     bg_tasks = request.app.state.agent_bg_tasks
     task = asyncio.create_task(_run())
-    bg_tasks.add(task)
-    task.add_done_callback(bg_tasks.discard)
+    track_background_task(task, bg_tasks)
     return {"job_id": job_id}
 
 

--- a/tests/agent/test_background.py
+++ b/tests/agent/test_background.py
@@ -1,0 +1,97 @@
+"""A fire-and-forget agent task that dies must say so.
+
+Every agent background task was wired as::
+
+    bg_tasks.add(task)
+    task.add_done_callback(bg_tasks.discard)
+
+`discard` drops the reference without ever inspecting the task, and asyncio does
+not surface an exception nobody retrieves from a task that is still referenced —
+so a task that raised simply vanished. That is not hypothetical: the manifest
+archive sync loop no-oped for a week (#281) with nothing in the logs, and this
+pattern is why nobody could see it.
+
+`db/pool.py` already got this right (`_log_bg_task_exception`); the agent never
+adopted it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+import structlog
+
+from orchestrator.agent.background import track_background_task
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_a_failing_background_task_is_logged():
+    bg: set[asyncio.Task] = set()
+
+    async def _boom() -> None:
+        raise RuntimeError("archive sync exploded")
+
+    with structlog.testing.capture_logs() as logs:
+        task = asyncio.create_task(_boom())
+        track_background_task(task, bg)
+        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.sleep(0)  # let done-callbacks run
+
+    failures = [m for m in logs if m.get("event") == "agent.background_task_failed"]
+    assert failures, "a background task died with no log line — the silent failure"
+    assert failures[0]["log_level"] == "error"
+    assert "archive sync exploded" in failures[0]["error"]
+    assert failures[0]["error_type"] == "RuntimeError"
+
+
+async def test_a_successful_background_task_logs_nothing():
+    bg: set[asyncio.Task] = set()
+
+    async def _fine() -> None:
+        return None
+
+    with structlog.testing.capture_logs() as logs:
+        task = asyncio.create_task(_fine())
+        track_background_task(task, bg)
+        await task
+        await asyncio.sleep(0)
+
+    assert not [m for m in logs if m.get("event") == "agent.background_task_failed"]
+
+
+async def test_a_cancelled_background_task_is_not_reported_as_a_failure():
+    """Shutdown cancels every tracked task; that is normal, not a fault. Logging
+    it as an error would make every redeploy look like a crash and train the
+    operator to ignore the very signal this exists to provide."""
+    bg: set[asyncio.Task] = set()
+
+    async def _forever() -> None:
+        await asyncio.sleep(3600)
+
+    with structlog.testing.capture_logs() as logs:
+        task = asyncio.create_task(_forever())
+        track_background_task(task, bg)
+        await asyncio.sleep(0)
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.sleep(0)
+
+    assert not [m for m in logs if m.get("event") == "agent.background_task_failed"]
+
+
+async def test_the_task_reference_is_still_released():
+    """The original reason for the callback — dropping the strong reference so
+    the set does not grow forever — must survive."""
+    bg: set[asyncio.Task] = set()
+
+    async def _fine() -> None:
+        return None
+
+    task = asyncio.create_task(_fine())
+    track_background_task(task, bg)
+    assert task in bg, "task must be held while in flight, or it can be GC'd mid-run"
+    await task
+    await asyncio.sleep(0)
+    assert task not in bg, "finished task was never released"


### PR DESCRIPTION
The pattern that let a broken background job hide for a week.

## The bug

Every fire-and-forget task in the agent — prefill, pull, manifest fetch, archive sync — was wired as:

```python
bg_tasks.add(task)
task.add_done_callback(bg_tasks.discard)
```

`discard` releases the strong reference but **never inspects the task**. asyncio only reports an unretrieved exception when the task object is garbage-collected, so for a task held in a set until it finishes, the traceback is discarded along with the reference. A task that raised simply vanished — no log, no metric, nothing.

## Why it matters

This is precisely why the manifest-archive sync loop silently no-oped **for a week** (#281). It was pointed at a static directory, copied 0 files every cycle, and its only success log was guarded by `if copied:` — so between that and this pattern, there was no observable difference between "working" and "dead".

`db/pool.py` already got this right (`_log_bg_task_exception` alongside `discard`). The agent never adopted the same discipline.

## The fix

New `agent/background.py`:

```python
def track_background_task(task, bg_tasks) -> None:
    bg_tasks.add(task)
    task.add_done_callback(bg_tasks.discard)
    task.add_done_callback(_log_task_exception)
```

Emits `agent.background_task_failed` at **error** level with task name, message and exception type. All four agent call sites (`app.py`, `routers/steam.py` x2, `routers/pull.py`) now use it, so the strong-reference and the failure-logging concerns **cannot be separated by accident** — which is exactly how this arose.

**Cancellation is deliberately not a failure.** The lifespan cancels every tracked task on shutdown/redeploy; reporting that as an error would make every normal restart look like a crash and train operators to ignore the signal this exists to provide.

## Alternatives rejected

- **A second `add_done_callback` at each site** — preserves the pattern that caused the bug; the next task added would forget again.
- **Exporting `db/pool.py`'s helper** — module-private, `pool.`-prefixed events, and it would couple the agent to the DB layer.
- **Refactoring `pool.py` onto the shared helper** — scope creep. It already behaves correctly and is load-bearing.

## Tests

Four, all watched RED first (initial failure was `ModuleNotFoundError`):
- a failing task logs at error with the right message and type
- a successful task logs nothing
- a **cancelled** task logs nothing
- the strong reference is still released once the task completes — the original purpose of the callback must survive

## Verification

- **1674 passed, 3 deselected, 0 failed**
- `ruff check`, `ruff format --check` (252 files), `mypy` strict (105 files): clean

## Deploy

Agent-only change — the NAS agent needs a redeploy; the LXC control plane does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124bEEK8jGD1FugqnN6WJyV
