### PR TITLE
UAT-14 follow-ups: archive temp freshness (without breaking manifest selection) + shared template counter

### DIFF
--- a/src/orchestrator/agent/manifest_archive.py
+++ b/src/orchestrator/agent/manifest_archive.py
@@ -85,8 +85,28 @@ def sync_manifests_to_archive(
             # atomic within a filesystem, so the final name only ever refers to a
             # complete file — no reader can observe a half-written manifest, and a
             # crash mid-copy leaves the archive untouched rather than poisoned.
+            src_stat = src.stat()
             shutil.copy2(src, tmp)
-            os.replace(tmp, archive_v1 / src.name)
+
+            # Two mtimes to satisfy, and they pull in opposite directions.
+            #
+            # IN FLIGHT the temp must look NEW. copy2 runs copystat, so it inherits
+            # the source's mtime — and a manifest only becomes eligible to copy once
+            # it is older than the settle window, so the temp is born looking stale.
+            # A concurrent sweep would see an orphan and unlink it mid-rename.
+            #
+            # ARCHIVED it must keep the SOURCE's mtime. manifest_locator picks the
+            # manifest to validate against with max(..., key=st_mtime) — newest
+            # wins — so re-stamping the archive would change which version validate
+            # compares against, which is the false-Partial bug class (UAT-13 F2).
+            #
+            # So: stamp the temp to now, rename, then restore the source's mtime on
+            # the archived file.
+            os.utime(tmp)
+            dest = archive_v1 / src.name
+            os.replace(tmp, dest)
+            with contextlib.suppress(OSError):
+                os.utime(dest, (src_stat.st_atime, src_stat.st_mtime))
             copied += 1
         except OSError as e:
             # Remove the stub so the next sync is free to retry.

--- a/tests/agent/test_manifest_archive_atomicity.py
+++ b/tests/agent/test_manifest_archive_atomicity.py
@@ -188,3 +188,66 @@ def test_a_stale_partial_from_a_killed_process_is_swept_up(tmp_path: Path) -> No
         "a just-created .partial may belong to a concurrent copy — deleting it would "
         "reintroduce the truncation race the unique names exist to prevent"
     )
+
+
+def test_the_temp_file_is_not_stale_when_it_is_renamed(tmp_path: Path) -> None:
+    """shutil.copy2 back-dates the temp file, which makes the sweep able to eat it.
+
+    copy2 runs copystat, so the temp inherits the SOURCE's mtime — and manifests are
+    deliberately backdated past the settle window before they are eligible to copy.
+    The temp is therefore born looking hours old. For the one statement between copy2
+    returning and os.replace, a concurrent sweep sees a stale .partial and unlinks it;
+    os.replace then raises FileNotFoundError and the copy is lost for that cycle.
+
+    Benign — the except OSError catches it and the next sync retries, nothing is
+    truncated — but avoidable: stamp the temp to now before renaming, so it can never
+    look stale while it is in use.
+
+    Asserted at the moment that matters, by inspecting the temp's age from inside
+    os.replace.
+    """
+    live, archive = tmp_path / "live", tmp_path / "archive"
+    # Aged well past the sweep threshold, exactly as a real settled manifest is.
+    _live_manifest(live, "app.bin", b"content", age_seconds=7200)
+
+    ages: list[float] = []
+    real_replace = os.replace
+
+    def spy(src, dst, *a, **kw):
+        ages.append(time.time() - os.stat(src).st_mtime)
+        return real_replace(src, dst, *a, **kw)
+
+    with mock.patch.object(os, "replace", spy):
+        sync_manifests_to_archive(live, archive)
+
+    assert ages, "no rename happened"
+    assert ages[0] < 60, (
+        f"the temp file was {ages[0]:.0f}s old at rename time — a concurrent sweep "
+        "would treat it as an orphan and unlink it mid-flight"
+    )
+
+
+def test_the_archived_file_keeps_the_sources_mtime(tmp_path: Path) -> None:
+    """Preserving mtime is load-bearing, not cosmetic.
+
+    manifest_locator picks which manifest to validate against with
+    `max(pool, key=lambda p: p.stat().st_mtime)` — newest wins. Stamping archived
+    files to "now" would make every freshly-synced manifest the newest, changing
+    which version validate compares against. That is the false-Partial bug class
+    (UAT-13 F2), so the mtime the archive carries must remain the source's.
+
+    This is the constraint that makes the in-flight freshness fix non-trivial: the
+    TEMP must look new so the sweep spares it, while the ARCHIVED file must look old.
+    """
+    live, archive = tmp_path / "live", tmp_path / "archive"
+    src = _live_manifest(live, "app.bin", b"content", age_seconds=7200)
+    src_mtime = os.stat(src).st_mtime
+
+    sync_manifests_to_archive(live, archive)
+
+    archived_mtime = os.stat(archive / "v1" / "app.bin").st_mtime
+    assert abs(archived_mtime - src_mtime) < 2, (
+        f"archived mtime {archived_mtime} should track the source's {src_mtime}. "
+        "manifest_locator selects the NEWEST manifest by mtime, so re-stamping the "
+        "archive changes which version validate uses."
+    )

