### PR TITLE
fix(steam): scan the archive for .bin manifests in the fetcher durability net

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — the manifest fetcher's recently-purchased safety net looked in the wrong directory — 2026-08-17
+
+`_enumerate_app_ids` covers apps prefilled *outside* `selectedAppsToPrefill.json` by taking (has `.bin`) minus (has `.shas`) — a net added by the #213 follow-up specifically so a `--recently-purchased` game still gets its `.shas` sidecar. It read the `.bin` only from `steam_manifest_cache_dir`, but the agent's archive-sync loop writes newly-prefilled manifests to `steam_manifest_archive_dir`. The net that exists precisely for those games therefore never saw them.
+
+- **Confirmed live 2026-08-17:** all 11 newly-purchased Steam games had their `.bin` in the archive and **zero** in the manifest cache, so none was ever a fetch candidate.
+- **Fixed:** the `.bin` scan now unions both roots. The `.shas` side is unchanged, so the delta stays bounded and a run still cannot trigger a full-library DepotDownloader logon burst (#228).
+- **Impact was latent, not active:** those games validate correctly from the archived `.bin`, so nothing was broken — the sidecar coverage simply never materialised. Same directory-mismatch shape as the archive-sync defect fixed earlier the same day.
+
 ### Fixed — a dying agent background task logged nothing, hiding failures indefinitely — 2026-08-17
 
 Every fire-and-forget task in the agent (prefill, pull, manifest fetch, archive sync) was wired as `bg_tasks.add(task)` + `task.add_done_callback(bg_tasks.discard)`. `discard` releases the strong reference without ever inspecting the task, and asyncio only reports an unretrieved exception when the task object is garbage-collected — which for a task held in a set until it finishes means the traceback is discarded along with the reference. A task that raised simply vanished.

--- a/src/orchestrator/platform/steam/manifest_fetcher.py
+++ b/src/orchestrator/platform/steam/manifest_fetcher.py
@@ -128,10 +128,19 @@ class DepotDownloaderManifestFetcher:
             except (TypeError, ValueError):
                 continue
         # Durability (#213 follow-up): also cover apps prefilled OUTSIDE the
-        # selection — a `.bin` in the live cache with no `.shas` in the archive yet
-        # (e.g. a `--recently-purchased` game). Bounded to that delta so the first
-        # run never triggers a full-library DepotDownloader logon burst (#228).
-        have_bin = self._app_ids_with_ext(self._manifest_cache_dir, "bin")
+        # selection — a `.bin` with no `.shas` yet (e.g. a `--recently-purchased`
+        # game). Bounded to that delta so the first run never triggers a
+        # full-library DepotDownloader logon burst (#228).
+        #
+        # Look for the `.bin` in BOTH roots. It was previously read only from the
+        # manifest cache dir, but the agent's archive-sync loop writes
+        # newly-prefilled manifests to the ARCHIVE — so the net that exists
+        # precisely for recently-purchased games never saw them. Confirmed live
+        # 2026-08-17: 11 newly-purchased games had their `.bin` in the archive and
+        # zero in the manifest cache.
+        have_bin = self._app_ids_with_ext(self._manifest_cache_dir, "bin") | self._app_ids_with_ext(
+            self._archive_dir, "bin"
+        )
         have_shas = self._app_ids_with_ext(self._archive_dir, "shas")
         return sorted(apps | (have_bin - have_shas))
 

--- a/tests/platform/steam/test_manifest_fetcher.py
+++ b/tests/platform/steam/test_manifest_fetcher.py
@@ -386,3 +386,44 @@ def test_enumerate_selection_only_when_no_cache_dir(tmp_path):
         manifest_cache_dir=None,
     )
     assert f._enumerate_app_ids() == [111]
