### PR TITLE
fix: calibrate the validate budget against measured disk throughput

### DIFF
--- a/.claude/build-progress.json
+++ b/.claude/build-progress.json
@@ -42,10 +42,11 @@
     "mp-only-exclusion",
     "manual-download-checker-agent",
     "epic-prefill-status-based",
-    "f18-cache-purge"
+    "f18-cache-purge",
+    "validate-timeout-recalibration"
   ],
-  "features_since_last_test": 0,
-  "features_since_last_health_check": 2,
+  "features_since_last_test": 1,
+  "features_since_last_health_check": 3,
   "test_interval": 2,
   "last_test_session": "2026-08-26",
   "testing_required": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — adversarial review of the recalibration: four defects, same shape as the one it fixed — 2026-09-01
+
+An independent adversarial reviewer returned **BLOCK** on the change below. Every finding verified before any code moved. Each is a number that was correct in isolation and wrong in the system around it — which is exactly what the recalibration existed to fix, reproduced one layer up.
+
+- **The ceiling was never bound to the budget that actually kills.** `worker.py:224` wraps every handler in `asyncio.wait_for(job_max_runtime_sec)` = 21600s. A validate ceiling above that is a fiction, and worse than useless: `CancelledError` is a `BaseException`, so it bypasses the sweep's per-game `except Exception` and aborts validates writing **no** `validation_history` row — the precise "cannot self-correct" mechanism the change was written to remove. 14400 ≤ 21600 already held; nothing enforced it. Now pinned by a test reading the real Settings value.
+- **The per-call budget ignored the sweep's own concurrency.** `sweep_batch_size` defaulted to 10 concurrent validates funnelling into the agent's `_CACHE_STAT_WORKERS = 2` executor, on a disk at 62–79% iowait. The 48–54 chunks/sec every budget derives from was measured **sequentially**, so under a sweep each call got a fifth to a tenth of it against a budget assuming the full rate. Default 10 → **2**, pinned to `_CACHE_STAT_WORKERS` by a test. Cost: some lost overlap on Epic's non-stat-bound work, accepted for honest budgets.
+- **Steam never got a size-aware budget, and the previous audit certified that as safe.** `steam_validate` was called with no chunk count, keeping the flat 300s base — ~12,000–16,000 chunks at the measured rate, so every large Steam game still timed out and never self-corrected. The audit called it "backward-compatible: unaffected"; it is unchanged, and on this hardware unchanged means broken. Steam self-enumerates agent-side so there is no manifest row to read, but the orchestrator holds the previous run's `validation_history.chunks_total`. A never-validated game falls back to the base.
+- **The sweep re-validated the same head forever.** Candidates were `ORDER BY id`. The sweep is one job killed at 6h and needs ~147h for the library, so it is *always* truncated — games past the ~1M-chunk mark were unreachable by construction. Now ordered least-recently-validated first (NULL first), so each truncated run advances coverage instead of repeating.
+- **The tests did not constrain the implementation.** Demonstrated rather than argued: rate `1.0` and ceiling `86400.0` — absurd in both directions, ceiling *above* the job budget — left all 28 tests passing. After the fix the same mutation fails 2. The two existing `steam_validate` spies broke on the signature change, which is the spy doing its job; they now accept `chunk_count` **explicitly** rather than absorbing it via `**kwargs`.
+- **`chunks_per_sec` is now genuinely configurable.** The docstring claimed overriding it needed no code edit; as shipped there was no Settings field and both call sites used the default. Now `validate_assumed_chunks_per_sec`, injected through the AgentClient constructor.
+
+**Deferred:** Game_shelf's client-side poll ceilings (~90s per-game, ~12 min full-sweep) will time out the UI on legitimately long validations. Cross-repo.
+
 ### Fixed — the validate budget is calibrated against measured disk throughput, not a hidden constant — 2026-09-01
 
 The NAS was rebuilt on OpenMediaVault on 2026-08-31 to remove UGREEN's `ugacl` shim. The rebuild left the NVMe cache that had fronted the RAID0 detached, and validation — stat-heavy random metadata I/O — collapsed from a measured **1,471–1,539 chunks/sec to 48–54**. Same code, same games; the hardware underneath changed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ for handoff clarity. Categories are ordered by impact severity.
 
 ## [Unreleased]
 
