### PR TITLE
chore(framework): record the 4.3.1 guardrails sync

### DIFF
--- a/.claude/manifest.json
+++ b/.claude/manifest.json
@@ -1,9 +1,9 @@
 {
-  "frameworkVersion": "4.3.0",
-  "frameworkCommit": "0396a1a",
+  "frameworkVersion": "4.3.1",
+  "frameworkCommit": "ce3a5f9",
   "frameworkRepo": "kraulerson/claude-dev-framework",
   "localClonePath": "~/.claude-dev-framework",
-  "lastSyncDate": "2026-07-09T17:20:36Z",
+  "lastSyncDate": "2026-08-16T17:51:23Z",
   "profile": "web-api",
   "profileInherits": [
     "_base"


### PR DESCRIPTION
## What

Bumps the in-repo record of which guardrails version this project is synced to. Three lines, no behavior change:

- `frameworkVersion` 4.3.0 -> 4.3.1
- `frameworkCommit` 0396a1a -> ce3a5f9
- `lastSyncDate` 2026-07-09 -> 2026-08-16

`profile` (web-api) and `profileInherits` are unchanged.

## Why

The guardrails on the machine were already updated to `ce3a5f9` on 2026-08-16 — the session-start banner reports `v4.3.1` and "Development Guardrails: ce3a5f9 — up to date". Only the committed record lagged, leaving the repo asserting a stale `0396a1a`. The upstream commit is kraulerson/claude-dev-framework#6 (headless-safe prompts: interactive reads guarded on `[ -t 0 ]`).

## Notes

- Split out of #302 deliberately so that PR stayed a pure agent bugfix.
- The `lastSyncDate` is backdated to the real sync date rather than today's.

## Correction to this PR's original description

The original description claimed that `config-guard.sh` blocks execution of `mark-evaluated.sh` and therefore deadlocks any commit routed through the evaluate gate. **That claim was wrong and has been removed.**

`config-guard.sh` does contain an allowlist for `mark-evaluated.sh`. The invocation failed it for a different reason: the allowlist pattern is

```
^[[:space:]]*(bash[[:space:]]+)?[^[:space:]]*mark-evaluated\.sh([[:space:]]|$)
```

which admits neither quotes nor spaces in the path. The call used a quoted absolute path containing a space (this project lives under ".../Claude Projects/..."), so it fell through to the block. A bare relative invocation from the repo root matches and is allowed.

There is a narrow real limitation here — the allowlist cannot match project paths containing spaces — but no change to the framework is proposed in this PR; that is out of scope for this repo.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HtQRabfirCcmMwkkBQKyk