--- a/tests/scripts/test_uat_template_renders_progress.py
+++ b/tests/scripts/test_uat_template_renders_progress.py
@@ -1,0 +1,63 @@
+"""The shared UAT template must show a real progress count on load.
+
+UAT-14. `updateProgress()` was called only from `setResult`, so a correctly generated
+page kept the static `0 / 0 completed` in its markup until the tester clicked
+something. That is indistinguishable from the generator fault that produced session
+14's v1 — a page whose JavaScript died and rendered no scenarios at all, which
+presented as headings plus `0 / 0`. The operator's report then was "The test session
+html does not have any test instructions in it at all", and a page that looks broken
+gets abandoned before anyone checks whether it is.
+
+HONEST SCOPE: this is a structural assertion on a template, not a rendering test. It
+checks the load path calls the counter refresh; it cannot prove what a browser paints.
+Rendering was verified once by hand with jsdom when session 14's copy was fixed
+(10 scenario blocks, steps visible, `0 / 10 completed`). Pinning it here stops the
+shared template silently regressing for every future session.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE = PROJECT_ROOT / "tests" / "uat" / "templates" / "test-session-template.html"
+
+
+def _script_body(html: str) -> str:
+    match = re.search(r"<script[^>]*>(.*?)</script>", html, re.S)
+    assert match is not None, "the template has no <script> block"
+    return match.group(1)
+
+
+def test_the_template_exists() -> None:
+    assert TEMPLATE.is_file(), f"missing shared UAT template at {TEMPLATE}"
+
+
+def test_the_counter_is_refreshed_at_load_not_only_on_a_click() -> None:
+    body = _script_body(TEMPLATE.read_text())
+
+    # Strip function bodies' worth of indentation: a top-level call sits in column 0,
+    # while the call inside setResult() is indented. That distinction is the whole
+    # point — the indented one fires on a click, which is too late.
+    top_level = [ln for ln in body.splitlines() if ln.startswith("updateProgress()")]
+
+    assert top_level, (
+        "updateProgress() is never called at load, so the header keeps its static "
+        "'0 / 0 completed' until the tester clicks a result — the same thing a page "
+        "whose JavaScript died looks like, which is how a working checklist gets "
+        "mistaken for a broken one."
+    )
+
+
+def test_the_load_refresh_runs_after_the_scenarios_are_rendered() -> None:
+    """Order matters: counting before rendering would report 0 of 0 regardless."""
+    body = _script_body(TEMPLATE.read_text())
+    lines = body.splitlines()
+
+    render = next((i for i, ln in enumerate(lines) if ln.startswith("renderScenarios()")), None)
+    refresh = next((i for i, ln in enumerate(lines) if ln.startswith("updateProgress()")), None)
+
+    assert render is not None, "renderScenarios() is not called at load"
+    assert refresh is not None, "updateProgress() is not called at load"
+    assert refresh > render, "the counter must be refreshed AFTER the scenarios render"

--- a/tests/uat/templates/test-session-template.html
+++ b/tests/uat/templates/test-session-template.html
@@ -271,6 +271,11 @@ function exportResults() {
 }
 
 renderScenarios();
+// Refresh the counter at LOAD, not only from setResult(). Without this the
+// header keeps its static '0 / 0 completed' until the tester clicks a result —
+// which is exactly what a page whose JavaScript died looks like, and is how a
+// perfectly good checklist gets mistaken for a broken one (UAT-14).
+updateProgress();
 </script>
 </body>
 </html>


### PR DESCRIPTION
The two follow-ups the PR #300 adversarial review flagged as optional. One of them hid a real trap.

## 1. The archive temp file looked stale the moment it was created

`shutil.copy2` runs `copystat`, so the temp inherits the **source's** mtime — and a manifest only becomes eligible to copy once it is older than the settle window. The temp is therefore born looking hours old. For the single statement between `copy2` returning and `os.replace`, a concurrent sweep sees an orphan and unlinks it; the rename then raises `FileNotFoundError`, the `except OSError` catches it, and one copy is lost until the next cycle.

Benign — the reviewer said so, and nothing is truncated — but avoidable.

**The obvious fix is wrong, and I wrote it before catching it.** `os.replace` carries the temp's mtime onto the destination, and `manifest_locator.py:94` selects the manifest to validate against with `max(pool, key=st_mtime)` — **newest wins**. Re-stamping the archive would make every freshly-synced manifest the newest and change which version validate compares against: the false-Partial bug class from UAT-13 F2. My first attempt's comment asserted *"the archived file's mtime comes from the rename target anyway"*, which is exactly backwards, and the test written against that claim went red immediately.

So there are two mtimes pulling in opposite directions:

| | requirement | why |
|---|---|---|
| **temp, in flight** | must look **new** | so a concurrent sweep spares it |
| **archived file** | must keep the **source's** mtime | so manifest selection is unchanged |

Stamp the temp, rename, then restore the source's mtime on the destination. Both properties have their own test, and the preservation test is the one that caught the error.

## 2. The shared UAT template never refreshed its progress counter on load

`updateProgress()` was called only from `setResult()`, so a correctly generated page kept the static `0 / 0 completed` until the tester clicked something — indistinguishable from the generator fault that produced session 14's v1, a page whose JavaScript died and rendered nothing at all. That fault's symptom in the Pantheon project drew the report *"The test session html does not have any test instructions in it at all"*, and a page that looks broken gets abandoned before anyone checks whether it is.

Session 14's own copy was fixed at the time; the shared template was not, so every future session would have inherited it.

Its test is a structural assertion on a template rather than a rendering test, and **says so in its docstring**: it checks the load path calls the refresh and that the refresh runs *after* the scenarios render. Rendering itself was verified once by hand with jsdom (10 scenario blocks, steps visible, `0 / 10 completed`).

## Tests

4 new, each observed failing first. **1778 passed**, 3 deselected. ruff, format and mypy clean across 108 files.

## Not deployed

Neither change is live. Both are safe to deploy with whatever ships next — the archive one only narrows an already-benign race, and the template one affects generated test pages, not the running service.
