### PR TITLE
Remove the archive temp race properly, and stop swallowing a failed mtime restore

### DIFF
--- a/src/orchestrator/agent/manifest_archive.py
+++ b/src/orchestrator/agent/manifest_archive.py
@@ -31,10 +31,12 @@ def sync_manifests_to_archive(
 ) -> int:
     """Copy .bin files present in live/v1 but not archive/v1 (append-only).
 
-    Preserves mtime (shutil.copy2), skips files written within ``settle_seconds``
-    (may be mid-write — picked up next cycle), never deletes from the archive, and
-    isolates per-file errors. Returns the number copied. A missing live dir or an
-    unwritable archive is a no-op returning 0."""
+    Copies with ``shutil.copyfile`` and then restores the source's mtime on the
+    archived file — NOT ``copy2``, whose ``copystat`` would hand back a temp already
+    carrying the source's stale mtime and let the orphan sweep unlink it mid-flight.
+    Skips files written within ``settle_seconds`` (may be mid-write — picked up next
+    cycle), never deletes from the archive, and isolates per-file errors. Returns the
+    number copied. A missing live dir or an unwritable archive is a no-op returning 0."""
     live_v1 = live_root / "v1"
     if not live_v1.is_dir():
         return 0
@@ -103,6 +105,27 @@ def sync_manifests_to_archive(
             # — so an archived file stamped "now" would outrank its siblings and
             # change which version validate compares against: the false-Partial bug
             # class (UAT-13 F2).
+            #
+            # RESIDUAL WINDOW, measured at ~9us: between the rename and the restore
+            # the archived file carries the temp's fresh mtime, so a locator call
+            # landing in that instant can pick it over a genuinely newer sibling.
+            # Reaching it needs all of: this sync archiving a manifest that is NOT
+            # its depot's newest (first backlog sync or a post-wipe heal — steady
+            # state archives the newest anyway), a concurrent validate statting that
+            # depot inside the window, and no prefilled_gids pin (#209 pins
+            # agent-prefilled runs). Cost is one wrong verdict for one game,
+            # corrected within 6h by the sweep. Stamping the temp with the source's
+            # times just before the rename would close it but reopen the
+            # sweep-eats-the-temp window instead — that failure is loud and benign
+            # (ENOENT -> copy_failed -> retried) where this one is silent, so it is
+            # arguably the better trade if this window ever proves reachable.
+            #
+            # NFS CAVEAT: the freshness argument above assumes one clock. On NFS the
+            # temp's mtime comes from the server while the sweep compares against the
+            # client's time.time(), so a server running >60s behind would make every
+            # in-flight temp look stale and the archive would never grow (loudly —
+            # copy_failed every cycle). Not the current deployment: the archive is a
+            # local named volume written only by this agent.
             shutil.copyfile(src, tmp)
             dest = archive_v1 / src.name
             os.replace(tmp, dest)

--- a/src/orchestrator/agent/manifest_archive.py
+++ b/src/orchestrator/agent/manifest_archive.py
@@ -86,27 +86,38 @@ def sync_manifests_to_archive(
             # complete file — no reader can observe a half-written manifest, and a
             # crash mid-copy leaves the archive untouched rather than poisoned.
             src_stat = src.stat()
-            shutil.copy2(src, tmp)
 
-            # Two mtimes to satisfy, and they pull in opposite directions.
+            # Two mtimes to satisfy, pulling in opposite directions.
             #
-            # IN FLIGHT the temp must look NEW. copy2 runs copystat, so it inherits
-            # the source's mtime — and a manifest only becomes eligible to copy once
-            # it is older than the settle window, so the temp is born looking stale.
-            # A concurrent sweep would see an orphan and unlink it mid-rename.
+            # IN FLIGHT the temp must look NEW, or the orphan sweep above unlinks it
+            # mid-copy. copyfile — NOT copy2 — because copystat is copy2's last act,
+            # so copy2 hands back a temp already carrying the source's mtime, and a
+            # manifest is only eligible to copy once it is older than the settle
+            # window. Stamping it fresh afterwards merely moves the exposure into the
+            # gap before the stamp; copyfile leaves the temp's mtime as its own write
+            # time, fresh from the first byte and refreshed by every write during a
+            # slow NFS copy.
             #
             # ARCHIVED it must keep the SOURCE's mtime. manifest_locator picks the
-            # manifest to validate against with max(..., key=st_mtime) — newest
-            # wins — so re-stamping the archive would change which version validate
-            # compares against, which is the false-Partial bug class (UAT-13 F2).
-            #
-            # So: stamp the temp to now, rename, then restore the source's mtime on
-            # the archived file.
-            os.utime(tmp)
+            # manifest to validate against with max(..., key=st_mtime) — newest wins
+            # — so an archived file stamped "now" would outrank its siblings and
+            # change which version validate compares against: the false-Partial bug
+            # class (UAT-13 F2).
+            shutil.copyfile(src, tmp)
             dest = archive_v1 / src.name
             os.replace(tmp, dest)
-            with contextlib.suppress(OSError):
+            try:
                 os.utime(dest, (src_stat.st_atime, src_stat.st_mtime))
+            except OSError as e:
+                # NOT suppressed. If this fails the archived manifest keeps the fresh
+                # mtime permanently and outranks every sibling for selection until a
+                # newer one lands — silently. The file's contents are correct, so
+                # this is a warning rather than a failure, but it must be visible.
+                _log.warning(
+                    "manifest_archive.mtime_restore_failed",
+                    bin=src.name,
+                    reason=f"{type(e).__name__}: {e}"[:200],
+                )
             copied += 1
         except OSError as e:
             # Remove the stub so the next sync is free to retry.

--- a/tests/agent/test_manifest_archive.py
+++ b/tests/agent/test_manifest_archive.py
@@ -52,14 +52,19 @@ def test_tolerates_unreadable_file(tmp_path, monkeypatch):
     live, arch = tmp_path / "live", tmp_path / "arch"
     _bin(live, "1_1_2_3.bin")
     _bin(live, "4_4_5_6.bin")
-    real = mod.shutil.copy2
+    # copyfile, not copy2: the sync stopped using copy2 because copystat is its last
+    # act, which handed back a temp already carrying the source's stale mtime and let
+    # the orphan sweep unlink it mid-flight. Patching copy2 here would simulate a
+    # failure that can no longer happen, and this test would pass while proving
+    # nothing.
+    real = mod.shutil.copyfile
 
     def flaky(src, dst, *a, **k):
         if Path(src).name == "1_1_2_3.bin":
             raise OSError("boom")
         return real(src, dst, *a, **k)
 
-    monkeypatch.setattr(mod.shutil, "copy2", flaky)
+    monkeypatch.setattr(mod.shutil, "copyfile", flaky)
     assert sync_manifests_to_archive(live, arch) == 1  # the good one still copied
 
 

--- a/tests/agent/test_manifest_archive_atomicity.py
+++ b/tests/agent/test_manifest_archive_atomicity.py
@@ -101,9 +101,13 @@ def test_a_failed_copy_leaves_nothing_behind(tmp_path: Path) -> None:
     """A failed copy leaves the archive unchanged, with no stub blocking a retry.
 
     HONEST SCOPE: with an unreadable source the copy fails before it creates