+### Fixed — the validate budget is calibrated against measured disk throughput, not a hidden constant — 2026-09-01
+
+The NAS was rebuilt on OpenMediaVault on 2026-08-31 to remove UGREEN's `ugacl` shim. The rebuild left the NVMe cache that had fronted the RAID0 detached, and validation — stat-heavy random metadata I/O — collapsed from a measured **1,471–1,539 chunks/sec to 48–54**. Same code, same games; the hardware underneath changed.
+
+- **`VALIDATE_TIMEOUT_PER_CHUNK_SEC = 0.00217` encoded an unstated assumption of ~461 chunks/sec.** At the real 50/sec the budget was ~9× short, and the point where a game could no longer finish inside its own budget was `chunks / 50 > 300 + 0.00217 × chunks`, i.e. **above ~16,826 chunks — 379 of 1,811 games (21%)**, including ARK: Survival Evolved (369,317), ARK ModKit UE4 (359,671), Warhammer 40,000: Darktide (310,059) and God of War (216,751). Confirmed live: Ghostwire Tokyo (~24,000 chunks) failed with `ReadTimeout` after 352s while Mortal Shell (14,142) succeeded, straddling the predicted line exactly.
+- **Those games could not self-correct.** A timed-out validate writes **no** `validation_history` row, so the game keeps whatever status it had — permanently, however many sweeps run. This is the same failure family as [#297], one layer down: that fix removed a flat cliff by scaling with chunk count, but the *scale factor* was itself calibrated against hardware that no longer exists.
+- **The rate is now an explicit `VALIDATE_TIMEOUT_ASSUMED_CHUNKS_PER_SEC` (40.0), and a `chunks_per_sec` keyword on `validate_timeout_for`.** 40 is deliberately below the measured 48 so a slow day does not reintroduce the cliff. Stating the throughput rather than a derived per-chunk figure is the actual fix: the previous form hid the assumption where nothing could flag it when it stopped being true. Being wrong in the *optimistic* direction is what caused the incident.
+- **Ceiling raised 1,800s → 14,400s.** A ceiling below the largest real game's requirement (~9,533s at 40/sec including the base) just moves the cliff. The ceiling's remaining job is narrower — bound a genuinely wedged agent — and it is no longer a scheduling constraint, because no full sweep fits in a 6-hour window at any ceiling on this hardware. The superseded test asserting `<= 1800` on that reasoning is replaced, with the dead premise recorded rather than deleted.
+
+**Not fixed here:** the underlying storage regression. Restoring a cache layer (`lvconvert --type cache` over the idle 360 GB NVMe, or more RAM to hold the ~10–15 GB metadata working set) is an infrastructure decision tracked separately. This change makes the system correct on the hardware as it currently is.
+
 ### Fixed — UAT session 14: eight defects, all of them a green status that had stopped meaning anything — 2026-08-26
 
 The test gate blocked the next feature. Its counter knew about two features; **158 commits** had landed since the previous session, so the three agent arms were scoped to the real surface. Both features under test met their acceptance criteria — `epic-prefill-status-based` is live and behaving as specified, `f18-cache-purge` satisfies all ten points of its spec coverage against ADR-0015 and #37. **Every defect found was in what the system reported, not in what it did.**

--- a/docs/security-audits/validate-timeout-recalibration-security-audit.md
+++ b/docs/security-audits/validate-timeout-recalibration-security-audit.md
@@ -1,0 +1,55 @@
+# Security Audit — Validate timeout recalibration
+
+**Feature:** validate-timeout-recalibration (express the assumed disk throughput explicitly; raise the ceiling above the largest real game)
+**Modules:**
+- `src/orchestrator/clients/agent_client.py` — `VALIDATE_TIMEOUT_ASSUMED_CHUNKS_PER_SEC`, `VALIDATE_TIMEOUT_CEILING_SEC`, `validate_timeout_for(..., chunks_per_sec=)`
+**Audit date:** 2026-09-01
+**Auditor:** self-review (Senior Security Engineer persona) + ruff (flake8-bandit `S`) + mypy + full suite
+**Phase:** 2 (Construction), Build Loop step 2.4
+
+<!-- Last Updated: 2026-09-01 -->
+
+## Scope
+
+The OMV rebuild of the NAS on 2026-08-31 removed the `ugacl` shim and left the NVMe cache that fronted the RAID0 detached. Validation throughput fell from a measured 1,471–1,539 chunks/sec to 48–54. The per-chunk timeout constant encoded an unstated assumption of ~461 chunks/sec, so every game above ~16,826 chunks — **379 of 1,811 (21%)** — could no longer finish inside its own budget, and because a timed-out validate writes no `validation_history` row, those games could never self-correct.
+
+Change: the rate becomes an explicit assumed-throughput constant (40.0, deliberately below the measured 48) plus a `chunks_per_sec` keyword override; the ceiling rises 1,800s → 14,400s. 18 new tests; one superseded test replaced with the constraint that still holds.
+
+## Methodology
+
+1. **SAST-lite.** `ruff check src/orchestrator/clients/agent_client.py tests/clients` — clean.
+2. **Type safety.** `mypy src/orchestrator/clients/agent_client.py` — clean.
+3. **Threat-model cross-check:** injection, path traversal, secret exposure, availability, resource exhaustion.
+4. **Tests.** Full suite 1796 passed, 3 deselected.
+
+## Audit findings
+
+| # | Severity | Title | Status |
+|---|----------|-------|--------|
+| 1 | SEV-4 (accepted) | A wedged agent can now hold a worker slot for 4h instead of 30m | Accepted — see below |
+
+### 1. Longer ceiling extends the worst-case hold on a worker slot (SEV-4, accepted)
+
+Raising `VALIDATE_TIMEOUT_CEILING_SEC` from 1,800s to 14,400s means a genuinely wedged or unreachable agent can occupy the validate path for four hours rather than thirty minutes before the client gives up.
+
+**Why it is accepted rather than mitigated.** The bound still exists and is still finite, which is the property that matters — the ceiling's purpose is to stop an *unbounded* hang, not to schedule work. The alternative is strictly worse and was the live defect: a ceiling below the largest game's genuine requirement means 21% of the library can never validate and never self-corrects, which is a permanent correctness failure rather than a temporary availability one. Pacing belongs to the sweep, not to a client timeout constant.
+
+**Residual exposure is bounded by design:** validate is read-only disk-stat, it holds no lock and mutates nothing until it returns, the orchestrator job's own timeout remains the primary guard, and a stuck job is cleaned by the startup reaper (observed reaping 1 orphan on 2026-09-01). No unauthenticated caller can reach this path — `/api/v1/games/{id}/validate` requires the bearer token, and the sweep is scheduler-driven.
+
+## Non-findings (explicitly checked, clean)
+
+- **No new external input.** `chunks_per_sec` is a keyword-only parameter with a module-constant default. It is not read from a request, a header, or a config file in this change; both call sites (`agent_client.py:249`, `:274`) use the default. No attacker-reachable path sets it.
+- **Division guarded.** `chunk_count / chunks_per_sec` is reached only under `chunk_count is not None and chunk_count > 0 and chunks_per_sec > 0`. A zero or negative throughput falls back to the base budget rather than raising or producing a negative/infinite timeout. Tested (`test_a_nonsense_count_falls_back_to_the_base`).
+- **No injection, no path traversal, no filesystem or subprocess surface.** The change is arithmetic over an integer already held in `manifests.chunk_count`.
+- **Secret-free.** No new log field, no new value in an error path. Timeout values are not sensitive.
+- **Connect timeout unchanged at 10s.** Only the READ budget scales — reaching the agent is fast or it is broken, so a network-level hang is still caught in 10s regardless of game size. Explicitly tested.
+- **Backward-compatible.** `validate_timeout_for(None)` and nonsensical counts return exactly the prior base budget, so steam (which self-enumerates agent-side and passes no count) is unaffected.
+- **No denial-of-service amplification.** The budget scales linearly with a value the orchestrator itself holds, capped. A caller cannot inflate it: `chunk_count` comes from the manifest record, not from the request.
+
+## Decision
+
+**Cleared to advance.** One accepted SEV-4 with the trade-off stated and bounded; no SEV-1/2/3. Additive and backward-compatible, no new input surface, division guarded, ruff + mypy clean, full suite green (1796 passed).
+
+**Explicitly out of scope:** the storage regression itself. This change makes the system correct on the hardware as it currently stands; restoring a cache layer is an infrastructure decision tracked separately.
+
+## Sign-off

--- a/docs/security-audits/validate-timeout-review-remediation-security-audit.md
+++ b/docs/security-audits/validate-timeout-review-remediation-security-audit.md
@@ -1,0 +1,70 @@
+# Security Audit — Validate timeout review remediation
+
+**Feature:** validate-timeout-review-remediation (four substantiated findings from the adversarial review of PR #303)
+**Modules:**
+- `src/orchestrator/clients/agent_client.py` — ceiling bound documented, `validate_chunks_per_sec` constructor injection, dead `VALIDATE_TIMEOUT_PER_CHUNK_SEC` removed
+- `src/orchestrator/core/settings.py` — `validate_assumed_chunks_per_sec` added; `sweep_batch_size` default 10 → 2
+- `src/orchestrator/jobs/handlers/sweep.py` — candidates ordered least-recently-validated first
+- `src/orchestrator/validator/disk_stat.py` — Steam passes its last known `chunks_total`
+- `src/orchestrator/api/main.py` — Settings → AgentClient wiring
+**Audit date:** 2026-09-01
+**Auditor:** self-review (Senior Security Engineer persona) + adversarial reviewer (independent) + ruff (flake8-bandit `S`) + mypy + full suite
+**Phase:** 2 (Construction), Build Loop step 2.4
+
+<!-- Last Updated: 2026-09-01 -->
+
+## Scope
+
+PR #303's own audit cleared it with one accepted SEV-4. An independent adversarial reviewer returned **BLOCK** with four substantiated findings, all verified in this session before any code was changed. Every one is the same shape as the defect #303 fixed — a number correct in isolation and wrong in the system around it.
+
+## Audit findings
+
+| # | Severity | Title | Status |
+|---|----------|-------|--------|
+| 1 | SEV-2 | Ceiling was unbounded against `job_max_runtime_sec` | Fixed + test |
+| 2 | SEV-2 | Per-call budget ignored the sweep's own concurrency | Fixed + test |
+| 3 | SEV-2 | Steam never received a size-aware budget | Fixed + tests |
+| 4 | SEV-3 | Tests did not constrain the implementation | Fixed + regression check |
+| 5 | SEV-3 | `chunks_per_sec` was not reachable from config | Fixed + test |
+
+### 1. Ceiling vs job budget (SEV-2, fixed)
+
+A validate ceiling above `Settings.job_max_runtime_sec` (21600s) is a fiction: `worker.py:224` wraps every handler in `asyncio.wait_for`, so the job is cancelled first. **`CancelledError` is a `BaseException`**, so it bypasses the sweep's per-game `except Exception` isolation (`sweep.py:81`) — in-flight validates abort writing **no** `validation_history` row. That is precisely the "cannot self-correct" mechanism #303 was written to remove. 14400 ≤ 21600 already held; the defect was that nothing enforced it. Now pinned by a test that reads the real Settings value.
+
+### 2. Sweep concurrency vs the agent's stat pool (SEV-2, fixed)
+
+`sweep_batch_size` defaulted to 10 concurrent validates, all funnelling into the agent's `_CACHE_STAT_WORKERS = 2` executor (`disk_stat.py:55`) against a disk at 62–79% iowait. The 48–54 chunks/sec figure every budget derives from was measured **sequentially**, so under a sweep each call received roughly a fifth to a tenth of it while its budget assumed the full rate. Default lowered to 2 and pinned to `_CACHE_STAT_WORKERS` by a test so the two cannot drift apart again.
+
+**Accepted cost:** any part of validate that is not stat-bound (Epic's base64 transfer and parse) loses overlap. Judged worth it — honest budgets over speculative concurrency on a saturated disk.
+
+### 3. Steam had no size-aware budget (SEV-2, fixed)
+
+`steam_validate` was called with no chunk count, keeping the flat 300s base — ~12,000–16,000 chunks at the measured rate. **PR #303's audit certified this as "backward-compatible: unaffected."** It is unchanged; on this hardware that means broken, and backward-compatibility was the wrong criterion to apply — the old behaviour was only ever safe on hardware that no longer exists. Steam self-enumerates agent-side so there is no manifest row to read, but the orchestrator holds the previous run's `validation_history.chunks_total`. A never-validated game has none and falls back to the base.
+
+### 4. Tests did not constrain the implementation (SEV-3, fixed)
+
+Demonstrated, not argued: setting the rate to `1.0` and the ceiling to `86400.0` — absurd in both directions, and a ceiling **above** the job budget — left all 28 tests passing. Reproduced in this session before writing any remediation. After the fix the same mutation **fails 2 tests**. This was the worst finding: #303's whole thesis is that the old constant hid an assumption nothing could flag, and its tests reproduced that property one layer up.
+
+### 5. Config claim was false (SEV-3, fixed)
+
+`validate_timeout_for`'s docstring claimed "overriding it must not require a code edit". As shipped there was no Settings field and both call sites used the module default, so the keyword was test-only surface wearing a config costume. Now a real `validate_assumed_chunks_per_sec` setting, injected via the AgentClient constructor at the composition root.
+
+## Non-findings (explicitly checked, clean)
+
+- **No new external input.** `validate_assumed_chunks_per_sec` is a pydantic-settings field with `gt=0`, sourced from env like every other setting; it is operator-controlled configuration, not request data. `chunk_count` for Steam comes from the orchestrator's own `validation_history`, never from a caller.
+- **No injection surface.** The new query is parameterised (`WHERE game_id=?`) and selects one integer column.
+- **Division still guarded.** `chunk_count > 0 and chunks_per_sec > 0` unchanged; `gt=0` on the setting makes a zero rate unconstructible.
+- **Sweep ordering is not attacker-influenced.** `last_validated_at` is written only by the validator.
+- **Lowering `sweep_batch_size` cannot starve.** The semaphore bounds concurrency, not total work; every candidate is still processed.
+- **Test fakes fail loudly, deliberately.** The two existing `steam_validate` spies broke on the signature change — the spy doing its job. They now accept `chunk_count` **explicitly** rather than absorbing it through `**kwargs`, so the next drift breaks them too.
+- **No secret exposure, no new log field, no filesystem or subprocess surface.**
+
+## Decision
+
+**Cleared to advance.** Three SEV-2s and two SEV-3s found by independent adversarial review, all fixed and each pinned by a test that fails against the pre-fix behaviour. Full suite 1806 passed, 3 deselected; ruff + mypy clean.
+
+**Explicitly deferred:** Game_shelf's client-side poll ceilings (~90s on the per-game Validate button, ~12 min on the full-sweep page) will time out the UI on legitimately long validations. Cross-repo, needs its own change.
+
+**Explicitly out of scope:** the storage regression. This makes the system correct on the hardware as it stands.
+
+## Sign-off

--- a/src/orchestrator/api/main.py
+++ b/src/orchestrator/api/main.py
@@ -182,6 +182,7 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     agent_client = AgentClient(
         base_url=settings.agent_base_url,
         token=settings.orchestrator_token.get_secret_value(),
+        validate_chunks_per_sec=settings.validate_assumed_chunks_per_sec,
     )
     app.state.agent_client = agent_client
     log.info(

--- a/src/orchestrator/clients/agent_client.py
+++ b/src/orchestrator/clients/agent_client.py
@@ -35,28 +35,53 @@ _STEAM_PREFILL_POLL_TIMEOUT_SEC = 37800.0  # 10.5h — 30 min of headroom over 1
 # 271s against the old 300s. So the budget scales with the chunk count the caller
 # already holds in manifests.chunk_count.
 VALIDATE_TIMEOUT_BASE_SEC = 300.0
-# Chosen so 359,671 chunks lands near 1080s — roughly 2.5x the measured average and
-# comfortably past the worst observed run, without approaching the ceiling.
-VALIDATE_TIMEOUT_PER_CHUNK_SEC = 0.00217
-# The sweep runs 6-hourly and takes ~40 min; one game must not be able to eat the
-# whole window, and a genuinely wedged agent still has to surface as a failure.
-VALIDATE_TIMEOUT_CEILING_SEC = 1800.0
+# THE DISK THROUGHPUT THE BUDGET ASSUMES, stated outright — the previous form
+# (`PER_CHUNK_SEC = 0.00217`) hid an assumption of ~461 chunks/sec, and nothing
+# flagged it when the hardware stopped being able to deliver that.
+#
+# Measured on 2026-09-01 from validation_history durations:
+#   before the OMV rebuild (bcache in front of the RAID0):  1471-1539 chunks/sec
+#   after  the OMV rebuild (raw RAID0, NVMe cache detached):  48-54 chunks/sec
+#
+# 40 is deliberately BELOW the measured 48, so a slow day does not reintroduce
+# the cliff. Raise it if a cache layer is restored — but measure first, and
+# remember that being wrong in the optimistic direction is what caused the
+# incident: 379 of 1811 games (21%) could not validate at all, and a timed-out
+# validate writes no validation_history row, so those games never self-correct.
+VALIDATE_TIMEOUT_ASSUMED_CHUNKS_PER_SEC = 40.0
+VALIDATE_TIMEOUT_PER_CHUNK_SEC = 1.0 / VALIDATE_TIMEOUT_ASSUMED_CHUNKS_PER_SEC
+# Must exceed the largest real game's requirement or the cliff simply moves: at
+# 40/sec ARK: Survival Evolved (369,317 chunks) needs ~9,533s including the base.
+# 4 hours leaves room for library growth. The ceiling exists so a genuinely
+# wedged agent still surfaces as a failure rather than hanging forever — it is
+# not a scheduling constraint, because the sweep no longer has to fit every game
+# into one 6-hourly window.
+VALIDATE_TIMEOUT_CEILING_SEC = 14400.0
 
 
-def validate_timeout_for(chunk_count: int | None) -> httpx.Timeout:
+def validate_timeout_for(
+    chunk_count: int | None,
+    *,
+    chunks_per_sec: float = VALIDATE_TIMEOUT_ASSUMED_CHUNKS_PER_SEC,
+) -> httpx.Timeout:
     """Read budget for a validate call, scaled to the work it implies.
 
     An unknown or nonsensical count keeps the base budget — no information means no
     change, so steam (which self-enumerates agent-side) behaves exactly as before.
 
+    ``chunks_per_sec`` is the assumed disk throughput. It is a parameter rather than
+    a baked-in constant because it is a property of the HARDWARE, not of the code:
+    the 2026-09-01 incident was a storage change silently invalidating a number
+    nobody could see. Overriding it must not require a code edit.
+
     Only the READ budget scales. Reaching the agent is fast or it is broken, so the
     connect timeout stays short.
     """
     read = VALIDATE_TIMEOUT_BASE_SEC
-    if chunk_count is not None and chunk_count > 0:
+    if chunk_count is not None and chunk_count > 0 and chunks_per_sec > 0:
         read = min(
             VALIDATE_TIMEOUT_CEILING_SEC,
-            VALIDATE_TIMEOUT_BASE_SEC + (chunk_count * VALIDATE_TIMEOUT_PER_CHUNK_SEC),
+            VALIDATE_TIMEOUT_BASE_SEC + (chunk_count / chunks_per_sec),
         )
     return httpx.Timeout(read, connect=10.0)
 

--- a/src/orchestrator/clients/agent_client.py
+++ b/src/orchestrator/clients/agent_client.py
@@ -49,13 +49,19 @@ VALIDATE_TIMEOUT_BASE_SEC = 300.0
 # incident: 379 of 1811 games (21%) could not validate at all, and a timed-out
 # validate writes no validation_history row, so those games never self-correct.
 VALIDATE_TIMEOUT_ASSUMED_CHUNKS_PER_SEC = 40.0
-VALIDATE_TIMEOUT_PER_CHUNK_SEC = 1.0 / VALIDATE_TIMEOUT_ASSUMED_CHUNKS_PER_SEC
 # Must exceed the largest real game's requirement or the cliff simply moves: at
 # 40/sec ARK: Survival Evolved (369,317 chunks) needs ~9,533s including the base.
 # 4 hours leaves room for library growth. The ceiling exists so a genuinely
-# wedged agent still surfaces as a failure rather than hanging forever — it is
-# not a scheduling constraint, because the sweep no longer has to fit every game
-# into one 6-hourly window.
+# wedged agent still surfaces as a failure rather than hanging forever.
+#
+# UPPER BOUND, and it is not negotiable: this must stay <= Settings.
+# job_max_runtime_sec (21600s). The worker wraps every handler in
+# asyncio.wait_for, so a ceiling above the job budget is a fiction — the job is
+# cancelled first, and CancelledError is a BaseException that bypasses the
+# sweep's per-game `except Exception`, aborting validates with NO
+# validation_history row. That is the very "cannot self-correct" mechanism this
+# constant was raised to remove. Pinned by
+# tests/clients/test_validate_timeout_review_remediation.py.
 VALIDATE_TIMEOUT_CEILING_SEC = 14400.0
 
 
@@ -102,8 +108,13 @@ class AgentClient:
         poll_timeout_sec: float = 7200.0,
         connect_retries: int = 2,
         connect_retry_backoff_sec: float = 0.5,
+        validate_chunks_per_sec: float = VALIDATE_TIMEOUT_ASSUMED_CHUNKS_PER_SEC,
     ) -> None:
         self._base_url = base_url
+        # Assumed disk throughput for validate budgets, injected from Settings so a
+        # hardware change is a config edit rather than a code edit — the 2026-09-01
+        # incident was exactly a storage change invalidating a buried constant.
+        self._validate_chunks_per_sec = validate_chunks_per_sec
         self._headers = {"Authorization": f"Bearer {token}"}
         self._transport = transport
         # UAT-12: poll at 3s (was 0.5s) — a multi-hour job needs far fewer
@@ -271,7 +282,7 @@ class AgentClient:
             "POST",
             "/v1/steam/validate",
             json={"app_id": app_id},
-            timeout=validate_timeout_for(chunk_count),
+            timeout=validate_timeout_for(chunk_count, chunks_per_sec=self._validate_chunks_per_sec),
         )
         result: dict[str, Any] = resp.json()
         return result
@@ -296,7 +307,7 @@ class AgentClient:
                 "cdn_base": cdn_base,
                 "raw_manifest_b64": raw_manifest_b64,
             },
-            timeout=validate_timeout_for(chunk_count),
+            timeout=validate_timeout_for(chunk_count, chunks_per_sec=self._validate_chunks_per_sec),
         )
         result: dict[str, Any] = resp.json()
         return result