+
+
+def test_enumerate_covers_a_prefilled_app_whose_bin_is_in_the_archive(tmp_path):
+    """The durability net must see manifests wherever prefill actually puts them.
+
+    Its stated purpose (#213 follow-up) is to cover apps prefilled OUTSIDE the
+    selection — e.g. a `--recently-purchased` game — by taking (has .bin) minus
+    (has .shas). But it read `.bin` only from steam_manifest_cache_dir, while the
+    agent's archive-sync loop writes newly-prefilled manifests to
+    steam_manifest_archive_dir. Confirmed live 2026-08-17: 11 newly-purchased
+    games had their `.bin` in the archive and ZERO in the manifest cache, so the
+    net that exists precisely for them never saw them.
+    """
+    cfg = tmp_path / "Config"
+    cfg.mkdir()
+    (cfg / "selectedAppsToPrefill.json").write_text(json.dumps([111]))
+
+    archive = tmp_path / "archive"
+    (archive / "v1").mkdir(parents=True)
+    # A recently-purchased game: prefilled (its .bin was archived), no .shas yet.
+    (archive / "v1" / "2282790_2282790_2282791_777.bin").write_bytes(b"m")
+
+    f = _fetcher(tmp_path, steam_config_dir=cfg, archive_dir=archive)
+    assert f._enumerate_app_ids() == [111, 2282790]
+
+
+def test_enumerate_does_not_refetch_an_app_that_already_has_shas(tmp_path):
+    """The net is (has .bin) MINUS (has .shas) — an app already covered must not
+    be re-fetched, or every run would trigger a needless DepotDownloader logon
+    burst (#228)."""
+    cfg = tmp_path / "Config"
+    cfg.mkdir()
+    (cfg / "selectedAppsToPrefill.json").write_text(json.dumps([]))
+
+    archive = tmp_path / "archive"
+    (archive / "v1").mkdir(parents=True)
+    (archive / "v1" / "2282790_2282790_2282791_777.bin").write_bytes(b"m")
+    (archive / "v1" / "2282790_2282790_2282791_777.shas").write_text("a" * 40 + "\n")
+
+    f = _fetcher(tmp_path, steam_config_dir=cfg, archive_dir=archive)
+    assert f._enumerate_app_ids() == []


### PR DESCRIPTION
The recently-purchased safety net was looking in the wrong directory, so it never saw a single recently-purchased game.

## The bug

`_enumerate_app_ids` covers apps prefilled **outside** `selectedAppsToPrefill.json` by taking (has `.bin`) minus (has `.shas`). That net was added by the #213 follow-up **specifically** so a `--recently-purchased` game still gets its `.shas` sidecar — its own comment says so:

```python
# Durability (#213 follow-up): also cover apps prefilled OUTSIDE the
# selection — a `.bin` ... with no `.shas` in the archive yet
# (e.g. a `--recently-purchased` game).
have_bin = self._app_ids_with_ext(self._manifest_cache_dir, "bin")   # <- wrong root
```

It reads the `.bin` only from `steam_manifest_cache_dir`. The agent's archive-sync loop writes newly-prefilled manifests to `steam_manifest_archive_dir`. So the net built for those games structurally could not see them.

## Confirmed live

All 11 newly-purchased Steam games, checked on the running agent:

```
app 2282790: steamprefill-cache.bin=0   archive.bin=1   archive.shas=0
app 460930:  steamprefill-cache.bin=0   archive.bin=9   archive.shas=0
app 1721110: steamprefill-cache.bin=0   archive.bin=1   archive.shas=0
```

Zero in the manifest cache, present in the archive, no `.shas`. None was ever a fetch candidate.

## The fix

The `.bin` scan now unions both roots. The `.shas` side is unchanged, so the delta stays bounded and a run still cannot trigger a full-library DepotDownloader logon burst (#228).

## Impact — latent, not active

Those games validate correctly from the archived `.bin`, so **nothing was broken**; the sidecar coverage simply never materialised. Worth fixing because `.shas` is the independent coverage path that survives `.bin` pruning.

This is the same directory-mismatch shape as the archive-sync defect fixed earlier today (#281) — two independent bugs, one root cause: manifests move between three directories and different consumers assume different ones.

## Tests

2 added, RED watched first (`Right contains one more item: 2282790`):
- an app whose `.bin` is in the archive **is** enumerated
- an app that already has `.shas` is **not** re-fetched — the delta must stay bounded

**1676 passed**, 3 deselected; `ruff check`, `ruff format --check` (252 files), `mypy` strict (105 files) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124bEEK8jGD1FugqnN6WJyV