-    anything, so this passes against the old implementation as well. It is kept as a
-    guard on the new one — the temp file must be cleaned up on any error path, or a
-    disk-full mid-copy would leave .partial files behind forever.
+    anything, so no temp ever exists and this passes against every version of the
+    implementation. It does NOT guard the cleanup in the except handler, despite an
+    earlier version of this note claiming it did — deleting `tmp.unlink()` left the
+    whole suite green until round 5 of review caught it. The real guard is
+    test_a_copy_that_fails_after_creating_the_temp_cleans_it_up, which fails the
+    copy AFTER the temp is on disk. What this one still pins is that a failure
+    before any write leaves the archive untouched.
     """
     live, archive = tmp_path / "live", tmp_path / "archive"
     src = _live_manifest(live, "app.bin", b"content")
@@ -204,8 +208,14 @@ def test_the_temp_file_is_not_stale_when_it_is_renamed(tmp_path: Path) -> None:
     os.replace then raises FileNotFoundError and the copy is lost for that cycle.
 
     Benign — the except OSError catches it and the next sync retries, nothing is
-    truncated — but avoidable: stamp the temp to now before renaming, so it can never
-    look stale while it is in use.
+    truncated.
+
+    NOTE: this docstring used to recommend stamping the temp to now before renaming
+    "so it can never look stale while it is in use". That was wrong and PR #302
+    disproved it: copystat is copy2's LAST act, so the stamp merely moved the
+    exposure into the gap before itself, exactly as wide. The fix was to drop copy2
+    for copyfile, which leaves the temp fresh from its first byte. See
+    test_the_temp_is_never_stale_at_any_point, which asserts the stronger property.
 
     Asserted at the moment that matters, by inspecting the temp's age from inside
     os.replace.
@@ -339,4 +349,38 @@ def test_a_failed_mtime_restore_is_logged_not_swallowed(tmp_path: Path) -> None:
     assert any("mtime_restore_failed" in str(entry.get("event", "")) for entry in logs), (
         "a failed restore leaves the archived manifest permanently outranking its "
         f"siblings for validation. It must say so. Logged: {[e.get('event') for e in logs]}"
+    )
+
+
+def test_a_copy_that_fails_after_creating_the_temp_cleans_it_up(tmp_path: Path) -> None:
+    """The error path must unlink a temp that actually exists.
+
+    Every other failure test in this file raises BEFORE the temp is created — a
+    chmod-000 source and a spy that throws on entry both fail at open. So none of
+    them exercises `tmp.unlink()` in the except handler, and deleting that line
+    leaves the whole archive suite green. Round 5 of review caught the disclosure on
+    test_a_failed_copy_leaves_nothing_behind claiming otherwise.
+
+    This simulates the real shape: a disk filling mid-write, where the temp is on
+    disk and partially written when the error lands.
+    """
+    live, archive = tmp_path / "live", tmp_path / "archive"
+    _live_manifest(live, "app.bin", b"content")
+    (archive / "v1").mkdir(parents=True)
+
+    real_copyfile = shutil.copyfile
+
+    def fail_after_creating(src, dst, *a, **kw):
+        real_copyfile(src, dst, *a, **kw)  # the temp now exists on disk
+        raise OSError(28, "No space left on device")
+
+    with mock.patch.object(shutil, "copyfile", fail_after_creating):
+        copied = sync_manifests_to_archive(live, archive)
+
+    assert copied == 0
+    leftovers = [p.name for p in (archive / "v1").iterdir()]
+    assert leftovers == [], (
+        f"the temp survived a mid-copy failure: {leftovers}. Without cleanup these "
+        "accumulate until the orphan sweep's next pass, and the sweep is the backstop "
+        "rather than the mechanism."
     )

--- a/tests/agent/test_manifest_archive_atomicity.py
+++ b/tests/agent/test_manifest_archive_atomicity.py
@@ -27,6 +27,8 @@ import time
 from pathlib import Path
 from unittest import mock
 
+import structlog.testing
+
 from orchestrator.agent.manifest_archive import sync_manifests_to_archive
 
 
@@ -138,13 +140,15 @@ def test_concurrent_syncs_do_not_share_a_temp_name(tmp_path: Path) -> None:
     _live_manifest(live, "app.bin", b"content")
 
     seen: list[str] = []
-    real_copy = shutil.copy2
+    real_copy = shutil.copyfile
 
     def spy(src, dst, *a, **kw):
         seen.append(Path(dst).name)
         return real_copy(src, dst, *a, **kw)
 
-    with mock.patch.object(shutil, "copy2", spy):
+    # copyfile, not copy2 — copystat is copy2's last act, so copy2 handed back a
+    # temp already carrying the source's stale mtime (see the staleness test).
+    with mock.patch.object(shutil, "copyfile", spy):
         sync_manifests_to_archive(live, archive)
         (archive / "v1" / "app.bin").unlink()  # force a second copy of the same name
         sync_manifests_to_archive(live, archive)
@@ -238,6 +242,11 @@ def test_the_archived_file_keeps_the_sources_mtime(tmp_path: Path) -> None:
 
     This is the constraint that makes the in-flight freshness fix non-trivial: the
     TEMP must look new so the sweep spares it, while the ARCHIVED file must look old.
+
+    HONEST SCOPE: this passes against the pre-change code too, where copy2 preserved
+    the mtime on its own. It does not pin the current implementation — it guards
+    against the NAIVE fix (stamp the temp and let the rename carry that mtime
+    through), which is the one I actually wrote first and which this test caught.
     """
     live, archive = tmp_path / "live", tmp_path / "archive"
     src = _live_manifest(live, "app.bin", b"content", age_seconds=7200)