--- a/src/orchestrator/core/settings.py
+++ b/src/orchestrator/core/settings.py
@@ -275,7 +275,15 @@ class Settings(BaseSettings):
     # (soundtracks/tools/servers/demos) from FUTURE prefill. Runs on the same
     # interval as the scheduled prefill; download-once-then-block.
     auto_classify_block_enabled: bool = True
-    sweep_batch_size: int = Field(default=10, ge=1)
+    # Capped at the agent's _CACHE_STAT_WORKERS (2). Concurrency above the stat
+    # pool adds queueing, not throughput, and silently divides the per-call
+    # throughput each validate budget assumes -- budgets measured sequentially
+    # are then wrong by the batch factor under a sweep (PR #303 review).
+    sweep_batch_size: int = Field(default=2, ge=1)
+    # The disk throughput validate budgets assume. A SETTING, not a constant:
+    # it is a property of the hardware, and the 2026-09-01 incident was a
+    # storage change silently invalidating a number nobody could see.
+    validate_assumed_chunks_per_sec: float = Field(default=40.0, gt=0)
     # Manifest-only fetcher (DepotDownloader) weekly cron — Monday 05:00 UTC,
     # offset from the sweep (03/09/15/21) and host prefill crons. 5-field, UTC.
     fetch_manifests_enabled: bool = True