@@ -250,4 +259,84 @@ def test_the_archived_file_keeps_the_sources_mtime(tmp_path: Path) -> None:
         f"archived mtime {archived_mtime} should track the source's {src_mtime}. "
         "manifest_locator selects the NEWEST manifest by mtime, so re-stamping the "
         "archive changes which version validate uses."
+    )
+
+
+def test_the_temp_is_never_stale_at_any_point(tmp_path: Path) -> None:
+    """Freshness must hold from the first byte, not from a stamp applied afterwards.
+
+    The first attempt at this used copy2 then os.utime(tmp). copystat is copy2's
+    LAST act, so the temp was still born carrying the source's mtime and the sweep
+    could still eat it — in the gap between copy2 returning and the utime, exactly
+    as wide as the gap it was meant to close. The race moved; it did not go.
+
+    copyfile does not call copystat, so the temp's mtime is its own write time:
+    fresh by construction, and refreshed by every write during a slow NFS copy
+    rather than only at the end.
+
+    Asserted at the moment copy2's version was stale — immediately on return from
+    the copy, before any stamping.
+    """
+    live, archive = tmp_path / "live", tmp_path / "archive"
+    _live_manifest(live, "app.bin", b"content", age_seconds=7200)
+
+    ages: list[float] = []
+    real_copyfile = shutil.copyfile
+    real_copy2 = shutil.copy2
+
+    def spy_copyfile(src, dst, *a, **kw):
+        out = real_copyfile(src, dst, *a, **kw)
+        ages.append(time.time() - os.stat(dst).st_mtime)
+        return out
+
+    def spy_copy2(src, dst, *a, **kw):
+        out = real_copy2(src, dst, *a, **kw)
+        ages.append(time.time() - os.stat(dst).st_mtime)
+        return out
+
+    with (
+        mock.patch.object(shutil, "copyfile", spy_copyfile),
+        mock.patch.object(shutil, "copy2", spy_copy2),
+    ):
+        sync_manifests_to_archive(live, archive)
+
+    # BOTH spies are installed because copy2 calls copyfile INTERNALLY — checking
+    # only the first sample would read the inner copyfile's fresh mtime and pass
+    # while the outer copy2 left it stale. The property is that the temp is fresh
+    # after EVERY copy operation, so assert on the worst sample.
+    assert ages, "no copy happened"
+    assert max(ages) < 60, (
+        f"the temp was {max(ages):.0f}s old on return from a copy — a sweep winning "
+        "the next statement would unlink it, which is the race this was supposed to "
+        "remove rather than relocate"
+    )
+
+
+def test_a_failed_mtime_restore_is_logged_not_swallowed(tmp_path: Path) -> None:
+    """The restore is load-bearing, so its failure must be visible.
+
+    If it fails after a successful rename, the archived file keeps the FRESH mtime
+    permanently and outranks every sibling manifest at manifest_locator's
+    max(pool, key=st_mtime) until a newer one lands — a persistent wrong-version
+    selection, the UAT-13 F2 class. Suppressing OSError made that silent, against
+    this project's own "no silent fallbacks, fail loud" rule and unlike every other
+    error path in this function.
+    """
+    live, archive = tmp_path / "live", tmp_path / "archive"
+    _live_manifest(live, "app.bin", b"content", age_seconds=7200)
+
+    def failing_restore(path, times=None, **kw):
+        # The restore is now the ONLY utime in this function — the temp no longer
+        # needs stamping, because copyfile leaves it fresh by construction.
+        raise OSError("simulated metadata failure")
+
+    logs: list[dict] = []
+    with mock.patch.object(os, "utime", failing_restore):
+        with structlog.testing.capture_logs() as captured:
+            sync_manifests_to_archive(live, archive)
+        logs = list(captured)
+
+    assert any("mtime_restore_failed" in str(entry.get("event", "")) for entry in logs), (
+        "a failed restore leaves the archived manifest permanently outranking its "
+        f"siblings for validation. It must say so. Logged: {[e.get('event') for e in logs]}"
     )


### PR DESCRIPTION
Follow-up to the post-merge review of #301. Both findings were SEV-3 and neither warranted a rollback; nothing here is deployed.

## The #301 fix moved the race rather than removing it

`copystat` is `copy2`'s **last** act, so `copy2` returns a temp already carrying the source's mtime — and a manifest only becomes eligible to copy once it is older than the settle window. Stamping it fresh on the next line therefore leaves an exposure between `copy2` returning and the stamp, **exactly as wide as the one it was meant to close**. The reviewer demonstrated the merged code still losing a cycle to a sweep winning that gap: `copied=0`, `manifest_archive.copy_failed FileNotFoundError`. #301's "avoidable, so avoided" framing was false.

`copyfile` does not call `copystat`, so the temp's mtime is its own write time — fresh from the first byte, and refreshed by every write during a slow NFS copy rather than only at the end. No stamping, no window at any point, and simpler than what it replaces.

## A failed mtime restore was silent

Unchanged in intent, no longer suppressed. If the restore fails after a successful rename, the archived manifest keeps the fresh mtime **permanently** and outranks every sibling at `manifest_locator.py:94`'s `max(pool, key=st_mtime)` until a newer one lands — a persistent wrong-version selection, the UAT-13 F2 class, and previously invisible. Against this project's own no-silent-fallbacks rule, and unlike every other error path in the function.