--- a/src/orchestrator/jobs/handlers/sweep.py
+++ b/src/orchestrator/jobs/handlers/sweep.py
@@ -30,13 +30,20 @@ _log = structlog.get_logger(__name__)
 _CANDIDATE_SQL = (
     "SELECT id, status FROM games "
     "WHERE status IN ('unknown','up_to_date','validation_failed') AND owned = 1 "
-    "ORDER BY id"
+    # Least-recently-validated first. The sweep is ONE job bounded by
+    # job_max_runtime_sec (6h) and needs ~147h for the library at post-rebuild
+    # speeds, so it is ALWAYS truncated. Ordering by id made every run re-validate
+    # the same head and never reach the tail (PR #303 review). NULL sorts first,
+    # so a never-validated game is picked up before any re-check.
+    "ORDER BY last_validated_at IS NOT NULL, last_validated_at, id"
 )
 
 # `full` mode (validate-all backfill, 2026-06-24): validate EVERY game across
 # all platforms, not just the already-cached subset. Carried on jobs.payload
 # `{"full": true}`.
-_CANDIDATE_SQL_FULL = "SELECT id, status FROM games ORDER BY id"
+_CANDIDATE_SQL_FULL = (
+    "SELECT id, status FROM games ORDER BY last_validated_at IS NOT NULL, last_validated_at, id"
+)
 
 
 async def sweep_handler(job: dict[str, Any], deps: Deps) -> None:

--- a/src/orchestrator/validator/disk_stat.py
+++ b/src/orchestrator/validator/disk_stat.py
@@ -347,5 +347,18 @@ async def validate_game(
         app_id_int = int(row["app_id"])
     except (TypeError, ValueError):
         return ValidationResult(0, 0, 0, "error", "", "app_id not numeric")
-    res = await deps.agent_client.steam_validate(app_id_int)
+    # Steam self-enumerates agent-side, so unlike Epic there is no manifest row to
+    # read a chunk count from at call time — which is why #303 left steam on the
+    # flat base budget and its audit wrongly certified that as "unaffected". On
+    # post-rebuild hardware the base covers only ~12-16k chunks, so every large
+    # steam game timed out, wrote NO validation_history row, and could never
+    # self-correct. The previous run's chunks_total is the size we DO hold; a
+    # never-validated game has none and correctly falls back to the base.
+    size_row = await pool.read_one(
+        "SELECT chunks_total FROM validation_history WHERE game_id=? ORDER BY id DESC LIMIT 1",
+        (game_id,),
+    )
+    last_total = size_row["chunks_total"] if size_row is not None else None
+    chunk_count = int(last_total) if last_total else None
+    res = await deps.agent_client.steam_validate(app_id_int, chunk_count=chunk_count)
     return _shape(res)

--- a/tests/clients/test_validate_timeout_recalibration.py
+++ b/tests/clients/test_validate_timeout_recalibration.py
@@ -1,0 +1,113 @@
+"""The validate budget must be calibrated against real throughput, not a constant.
+
+2026-09-01. The OMV rebuild of the NAS removed the bcache layer that fronted the
+RAID0, and validation — which is stat-heavy random metadata I/O — went from a
+measured 1,471-1,539 chunks/sec to 48-54. Same code, same games; the hardware
+underneath changed.
+
+``VALIDATE_TIMEOUT_PER_CHUNK_SEC = 0.00217`` encodes an assumption of ~461
+chunks/sec. At 50/sec the budget is roughly 9x short, and the crossover where a
+game can no longer finish inside its own budget is::
+
+    chunks / 50 > 300 + 0.00217 * chunks   ->   fails above ~16,826 chunks
+
+That is 379 of 1,811 games (21%), including ARK: Survival Evolved (369,317
+chunks), ARK ModKit UE4 (359,671), Warhammer 40,000: Darktide (310,059) and God
+of War (216,751). Confirmed live: Ghostwire Tokyo (~24,000 chunks) failed with
+``AgentError: agent unreachable: ReadTimeout`` after 352 s, while Mortal Shell
+(14,142 chunks) succeeded — exactly straddling the predicted line.
+
+Those games cannot self-correct: a timed-out validate writes NO validation_history
+row, so the game keeps whatever status it had. They stay wrong forever.
+
+The fix is not another hand-tuned constant — that is what broke. The rate is
+expressed as an explicit assumed throughput so the next hardware change is a
+config edit rather than an incident.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.clients.agent_client import (
+    VALIDATE_TIMEOUT_ASSUMED_CHUNKS_PER_SEC,
+    VALIDATE_TIMEOUT_BASE_SEC,
+    VALIDATE_TIMEOUT_CEILING_SEC,
+    validate_timeout_for,
+)
+
+# The largest game on record, from the live DB on 2026-09-01.
+LARGEST_GAME_CHUNKS = 369_317
+# Measured post-rebuild throughput, from validation_history durations.
+MEASURED_CHUNKS_PER_SEC = 48.0
+
+
+class TestTheRateIsAnExplicitThroughputAssumption:
+    def test_the_assumed_throughput_is_stated_not_buried_in_a_per_chunk_constant(
+        self,
+    ) -> None:
+        """A reader must be able to see what hardware speed the budget assumes."""
+        assert VALIDATE_TIMEOUT_ASSUMED_CHUNKS_PER_SEC > 0
+
+    def test_the_assumption_is_not_faster_than_the_hardware_measured(self) -> None:
+        """The old 0.00217 s/chunk assumed ~461/sec against a real 48-54. Assuming a
+        rate the disks cannot deliver is precisely the bug."""
+        assert VALIDATE_TIMEOUT_ASSUMED_CHUNKS_PER_SEC <= MEASURED_CHUNKS_PER_SEC
+
+    def test_the_throughput_can_be_overridden_per_call(self) -> None:
+        """Hardware changes. This must not require a code edit next time."""
+        slow = validate_timeout_for(100_000, chunks_per_sec=10.0).read
+        fast = validate_timeout_for(100_000, chunks_per_sec=1000.0).read
+        assert slow > fast
+
+
+class TestEveryRealGameFitsInsideItsBudget:
+    @pytest.mark.parametrize(
+        ("chunks", "title"),
+        [
+            (369_317, "ARK: Survival Evolved"),
+            (359_671, "ARK ModKit (UE4)"),
+            (310_059, "Warhammer 40,000: Darktide"),
+            (216_843, "ARK: Survival Ascended"),
+            (216_751, "God of War"),
+            (24_000, "Ghostwire Tokyo"),
+            (16_827, "one chunk past the old crossover"),
+        ],
+    )
+    def test_the_budget_covers_the_time_the_work_actually_takes(
+        self, chunks: int, title: str
+    ) -> None:
+        need = chunks / MEASURED_CHUNKS_PER_SEC
+        budget = validate_timeout_for(chunks).read
+        assert budget >= need, (
+            f"{title}: {chunks} chunks needs {need:.0f}s at the measured "
+            f"{MEASURED_CHUNKS_PER_SEC:.0f}/s but is given {budget:.0f}s"
+        )
+
+    def test_the_ceiling_does_not_clip_the_largest_real_game(self) -> None:
+        """A ceiling below the biggest game reintroduces the class of bug: that game
+        can never validate, and never self-corrects, however long it runs."""
+        assert VALIDATE_TIMEOUT_CEILING_SEC >= LARGEST_GAME_CHUNKS / MEASURED_CHUNKS_PER_SEC
+
+
+class TestTheOldGuaranteesStillHold:
+    def test_an_unknown_chunk_count_keeps_the_base_budget(self) -> None:
+        assert validate_timeout_for(None).read == VALIDATE_TIMEOUT_BASE_SEC
+
+    @pytest.mark.parametrize("bad", [0, -1])
+    def test_a_nonsense_count_falls_back_to_the_base(self, bad: int) -> None:
+        assert validate_timeout_for(bad).read == VALIDATE_TIMEOUT_BASE_SEC
+
+    def test_a_small_game_never_gets_less_than_the_base(self) -> None:
+        assert validate_timeout_for(50).read >= VALIDATE_TIMEOUT_BASE_SEC
+
+    def test_it_still_grows_with_the_count(self) -> None:
+        assert validate_timeout_for(200_000).read > validate_timeout_for(20_000).read
+
+    def test_it_is_still_capped(self) -> None:
+        """A wedged agent must still surface as a failure rather than hang forever."""
+        assert validate_timeout_for(500_000_000).read == VALIDATE_TIMEOUT_CEILING_SEC
+
+    def test_connect_timeout_stays_short(self) -> None:
+        """Reaching the agent is fast or it is broken — only the WORK is slow."""
+        assert validate_timeout_for(LARGEST_GAME_CHUNKS).connect == 10.0

--- a/tests/clients/test_validate_timeout_review_remediation.py
+++ b/tests/clients/test_validate_timeout_review_remediation.py
@@ -1,0 +1,115 @@
+"""Findings from the adversarial review of PR #303, each pinned by a test.
+
+The recalibration in #303 was right in direction and oversold in effect. An
+adversarial reviewer substantiated four defects; every one is a case of a number
+that was correct in isolation and wrong in the system it lives in — the same
+failure the PR itself was written to fix, one layer up.
+
+1. THE SWEEP IS ONE JOB, HARD-KILLED AT ``job_max_runtime_sec`` (21600s).
+   Raising the per-call ceiling does nothing for it. At the measured 48-54
+   chunks/sec a 6h window covers ~1.1M chunks; the library is 26.5M. Worse, the
+   candidate query ordered by ``id``, so every sweep re-validated the same head
+   and died before the tail — games past the ~1M-chunk mark were never reached,
+   deterministically, forever.
+
+2. THE PER-CALL BUDGET IGNORED THE SWEEP'S OWN CONCURRENCY. ``sweep_batch_size``
+   defaulted to 10 concurrent validates, all funnelling into the agent's
+   ``_CACHE_STAT_WORKERS = 2`` stat pool. The 48-54 measurement was taken
+   sequentially, so under a sweep each call got roughly a tenth of it while its
+   budget assumed the full rate.
+
+3. STEAM WAS NEVER FIXED. ``steam_validate`` is called with no chunk count, so
+   it keeps the flat 300s base — about 12,000-16,000 chunks at the measured rate.
+   The #303 audit certified this as "backward-compatible: unaffected". It IS
+   unchanged; on this hardware that means broken, and backward-compatible was
+   the wrong test to apply.
+
+4. THE TESTS DID NOT CONSTRAIN THE IMPLEMENTATION. Setting the rate to 1.0 and
+   the ceiling to 86400 — absurd in both directions, and a ceiling ABOVE the job
+   budget — left all 28 tests passing. Reproduced before writing this file.
+"""
+
+from __future__ import annotations
+
+from orchestrator.clients.agent_client import (
+    VALIDATE_TIMEOUT_ASSUMED_CHUNKS_PER_SEC,
+    VALIDATE_TIMEOUT_CEILING_SEC,
+)
+from orchestrator.core.settings import Settings
+from orchestrator.jobs.handlers import sweep as sweep_mod
+from orchestrator.validator.disk_stat import _CACHE_STAT_WORKERS
+
+# Measured on the post-rebuild hardware, 2026-09-01, from validation_history.
+MEASURED_CHUNKS_PER_SEC = 48.0
+
+
+class TestTheCeilingSitsUnderTheBudgetThatActuallyKills:
+    def test_the_ceiling_cannot_exceed_the_job_runtime_budget(self) -> None:
+        """A validate ceiling above ``job_max_runtime_sec`` is a lie: the worker
+        wraps every handler in ``asyncio.wait_for`` (worker.py:224), so the job is
+        cancelled first. Worse than useless — cancellation raises CancelledError,
+        which is a BaseException and bypasses the sweep's per-game ``except
+        Exception`` isolation, so in-flight validates abort writing NO
+        validation_history row. That is precisely the "cannot self-correct"
+        mechanism #303 claims to remove."""
+        budget = Settings(orchestrator_token="x" * 32).job_max_runtime_sec
+        assert budget >= VALIDATE_TIMEOUT_CEILING_SEC, (
+            f"ceiling {VALIDATE_TIMEOUT_CEILING_SEC}s exceeds the job budget "
+            f"{budget}s — the job is killed before the HTTP call gives up"
+        )
+
+
+class TestTheAssumedRateIsPinnedToSomethingReal:
+    def test_the_rate_is_within_a_plausible_band_of_the_measurement(self) -> None:
+        """The old value implied ~461/sec against a real 48-54 and nothing caught
+        it. A band is what makes that catchable: too fast reintroduces the cliff,
+        absurdly slow hands every game a budget past the job runtime and hides
+        genuine agent wedges. Widen it deliberately with a measurement, never to
+        make a test pass."""
+        assert 20.0 <= VALIDATE_TIMEOUT_ASSUMED_CHUNKS_PER_SEC <= 200.0
+
+    def test_the_rate_is_not_optimistic_against_the_measurement(self) -> None:
+        assert VALIDATE_TIMEOUT_ASSUMED_CHUNKS_PER_SEC <= MEASURED_CHUNKS_PER_SEC
+
+    def test_the_rate_is_reachable_from_settings_not_only_from_a_constant(self) -> None:
+        """#303's docstring claimed "overriding it must not require a code edit".
+        As shipped there was no Settings field and both call sites used the
+        default, so the claim was false and the keyword was test-only surface."""
+        s = Settings(orchestrator_token="x" * 32)
+        assert hasattr(s, "validate_assumed_chunks_per_sec")
+        assert s.validate_assumed_chunks_per_sec > 0
+
+
+class TestTheSweepCanMakeProgressAcrossTruncatedRuns:
+    def test_candidates_are_ordered_least_recently_validated_first(self) -> None:
+        """STRUCTURAL, and honest about it: this asserts the ordering clause, not
+        observed behaviour against a populated DB.
+
+        ``ORDER BY id`` guarantees a truncated sweep re-does the same head every
+        time. Since the sweep is killed at 6h and needs ~147h for the library, the
+        tail was unreachable by construction. Oldest-validated-first makes each
+        truncated run pick up where the last left off, so the library is covered
+        across runs even though no single run can finish."""
+        for sql in (sweep_mod._CANDIDATE_SQL, sweep_mod._CANDIDATE_SQL_FULL):
+            assert "ORDER BY id" not in sql, (
+                "ordering by id makes a truncated sweep re-validate the same head "
+                "forever and never reach the tail"
+            )
+            assert "last_validated_at" in sql, (
+                "the sweep must order by last_validated_at so a run that is cut "
+                "off still advances coverage"
+            )
+
+
+class TestTheSweepsConcurrencyMatchesWhatTheAgentCanActuallyDo:
+    def test_batch_size_does_not_exceed_the_agents_stat_pool(self) -> None:
+        """Ten concurrent validates against two stat threads adds queueing, not
+        throughput, and silently divides the per-call rate by the batch size — so
+        every budget computed from a sequential measurement is wrong under a
+        sweep. Pinning these together is what stops them drifting apart again."""
+        s = Settings(orchestrator_token="x" * 32)
+        assert s.sweep_batch_size <= _CACHE_STAT_WORKERS, (
+            f"sweep_batch_size={s.sweep_batch_size} exceeds the agent's "
+            f"_CACHE_STAT_WORKERS={_CACHE_STAT_WORKERS}; the extra concurrency "
+            f"buys queueing delay and invalidates every per-call budget"
+        )

--- a/tests/clients/test_validate_timeout_scaling.py
+++ b/tests/clients/test_validate_timeout_scaling.py
@@ -52,10 +52,19 @@ class TestScaling:
         wedged agent still has to surface as a failure rather than hang the sweep."""
         assert validate_timeout_for(500_000_000).read == VALIDATE_TIMEOUT_CEILING_SEC
 
-    def test_the_ceiling_fits_inside_the_sweeps_own_budget(self) -> None:
-        """The sweep runs every 6 hours and currently takes ~40 minutes. A single
-        game must not be able to consume the whole window."""
-        assert VALIDATE_TIMEOUT_CEILING_SEC <= 1800
+    def test_the_ceiling_still_bounds_a_wedged_agent(self) -> None:
+        """SUPERSEDED 2026-09-01. This asserted ``<= 1800`` on the reasoning that
+        "the sweep runs every 6 hours and takes ~40 minutes, so one game must not
+        consume the window". That premise died with the OMV rebuild: validation
+        dropped from ~1500 to ~50 chunks/sec, no full sweep fits in 6 hours at any
+        ceiling, and a 1800s cap meant 379 of 1811 games could never validate at
+        all — permanently, since a timed-out validate writes no history row.
+
+        The ceiling's real job is narrower: stop a genuinely wedged agent hanging
+        forever. It must therefore be finite and not absurd, but it is no longer a
+        scheduling constraint. Pacing belongs to the sweep, not to this constant.
+        """
+        assert 0 < VALIDATE_TIMEOUT_CEILING_SEC <= 86_400
 
     def test_it_grows_with_the_count(self) -> None:
         assert validate_timeout_for(200_000).read > validate_timeout_for(20_000).read

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -346,7 +346,11 @@ class TestFieldValidators:
         assert s.validation_sweep_enabled is True
         # Every 6h (03/09/15/21 UTC), offset from the prefill crons.
         assert s.validation_sweep_cron == "0 3,9,15,21 * * *"
-        assert s.sweep_batch_size == 10
+        # 10 -> 2 (PR #303 review): capped at the agent's _CACHE_STAT_WORKERS.
+        # Concurrency above the stat pool adds queueing rather than throughput and
+        # silently divides the throughput each validate budget assumes, so budgets
+        # measured sequentially were wrong by the batch factor under a sweep.
+        assert s.sweep_batch_size == 2
 
     def test_invalid_sweep_cron_fails_fast(self, monkeypatch):
         monkeypatch.setenv("ORCH_TOKEN", VALID_TOKEN)

--- a/tests/jobs/test_validate_handler.py
+++ b/tests/jobs/test_validate_handler.py
@@ -21,9 +21,14 @@ class _StubAgent:
     def __init__(self, response):
         self._response = response
         self.calls: list[int] = []
+        self.chunk_counts: list[int | None] = []
 
-    async def steam_validate(self, app_id: int):
+    # chunk_count is accepted EXPLICITLY, not swallowed by **kwargs. The
+    # signature change that broke this fake is the fake doing its job: a spy
+    # that silently absorbs new arguments stops protecting against drift.
+    async def steam_validate(self, app_id: int, *, chunk_count: int | None = None):
         self.calls.append(app_id)
+        self.chunk_counts.append(chunk_count)
         return self._response
 
 

--- a/tests/validator/test_disk_stat.py
+++ b/tests/validator/test_disk_stat.py
@@ -237,9 +237,14 @@ class _FakeAgentSV:
     def __init__(self, response):
         self._response = response
         self.calls: list[int] = []
+        self.chunk_counts: list[int | None] = []
 
-    async def steam_validate(self, app_id: int) -> dict:
+    # chunk_count is accepted EXPLICITLY, not swallowed by **kwargs. The
+    # signature change that broke this fake is the fake doing its job: a spy
+    # that silently absorbs new arguments stops protecting against drift.
+    async def steam_validate(self, app_id: int, *, chunk_count: int | None = None) -> dict:
         self.calls.append(app_id)
+        self.chunk_counts.append(chunk_count)
         return self._response
 
 

--- a/tests/validator/test_steam_validate_passes_chunk_count.py
+++ b/tests/validator/test_steam_validate_passes_chunk_count.py
@@ -1,0 +1,119 @@
+"""The Steam validate caller passes the size it already knows.
+
+Adversarial review of PR #303. That PR scaled the validate budget by chunk count
+and its security audit certified Steam as "backward-compatible: unaffected".
+Steam IS unchanged — ``steam_validate`` was called with no count, so it kept the
+flat 300s base — and on the post-rebuild hardware (48-54 chunks/sec, measured)
+300s covers only ~12,000-16,000 chunks. Every large Steam game therefore still
+timed out, wrote NO validation_history row, and could never self-correct: the
+exact defect #303 existed to remove, left in place on the platform holding the
+biggest games. ARK: Survival Evolved is 369,317 chunks and needs ~7,700s.
+
+"Backward-compatible" was the wrong test. The old behaviour was only safe on
+hardware that no longer exists.
+
+Steam self-enumerates agent-side, so unlike Epic there is no manifest row to read
+the count from at call time. The orchestrator does, however, hold the previous
+run's ``validation_history.chunks_total`` — the same figure the incident analysis
+was built on. A first-ever validation has no history and correctly falls back to
+the base budget.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.core.settings import Settings
+from orchestrator.jobs.worker import Deps
+from orchestrator.validator.disk_stat import validate_game
+
+pytestmark = pytest.mark.asyncio
+
+SETTINGS = Settings(orchestrator_token="x" * 32)
+
+
+class _RecordingAgent:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def steam_validate(self, app_id, **kwargs):
+        self.calls.append({"app_id": app_id, **kwargs})
+        return {
+            "chunks_total": 10,
+            "chunks_cached": 10,
+            "chunks_missing": 0,
+            "outcome": "cached",
+            "versions": "1",
+            "error": None,
+        }
+
+
+async def _seed_game(pool, app_id: str, title: str) -> int:
+    await pool.execute_write(
+        "INSERT INTO games (platform, app_id, title, owned, status) "
+        "VALUES ('steam', ?, ?, 1, 'up_to_date')",
+        (app_id, title),
+    )
+    row = await pool.read_one("SELECT id FROM games WHERE app_id=?", (app_id,))
+    return int(row["id"])
+
+
+async def _seed_history(pool, game_id: int, chunks_total: int, finished_at: str) -> None:
+    await pool.execute_write(
+        "INSERT INTO validation_history "
+        "(game_id, manifest_version, started_at, finished_at, method, "
+        " chunks_total, chunks_cached, chunks_missing, outcome) "
+        "VALUES (?, '1', ?, ?, 'disk_stat', ?, ?, 0, 'cached')",
+        (game_id, finished_at, finished_at, chunks_total, chunks_total),
+    )
+
+
+async def test_the_last_known_size_reaches_the_client(pool) -> None:
+    game_id = await _seed_game(pool, "346110", "ARK: Survival Evolved")
+    await _seed_history(pool, game_id, 369_317, "2026-08-30 00:00:00")
+    agent = _RecordingAgent()
+
+    await validate_game(pool, Deps(pool=pool, agent_client=agent), game_id, SETTINGS)
+
+    assert agent.calls, "the agent was never called"
+    assert agent.calls[0].get("chunk_count") == 369_317, (
+        "steam's known size must reach the client, or every large steam game keeps "
+        f"the flat base budget and times out; got {agent.calls[0]}"
+    )
+
+
+async def test_the_newest_history_row_wins(pool) -> None:
+    """A game that shrank or grew must be budgeted on its most recent measurement."""
+    game_id = await _seed_game(pool, "220", "Half-Life 2")
+    await _seed_history(pool, game_id, 5_000, "2026-07-01 00:00:00")
+    await _seed_history(pool, game_id, 90_000, "2026-08-30 00:00:00")
+    agent = _RecordingAgent()
+
+    await validate_game(pool, Deps(pool=pool, agent_client=agent), game_id, SETTINGS)
+
+    assert agent.calls[0].get("chunk_count") == 90_000
+
+
+async def test_a_never_validated_game_falls_back_to_the_base_budget(pool) -> None:
+    """First-ever validation has no history row. That must degrade quietly to the
+    base budget rather than raise — a new purchase must still be validatable."""
+    game_id = await _seed_game(pool, "440", "Team Fortress 2")
+    agent = _RecordingAgent()
+
+    await validate_game(pool, Deps(pool=pool, agent_client=agent), game_id, SETTINGS)
+
+    assert agent.calls, "the agent was never called"
+    assert agent.calls[0].get("chunk_count") is None
+
+
+async def test_a_zero_chunk_history_row_does_not_shrink_the_budget(pool) -> None:
+    """An errored prior run can leave chunks_total = 0. Passing that through would
+    be read as 'no information' anyway, but it must never produce a budget below
+    the base."""
+    game_id = await _seed_game(pool, "570", "Dota 2")
+    await _seed_history(pool, game_id, 0, "2026-08-30 00:00:00")
+    agent = _RecordingAgent()
+
+    await validate_game(pool, Deps(pool=pool, agent_client=agent), game_id, SETTINGS)
+
+    assert agent.calls[0].get("chunk_count") in (None, 0)


### PR DESCRIPTION
## What happened

The NAS was rebuilt on OpenMediaVault on 2026-08-31 to remove UGREEN's `ugacl` shim. That rebuild was correct and fixed real damage — but it left the NVMe cache that had fronted the RAID0 **detached**, and validation is stat-heavy random metadata I/O.

Measured from `validation_history` durations on 2026-09-01:

| | chunks/sec |
|---|---|
| before the rebuild (bcache in front of RAID0) | **1,471 – 1,539** |
| after the rebuild (raw RAID0, NVMe idle) | **48 – 54** |

Same code, same games. Corroborated on the host: `wa` 62–79%, `/sys/fs/bcache` shows no registered cache set, and `nvme0n1`/`nvme1n1` sit unused as `volume1_bdata` (360 G) / `volume1_bmeta` (4 M).

## The defect this exposed

`VALIDATE_TIMEOUT_PER_CHUNK_SEC = 0.00217` encoded an **unstated assumption of ~461 chunks/sec**. At the real 50/sec the budget is ~9× short, and the crossover where a game can no longer finish inside its own budget is:

```
chunks / 50  >  300 + 0.00217 × chunks   →   fails above ~16,826 chunks
```

That is **379 of 1,811 games (21%)**, including ARK: Survival Evolved (369,317 chunks), ARK ModKit UE4 (359,671), Warhammer 40,000: Darktide (310,059), ARK: Survival Ascended (216,843) and God of War (216,751).

Confirmed live rather than predicted: **Ghostwire Tokyo (~24,000 chunks) failed** with `AgentError: agent unreachable: ReadTimeout` after 352 s, while **Mortal Shell (14,142 chunks) succeeded** — straddling the calculated line exactly.

**These games could not self-correct.** A timed-out validate writes **no** `validation_history` row, so the game keeps whatever status it had, permanently, however many sweeps run.

This is the same family as #297 one layer down: that fix removed a flat 300 s cliff by scaling with chunk count, but the *scale factor* was itself calibrated against hardware that no longer exists.

## The change

- **`VALIDATE_TIMEOUT_ASSUMED_CHUNKS_PER_SEC = 40.0`** replaces the derived per-chunk constant. Stating the throughput outright *is* the fix — the previous form hid the assumption where nothing could flag it when the hardware stopped delivering it. 40 is deliberately below the measured 48 so a slow day does not reintroduce the cliff.
- **`chunks_per_sec` keyword on `validate_timeout_for`** — the rate is a property of the hardware, not the code, so changing it must not require a code edit next time.
- **Ceiling 1,800 s → 14,400 s.** A ceiling below the largest real game's requirement (~9,533 s at 40/sec) just moves the cliff. The ceiling's remaining job is narrower — bound a genuinely wedged agent — and it is no longer a scheduling constraint, because no full sweep fits in a 6-hour window at any ceiling on this hardware.

## Tests

18 new tests in `tests/clients/test_validate_timeout_recalibration.py`, parametrised over the five largest real games plus the two that straddled the line live. RED verified on behaviour, not on a missing symbol: the new constant was first introduced holding the *old* implied value (461.0) so the assertions failed for the right reason — 10 failed, 8 passed.

**One superseded test replaced.** `test_the_ceiling_fits_inside_the_sweeps_own_budget` asserted `<= 1800` on the reasoning "the sweep runs every 6 hours and takes ~40 minutes". That premise died with the rebuild. The dead reasoning is recorded in the replacement's docstring rather than deleted.

Full suite: **1796 passed**, 3 deselected. ruff + mypy clean.

## Scope

**Not addressed here:** the storage regression itself. Restoring a cache layer — `lvconvert --type cache` over the idle 360 GB NVMe (needs a `vgmerge` first; the cache LVs are in `..._pool1_bcache` while `/volume1` is in `..._pool1`), or more RAM to hold the ~10–15 GB metadata working set — is an infrastructure decision tracked separately. This change makes the system correct on the hardware as it currently stands.

**Deploy note:** this must ship together with #302, which is still open. The agent currently runs the image built at `6c2d0db` (#300), so #301 and #302 both need to land — #301 carries a relocated race that #302 corrects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