Now logs `manifest_archive.mtime_restore_failed`. A warning rather than a failure: the file's contents are correct, only its ranking is wrong.

## Three test spies were patching a call that no longer happens

| spy | status |
|---|---|
| `test_concurrent_syncs_do_not_share_a_temp_name` | added in #301, re-pointed |
| `test_the_temp_is_never_stale_at_any_point` | new here |
| `test_tolerates_unreadable_file` | **pre-existing** — simulated a copy failure that could no longer occur, so it passed while proving nothing |

That last one is the third time this session a test has looked like protection and not been. It carries a comment now so the next person moving this code notices.

**My own first staleness test had the same disease**: it sampled the temp's age after the first copy call, but `copy2` calls `copyfile` *internally*, so it read the inner fresh mtime and passed against the broken code. It now asserts on the worst sample across every copy operation.

## Honest scope

The mtime-preservation test gains a **HONEST SCOPE** note. It passes against the pre-change code too, so it does not pin this implementation — it guards against the *naive* fix (stamp the temp and let the rename carry that mtime through), which is precisely the one I wrote first and which this test caught.

## Tests

2 new, both observed failing first; 3 spies re-pointed. **1780 passed**, 3 deselected. ruff, format and mypy clean across 108 files.

## Deployment

Neither #301 nor this has shipped to the LXC or the NAS. They should go out together.
